### PR TITLE
refactor: btree invariant testing and bug fixes

### DIFF
--- a/internal/minisql/btree_invariants_test.go
+++ b/internal/minisql/btree_invariants_test.go
@@ -1,0 +1,278 @@
+package minisql
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestTable_BTreeInvariants_InsertSequence(t *testing.T) {
+	var (
+		ctx           = context.Background()
+		pager, dbFile = initTest(t)
+		rows          = gen.MediumRows(60)
+		tablePager    = pager.ForTable(testMediumColumns)
+		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(tablePager), pager, nil)
+		txPager       = NewTransactionalPager(tablePager, txManager, testTableName, "")
+		table         = NewTable(testLogger, txPager, txManager, testTableName, testMediumColumns, 0, nil)
+	)
+	table.maximumICells = 5
+
+	for i, row := range rows {
+		stmt := Statement{
+			Kind:    Insert,
+			Fields:  fieldsFromColumns(testMediumColumns...),
+			Inserts: [][]OptionalValue{row.Values},
+		}
+		mustInsert(ctx, t, table, txManager, stmt)
+
+		assertTableBTreeInvariants(t, pager, table)
+		checkRows(ctx, t, table, rows[:i+1])
+	}
+}
+
+func TestTable_BTreeInvariants_RandomDeleteSequence(t *testing.T) {
+	var (
+		ctx           = context.Background()
+		pager, dbFile = initTest(t)
+		rows          = gen.MediumRows(60)
+		tablePager    = pager.ForTable(testMediumColumns)
+		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(tablePager), pager, nil)
+		txPager       = NewTransactionalPager(tablePager, txManager, testTableName, "")
+		table         = NewTable(testLogger, txPager, txManager, testTableName, testMediumColumns, 0, nil)
+	)
+	table.maximumICells = 5
+
+	stmt := Statement{
+		Kind:    Insert,
+		Fields:  fieldsFromColumns(testMediumColumns...),
+		Inserts: make([][]OptionalValue, 0, len(rows)),
+	}
+	for _, row := range rows {
+		stmt.Inserts = append(stmt.Inserts, row.Values)
+	}
+	mustInsert(ctx, t, table, txManager, stmt)
+	assertTableBTreeInvariants(t, pager, table)
+
+	remaining := append([]Row(nil), rows...)
+	order := rand.New(rand.NewSource(42)).Perm(len(rows))
+	for step, idx := range order {
+		row := rows[idx]
+		ids := rowIDs(row)
+		result := mustDelete(ctx, t, table, txManager, pager, Statement{
+			Kind: Delete,
+			Conditions: OneOrMore{
+				{
+					FieldIsInAny(Field{Name: "id"}, ids...),
+				},
+			},
+		})
+		require.Equal(t, 1, result.RowsAffected)
+
+		for i := range remaining {
+			if remaining[i].Values[0] == row.Values[0] {
+				remaining = append(remaining[:i], remaining[i+1:]...)
+				break
+			}
+		}
+
+		assertTableBTreeInvariants(t, pager, table)
+		if t.Failed() {
+			t.Fatalf("btree invariants failed at delete step=%d row_idx=%d", step, idx)
+		}
+		checkRows(ctx, t, table, remaining)
+	}
+}
+
+func TestTable_BTreeInvariants_DeleteRegression_52Then5(t *testing.T) {
+	var (
+		ctx           = context.Background()
+		pager, dbFile = initTest(t)
+		rows          = gen.MediumRows(60)
+		tablePager    = pager.ForTable(testMediumColumns)
+		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(tablePager), pager, nil)
+		txPager       = NewTransactionalPager(tablePager, txManager, testTableName, "")
+		table         = NewTable(testLogger, txPager, txManager, testTableName, testMediumColumns, 0, nil)
+	)
+	table.maximumICells = 5
+
+	stmt := Statement{
+		Kind:    Insert,
+		Fields:  fieldsFromColumns(testMediumColumns...),
+		Inserts: make([][]OptionalValue, 0, len(rows)),
+	}
+	for _, row := range rows {
+		stmt.Inserts = append(stmt.Inserts, row.Values)
+	}
+	mustInsert(ctx, t, table, txManager, stmt)
+	assertTableBTreeInvariants(t, pager, table)
+
+	for _, idx := range []int{52, 5} {
+		result := mustDelete(ctx, t, table, txManager, pager, Statement{
+			Kind: Delete,
+			Conditions: OneOrMore{
+				{
+					FieldIsInAny(Field{Name: "id"}, rowIDs(rows[idx])...),
+				},
+			},
+		})
+		require.Equal(t, 1, result.RowsAffected)
+		assertTableBTreeInvariants(t, pager, table)
+	}
+}
+
+func assertTableBTreeInvariants(t *testing.T, pager *pagerImpl, table *Table) {
+	t.Helper()
+
+	require.Greater(t, int(pager.TotalPages()), 0)
+	rootPage := pager.pages[table.GetRootPageIdx()]
+	require.NotNil(t, rootPage)
+	require.True(t, (rootPage.LeafNode != nil) != (rootPage.InternalNode != nil), "root must be either leaf or internal")
+
+	state := &tableTreeCheckState{
+		t:       t,
+		pager:   pager,
+		table:   table,
+		visited: make(map[PageIndex]struct{}),
+	}
+
+	summary := state.walk(table.GetRootPageIdx(), 0, 0)
+	if rootPage.LeafNode != nil {
+		assert.Equal(t, 0, int(rootPage.LeafNode.Header.Parent))
+		assert.True(t, rootPage.LeafNode.Header.IsRoot)
+		if summary.hasRows {
+			assert.Equal(t, rootPage.LeafNode.Keys()[0], summary.minKey)
+			assert.Equal(t, rootPage.LeafNode.Keys()[len(rootPage.LeafNode.Keys())-1], summary.maxKey)
+		}
+	} else {
+		assert.Equal(t, 0, int(rootPage.InternalNode.Header.Parent))
+		assert.True(t, rootPage.InternalNode.Header.IsRoot)
+	}
+
+	for i, leafIdx := range state.leaves {
+		page := pager.pages[leafIdx]
+		require.NotNil(t, page)
+		require.NotNil(t, page.LeafNode)
+		if i == len(state.leaves)-1 {
+			assert.Equal(t, 0, int(page.LeafNode.Header.NextLeaf), "last leaf should terminate the chain")
+			continue
+		}
+		assert.Equal(t, state.leaves[i+1], page.LeafNode.Header.NextLeaf, "leaf chain must follow in-order traversal")
+	}
+}
+
+type tableTreeCheckState struct {
+	t       *testing.T
+	pager   *pagerImpl
+	table   *Table
+	visited map[PageIndex]struct{}
+	leaves  []PageIndex
+}
+
+type tableSubtreeSummary struct {
+	hasRows   bool
+	minKey    RowID
+	maxKey    RowID
+	leafDepth int
+}
+
+func (s *tableTreeCheckState) walk(pageIdx, parentIdx PageIndex, depth int) tableSubtreeSummary {
+	s.t.Helper()
+
+	if _, ok := s.visited[pageIdx]; ok {
+		require.FailNowf(s.t, "table tree cycle", "page %d visited more than once", pageIdx)
+	}
+	s.visited[pageIdx] = struct{}{}
+
+	require.Less(s.t, int(pageIdx), len(s.pager.pages))
+	page := s.pager.pages[pageIdx]
+	require.NotNil(s.t, page)
+	require.Nil(s.t, page.FreePage, "reachable table page %d cannot also be free", pageIdx)
+	require.True(s.t, (page.LeafNode != nil) != (page.InternalNode != nil), "page %d must be either leaf or internal", pageIdx)
+
+	if page.LeafNode != nil {
+		node := page.LeafNode
+		assert.Equal(s.t, parentIdx, node.Header.Parent, "leaf %d has wrong parent", pageIdx)
+		if pageIdx == s.table.GetRootPageIdx() {
+			assert.True(s.t, node.Header.IsRoot)
+		} else {
+			assert.False(s.t, node.Header.IsRoot)
+		}
+
+		keys := node.Keys()
+		for i := 1; i < len(keys); i++ {
+			assert.Less(s.t, keys[i-1], keys[i], "leaf %d keys must be strictly increasing", pageIdx)
+		}
+
+		s.leaves = append(s.leaves, pageIdx)
+		if len(keys) == 0 {
+			assert.Equal(s.t, s.table.GetRootPageIdx(), pageIdx, "only the root leaf may be empty")
+			assert.Equal(s.t, 0, int(node.Header.NextLeaf))
+			return tableSubtreeSummary{leafDepth: depth}
+		}
+
+		return tableSubtreeSummary{
+			hasRows:   true,
+			minKey:    keys[0],
+			maxKey:    keys[len(keys)-1],
+			leafDepth: depth,
+		}
+	}
+
+	node := page.InternalNode
+	assert.Equal(s.t, parentIdx, node.Header.Parent, "internal page %d has wrong parent", pageIdx)
+	if pageIdx == s.table.GetRootPageIdx() {
+		assert.True(s.t, node.Header.IsRoot)
+	} else {
+		assert.False(s.t, node.Header.IsRoot)
+	}
+	assert.NotEqual(s.t, RightChildNotSet, node.Header.RightChild, "internal page %d must have a right child", pageIdx)
+	assert.Positive(s.t, int(node.Header.KeysNum), "reachable internal page %d must have at least one key", pageIdx)
+	assert.LessOrEqual(s.t, int(node.Header.KeysNum), s.table.maxICells(pageIdx), "internal page %d exceeds max keys", pageIdx)
+	if pageIdx != s.table.GetRootPageIdx() {
+		assert.GreaterOrEqual(s.t, int(node.Header.KeysNum), s.table.maxICells(pageIdx)/2, "internal page %d underflowed", pageIdx)
+	}
+
+	keys := node.Keys()
+	for i := 1; i < len(keys); i++ {
+		assert.Less(s.t, keys[i-1], keys[i], "internal page %d separator keys must be strictly increasing", pageIdx)
+	}
+
+	firstChildIdx, err := node.Child(0)
+	require.NoError(s.t, err)
+	firstSummary := s.walk(firstChildIdx, pageIdx, depth+1)
+	require.True(s.t, firstSummary.hasRows, "child %d of internal page %d must not be empty", firstChildIdx, pageIdx)
+	assert.Equal(s.t, node.ICells[0].Key, firstSummary.maxKey, "internal page %d first separator should equal left child max", pageIdx)
+
+	prevMax := firstSummary.maxKey
+	minKey := firstSummary.minKey
+	leafDepth := firstSummary.leafDepth
+
+	for i := uint32(1); i < node.Header.KeysNum; i++ {
+		childIdx, err := node.Child(i)
+		require.NoError(s.t, err)
+		childSummary := s.walk(childIdx, pageIdx, depth+1)
+		require.True(s.t, childSummary.hasRows, "child %d of internal page %d must not be empty", childIdx, pageIdx)
+		assert.Equal(s.t, leafDepth, childSummary.leafDepth, "all leaves must be at the same depth")
+		assert.Less(s.t, prevMax, childSummary.minKey, "child %d of internal page %d overlaps previous range", childIdx, pageIdx)
+		assert.Equal(s.t, node.ICells[i].Key, childSummary.maxKey, "internal page %d separator should equal child max", pageIdx)
+		prevMax = childSummary.maxKey
+	}
+
+	rightSummary := s.walk(node.Header.RightChild, pageIdx, depth+1)
+	require.True(s.t, rightSummary.hasRows, "right child %d of internal page %d must not be empty", node.Header.RightChild, pageIdx)
+	assert.Equal(s.t, leafDepth, rightSummary.leafDepth, "all leaves must be at the same depth")
+	assert.Less(s.t, prevMax, rightSummary.minKey, "right child of internal page %d overlaps previous range", pageIdx)
+	maxKey := rightSummary.maxKey
+
+	return tableSubtreeSummary{
+		hasRows:   true,
+		minKey:    minKey,
+		maxKey:    maxKey,
+		leafDepth: leafDepth,
+	}
+}

--- a/internal/minisql/delete_test.go
+++ b/internal/minisql/delete_test.go
@@ -299,7 +299,7 @@ func TestTable_Delete_LeafNodeRebalancing(t *testing.T) {
 
 		/*
 			           +----------------------------+
-			           |        5,         11,      |
+			           |        5,         10,      |
 			           +----------------------------+
 			          /              /               \
 			+--------+           +--------+          +----------+
@@ -309,7 +309,7 @@ func TestTable_Delete_LeafNodeRebalancing(t *testing.T) {
 
 		// Check the root page
 		assert.Equal(t, 2, int(pager.pages[0].InternalNode.Header.KeysNum))
-		assert.Equal(t, []RowID{5, 11}, pager.pages[0].InternalNode.Keys())
+		assert.Equal(t, []RowID{5, 10}, pager.pages[0].InternalNode.Keys())
 		// Check the leaf pages
 		assert.Equal(t, []RowID{1, 3, 5}, pager.pages[2].LeafNode.Keys())
 		assert.Equal(t, []RowID{7, 8, 10}, pager.pages[4].LeafNode.Keys())

--- a/internal/minisql/node.go
+++ b/internal/minisql/node.go
@@ -144,7 +144,7 @@ func (n *InternalNode) RemoveLastCell() {
 
 // PrependCell ...
 func (n *InternalNode) PrependCell(cell ICell) {
-	for i := int(n.Header.KeysNum) - 1; i > 0; i-- {
+	for i := int(n.Header.KeysNum); i > 0; i-- {
 		n.ICells[i] = n.ICells[i-1]
 	}
 	n.ICells[0] = cell

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -664,12 +664,83 @@ func (t *Table) DeleteKey(ctx context.Context, pageIdx PageIndex, key RowID) err
 
 	// Check for underflow
 	if page.LeafNode.AtLeastHalfFull() {
-		return nil
+		return t.updateParentMaxKey(ctx, page)
 	}
 
 	// Rebalance leaf node
 	if err := t.rebalanceLeaf(ctx, page, key); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (t *Table) updateParentMaxKey(ctx context.Context, page *Page) error {
+	if page == nil {
+		return nil
+	}
+
+	var parentIdx PageIndex
+	switch {
+	case page.LeafNode != nil:
+		if page.LeafNode.Header.IsRoot {
+			return nil
+		}
+		parentIdx = page.LeafNode.Header.Parent
+	case page.InternalNode != nil:
+		if page.InternalNode.Header.IsRoot {
+			return nil
+		}
+		parentIdx = page.InternalNode.Header.Parent
+	default:
+		return nil
+	}
+
+	parentPage, err := t.pager.ModifyPage(ctx, parentIdx)
+	if err != nil {
+		return fmt.Errorf("update parent max key: %w", err)
+	}
+
+	position, err := parentPage.InternalNode.IndexOfPage(page.Index)
+	if err != nil {
+		return fmt.Errorf("update parent max key: %w", err)
+	}
+	if position < parentPage.InternalNode.Header.KeysNum {
+		maxKey, err := t.GetMaxKey(ctx, page)
+		if err != nil {
+			return fmt.Errorf("update parent max key: %w", err)
+		}
+		if parentPage.InternalNode.ICells[position].Key == maxKey {
+			return nil
+		}
+		parentPage.InternalNode.ICells[position].Key = maxKey
+		return t.updateParentMaxKey(ctx, parentPage)
+	}
+
+	return t.updateParentMaxKey(ctx, parentPage)
+}
+
+func (t *Table) refreshInternalNodeKeys(ctx context.Context, page *Page) error {
+	if page == nil || page.InternalNode == nil {
+		return nil
+	}
+
+	for i := uint32(0); i < page.InternalNode.Header.KeysNum; i++ {
+		childIdx, err := page.InternalNode.Child(i)
+		if err != nil {
+			return fmt.Errorf("refresh internal node keys: %w", err)
+		}
+
+		childPage, err := t.pager.ReadPage(ctx, childIdx)
+		if err != nil {
+			return fmt.Errorf("refresh internal node keys: %w", err)
+		}
+
+		maxKey, err := t.GetMaxKey(ctx, childPage)
+		if err != nil {
+			return fmt.Errorf("refresh internal node keys: %w", err)
+		}
+		page.InternalNode.ICells[i].Key = maxKey
 	}
 
 	return nil
@@ -729,7 +800,10 @@ func (t *Table) rebalanceLeaf(ctx context.Context, page *Page, key RowID) error 
 	if err != nil {
 		return fmt.Errorf("rebalance leaf: %w", err)
 	}
-	myPositionInParent := parentPage.InternalNode.IndexOfChild(key)
+	myPositionInParent, err := parentPage.InternalNode.IndexOfPage(page.Index)
+	if err != nil {
+		return fmt.Errorf("rebalance leaf: %w", err)
+	}
 
 	var (
 		left  *Page
@@ -748,21 +822,33 @@ func (t *Table) rebalanceLeaf(ctx context.Context, page *Page, key RowID) error 
 	}
 
 	if right != nil && right.LeafNode.CanBorrowFirst() {
-		return t.borrowFromRightLeaf(
+		if err := t.borrowFromRightLeaf(
 			parentPage.InternalNode,
 			leafNode,
 			right.LeafNode,
 			myPositionInParent,
-		)
+		); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	if left != nil && left.LeafNode.CanBorrowLast() {
-		return t.borrowFromLeftLeaf(
+		if err := t.borrowFromLeftLeaf(
 			parentPage.InternalNode,
 			leafNode,
 			left.LeafNode,
 			myPositionInParent-1,
-		)
+		); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	if right != nil && leafNode.CanMergeWith(right.LeafNode) {
@@ -776,7 +862,13 @@ func (t *Table) rebalanceLeaf(ctx context.Context, page *Page, key RowID) error 
 			return err
 		}
 
-		return t.pager.AddFreePage(ctx, right.Index)
+		if err := t.pager.AddFreePage(ctx, right.Index); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	if left != nil && leafNode.CanMergeWith(left.LeafNode) {
@@ -790,7 +882,13 @@ func (t *Table) rebalanceLeaf(ctx context.Context, page *Page, key RowID) error 
 			return err
 		}
 
-		return t.pager.AddFreePage(ctx, page.Index)
+		if err := t.pager.AddFreePage(ctx, page.Index); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	return nil
@@ -823,7 +921,7 @@ func (t *Table) borrowFromRightLeaf(parent *InternalNode, node, right *LeafNode,
 
 	node.AppendCells(cellToRotate)
 
-	parent.ICells[idx].Key = right.FirstCell().Key
+	parent.ICells[idx].Key = node.LastCell().Key
 
 	return nil
 }
@@ -839,6 +937,9 @@ func (t *Table) mergeLeaves(ctx context.Context, parent, left, right *Page, idx 
 	// Remove key from parent plus the right child pointer
 	if err := parent.InternalNode.DeleteKeyAndRightChild(idx); err != nil {
 		return err
+	}
+	if err := t.refreshInternalNodeKeys(ctx, parent); err != nil {
+		return fmt.Errorf("merge leaves: %w", err)
 	}
 
 	if parent.InternalNode.Header.IsRoot && parent.InternalNode.Header.KeysNum == 0 {
@@ -856,7 +957,7 @@ func (t *Table) mergeLeaves(ctx context.Context, parent, left, right *Page, idx 
 
 	// Check for underflow
 	if parent.InternalNode.AtLeastHalfFull(t.maxICells(parent.Index)) {
-		return nil
+		return t.updateParentMaxKey(ctx, parent)
 	}
 
 	return t.rebalanceInternal(ctx, parent)
@@ -870,11 +971,31 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 			if err != nil {
 				return fmt.Errorf("rebalance internal: %w", err)
 			}
-			firstChildPage, err := t.pager.ModifyPage(ctx, node.ICells[0].Child)
+			firstChildPage, err := t.pager.ModifyPage(ctx, node.Header.RightChild)
 			if err != nil {
 				return fmt.Errorf("rebalance internal: %w", err)
 			}
-			rootPage.InternalNode = firstChildPage.InternalNode.Clone()
+			switch {
+			case firstChildPage.InternalNode != nil:
+				rootPage.InternalNode = firstChildPage.InternalNode.Clone()
+				rootPage.InternalNode.Header.IsRoot = true
+				rootPage.InternalNode.Header.Parent = 0
+				rootPage.LeafNode = nil
+				for _, childIdx := range rootPage.InternalNode.Children() {
+					childPage, err := t.pager.ModifyPage(ctx, childIdx)
+					if err != nil {
+						return fmt.Errorf("rebalance internal: %w", err)
+					}
+					childPage.setParent(t.GetRootPageIdx())
+				}
+			case firstChildPage.LeafNode != nil:
+				rootPage.InternalNode = nil
+				rootPage.LeafNode = firstChildPage.LeafNode.DeepClone()
+				rootPage.LeafNode.Header.IsRoot = true
+				rootPage.LeafNode.Header.Parent = 0
+			default:
+				return fmt.Errorf("rebalance internal: invalid child page type %d", firstChildPage.Index)
+			}
 			return t.pager.AddFreePage(ctx, firstChildPage.Index)
 		}
 		return nil
@@ -916,7 +1037,10 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 		); err != nil {
 			return fmt.Errorf("borrow from right internal: %w", err)
 		}
-		return nil
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	if left != nil && left.InternalNode.MoreThanHalfFull(t.maxICells(left.Index)) {
@@ -929,10 +1053,13 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 		); err != nil {
 			return fmt.Errorf("borrow from left internal: %w", err)
 		}
-		return nil
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
-	if right != nil && int(right.InternalNode.Header.KeysNum+node.Header.KeysNum) <= t.maxICells(right.Index) {
+	if right != nil && int(right.InternalNode.Header.KeysNum+node.Header.KeysNum+1) <= t.maxICells(right.Index) {
 		if err := t.mergeInternalNodes(
 			ctx,
 			parentPage,
@@ -943,10 +1070,16 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 			return fmt.Errorf("merge internal node with right: %w", err)
 		}
 
-		return t.pager.AddFreePage(ctx, right.Index)
+		if err := t.pager.AddFreePage(ctx, right.Index); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
-	if left != nil && int(left.InternalNode.Header.KeysNum+node.Header.KeysNum) <= t.maxICells(left.Index) {
+	if left != nil && int(left.InternalNode.Header.KeysNum+node.Header.KeysNum+1) <= t.maxICells(left.Index) {
 		if err := t.mergeInternalNodes(
 			ctx,
 			parentPage,
@@ -957,7 +1090,13 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 			return fmt.Errorf("merge internal node with left: %w", err)
 		}
 
-		return t.pager.AddFreePage(ctx, page.Index)
+		if err := t.pager.AddFreePage(ctx, page.Index); err != nil {
+			return err
+		}
+		if err := t.refreshInternalNodeKeys(ctx, parentPage); err != nil {
+			return err
+		}
+		return t.updateParentMaxKey(ctx, parentPage)
 	}
 
 	return nil
@@ -969,11 +1108,9 @@ func (t *Table) rebalanceInternal(ctx context.Context, page *Page) error {
 // It also updates the key in the parent node.
 func (t *Table) borrowFromLeftInternal(ctx context.Context, parent, page, left *Page, idx uint32) error {
 	page.InternalNode.PrependCell(ICell{
-		Key:   parent.InternalNode.ICells[idx-1].Key,
+		Key:   parent.InternalNode.ICells[idx].Key,
 		Child: left.InternalNode.Header.RightChild,
 	})
-
-	parent.InternalNode.ICells[idx-1].Key = left.InternalNode.LastCell().Key
 
 	childPage, err := t.pager.ModifyPage(ctx, left.InternalNode.Header.RightChild)
 	if err != nil {
@@ -982,6 +1119,18 @@ func (t *Table) borrowFromLeftInternal(ctx context.Context, parent, page, left *
 	childPage.setParent(page.Index)
 
 	left.InternalNode.RemoveLastCell()
+
+	leftMax, err := t.GetMaxKey(ctx, left)
+	if err != nil {
+		return fmt.Errorf("borrow from left internal: %w", err)
+	}
+	parent.InternalNode.ICells[idx].Key = leftMax
+	if err := t.refreshInternalNodeKeys(ctx, page); err != nil {
+		return fmt.Errorf("borrow from left internal: %w", err)
+	}
+	if err := t.refreshInternalNodeKeys(ctx, left); err != nil {
+		return fmt.Errorf("borrow from left internal: %w", err)
+	}
 
 	return nil
 }
@@ -1003,19 +1152,26 @@ func (t *Table) borrowFromRightInternal(ctx context.Context, parent, page, right
 	}
 	childPage.setParent(page.Index)
 
-	parent.InternalNode.ICells[idx].Key = right.InternalNode.FirstCell().Key
-
 	right.InternalNode.RemoveFirstCell()
+
+	pageMax, err := t.GetMaxKey(ctx, page)
+	if err != nil {
+		return fmt.Errorf("borrow from right internal: %w", err)
+	}
+	parent.InternalNode.ICells[idx].Key = pageMax
+	if err := t.refreshInternalNodeKeys(ctx, page); err != nil {
+		return fmt.Errorf("borrow from right internal: %w", err)
+	}
+	if err := t.refreshInternalNodeKeys(ctx, right); err != nil {
+		return fmt.Errorf("borrow from right internal: %w", err)
+	}
 
 	return nil
 }
 
 // mergeInternalNodes merges two internal nodes and deletes the key from the parent node.
 func (t *Table) mergeInternalNodes(ctx context.Context, parent, left, right *Page, idx uint32) error {
-	var (
-		leftCells = left.InternalNode.Header.KeysNum
-		leftIndex = left.Index
-	)
+	leftIndex := left.Index
 	if parent.InternalNode.Header.IsRoot && parent.InternalNode.Header.KeysNum == 1 {
 		leftIndex = t.GetRootPageIdx()
 	}
@@ -1055,6 +1211,12 @@ func (t *Table) mergeInternalNodes(ctx context.Context, parent, left, right *Pag
 	if err := parent.InternalNode.DeleteKeyAndRightChild(idx); err != nil {
 		return err
 	}
+	if err := t.refreshInternalNodeKeys(ctx, left); err != nil {
+		return fmt.Errorf("merge internal nodes: %w", err)
+	}
+	if err := t.refreshInternalNodeKeys(ctx, parent); err != nil {
+		return fmt.Errorf("merge internal nodes: %w", err)
+	}
 
 	// If root has no keys, make left the new root
 	if parent.InternalNode.Header.IsRoot && parent.InternalNode.Header.KeysNum == 0 {
@@ -1062,24 +1224,23 @@ func (t *Table) mergeInternalNodes(ctx context.Context, parent, left, right *Pag
 		if err != nil {
 			return fmt.Errorf("get root page: %w", err)
 		}
-		*rootPage.InternalNode = *left.InternalNode
+		rootPage.InternalNode = left.InternalNode.Clone()
 		rootPage.LeafNode = nil
 		rootPage.InternalNode.Header.IsRoot = true
 		rootPage.InternalNode.Header.Parent = 0
-		for idx := range leftCells {
-			childPage, err := t.pager.ModifyPage(ctx, left.InternalNode.ICells[idx].Child)
+		for _, childIdx := range rootPage.InternalNode.Children() {
+			childPage, err := t.pager.ModifyPage(ctx, childIdx)
 			if err != nil {
 				return fmt.Errorf("get child page: %w", err)
 			}
-			childPage.setParent(0)
+			childPage.setParent(t.GetRootPageIdx())
 		}
-		oldRightChildPage.setParent(leftIndex)
 		return t.pager.AddFreePage(ctx, left.Index)
 	}
 
 	// Check for underflow
 	if parent.InternalNode.AtLeastHalfFull(t.maxICells(parent.Index)) {
-		return nil
+		return t.updateParentMaxKey(ctx, parent)
 	}
 
 	return t.rebalanceInternal(ctx, parent)


### PR DESCRIPTION
- rebalanceLeaf() now locates a child in its parent by page index, not by the deleted key.
- borrowFromLeftInternal() now uses the correct separator slot instead of subtracting the index twice.
- empty-root internal collapse now promotes the surviving child from RightChild, not an invalid ICells[0].Child.
- root replacement after internal merges now rewrites child parent pointers more safely.
- simple leaf deletions now propagate updated max keys upward with updateParentMaxKey().
- Propagated parent separator updates after leaf/internal borrow and merge paths via updateParentMaxKey.
- Fixed borrowFromRightLeaf to set the separator from the new left-child max (node.LastCell().Key).
- Updated internal borrow logic to recompute separators from subtree maxes (GetMaxKey) rather than stale sibling cell values.
- Internal-node prepend shift bug in node.go.
- Stale separator keys after leaf/internal merge/borrow by adding separator refresh logic and wiring it into rebalance paths in table.go.
- Off-by-one merge-capacity check for internal merges (+1 bridge separator) in table.go, which was causing internal page ... exceeds max keys.