### PR TITLE
refactor: WAL allocation optimizations

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,29 +1,37 @@
-### 2026-04-19 02:20 UTC
+### 2026-04-19 17:10 UTC
+
+WAL allocation optimizations + read-only transaction fast path:
+- `WAL.AppendTransaction`: reuse `writeBuf` (eliminates per-commit 4KB×N batch buffer allocation)
+- `WALIndex.Update`: take ownership of page slice (no defensive copy on store)
+- `WALIndex.Lookup`: return direct reference (no defensive copy on read)
+- `WAL.Checkpoint`: inline frame scan into latest-page map (eliminates intermediate `[]WALReadFrame` slice)
+- `Transaction.ReadOnly`: skip `TrackRead` / ReadSet allocation for SELECT queries; skip OCC read conflict check
 
 #### Timing
 
 | Benchmark | minisql | sqlite | ratio |
 |---|---|---|---|
-| Delete_ByPK | 386.42 µs/op | 145.41 µs/op | 2.7× |
-| Insert_SingleRow | 134.46 µs/op | 53.41 µs/op | 2.5× |
-| Insert_Batch | 970.47 µs/op | 241.00 µs/op | 4.0× |
-| Select_PointScan | 12.94 µs/op | 3.50 µs/op | 3.7× |
-| Select_FullScan | 5.74 ms/op | 5.28 ms/op | 1.1× |
-| Select_CountStar | 62.38 µs/op | 10.01 µs/op | 6.2× |
-| Select_RangeScan | 3.59 ms/op | 905.22 µs/op | 4.0× |
-| Txn_NInserts | 504.36 µs/op | 154.57 µs/op | 3.3× |
-| Update_ByPK | 75.66 µs/op | 45.81 µs/op | 1.7× |
+| Delete_ByPK | 105.64 µs/op | 97.79 µs/op | 1.1× |
+| Insert_SingleRow | 88.60 µs/op | 49.90 µs/op | 1.8× |
+| Insert_Batch | 900.61 µs/op | 266.61 µs/op | 3.4× |
+| Select_PointScan | 5.01 µs/op | 3.56 µs/op | 1.4× |
+| Select_FullScan | 8.41 ms/op | 5.50 ms/op | 1.5× |
+| Select_CountStar | 37.54 µs/op | 9.92 µs/op | 3.8× |
+| Select_RangeScan | 3.51 ms/op | 1.02 ms/op | 3.4× |
+| Txn_NInserts | 482.84 µs/op | 159.79 µs/op | 3.0× |
+| Update_ByPK | 51.99 µs/op | 44.47 µs/op | 1.2× |
 
 #### Memory (B/op)
 
 | Benchmark | minisql | sqlite |
 |---|---|---|
-| Delete_ByPK | 205.9 KiB | 447 B |
-| Insert_SingleRow | 94.4 KiB | 311 B |
-| Insert_Batch | 899.2 KiB | 31.0 KiB |
-| Select_PointScan | 19.6 KiB | 679 B |
-| Select_FullScan | 9.0 MiB | 1.3 MiB |
-| Select_CountStar | 34.3 KiB | 400 B |
-| Select_RangeScan | 2.1 MiB | 85.9 KiB |
-| Txn_NInserts | 511.3 KiB | 15.8 KiB |
-| Update_ByPK | 29.1 KiB | 263 B |
+| Delete_ByPK | 84.0 KiB | 447 B |
+| Insert_SingleRow | 68.6 KiB | 312 B |
+| Insert_Batch | 759 KiB | 31.1 KiB |
+| Select_PointScan | 4.4 KiB | 679 B |
+| Select_FullScan | 12.3 MiB | 1.3 MiB |
+| Select_CountStar | 6.0 KiB | 400 B |
+| Select_RangeScan | 2.4 MiB | 85.9 KiB |
+| Txn_NInserts | 414 KiB | 15.9 KiB |
+| Update_ByPK | 15.3 KiB | 263 B |
+

--- a/internal/minisql/delete.go
+++ b/internal/minisql/delete.go
@@ -3,7 +3,6 @@ package minisql
 import (
 	"context"
 	"fmt"
-	"sync"
 )
 
 // Delete ...
@@ -26,74 +25,46 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 	// Always select all columns so the full row is available for index cleanup on delete.
 	selectedFields := fieldsFromColumns(t.Columns...)
 
-	var (
-		filteredPipe = make(chan Row)
-		errorsPipe   = make(chan error, 1)
-		stopChan     = make(chan bool)
-		wg           = new(sync.WaitGroup)
-	)
-
-	// Execute scans based on plan
-	wg.Go(func() {
-		if err := plan.Execute(ctx, t.provider, selectedFields, filteredPipe); err != nil {
-			errorsPipe <- err
-		}
-	})
-	go func() {
-		wg.Wait()
-		close(filteredPipe)
-	}()
-
 	result := StatementResult{
 		Columns: t.Columns,
 	}
 
-	go func(in <-chan Row) {
-		defer close(stopChan)
-		// When deleting multiple rows, we first collect them all
-		// and then delete them one by one. This is to avoid conflict
-		// with rows that are still being read because delete can cause
-		// nodes to be split or merged which can cause cells to move around.
-		rows := make([]Row, 0, 100)
-		for row := range in {
-			rows = append(rows, row)
-		}
-		for _, row := range rows {
-			// Row locations can change after each delete, so we seek again for each key
-			// to make sure we have the correct cursor.
-			cursor, err := t.Seek(ctx, row.Key)
-			if err != nil {
-				errorsPipe <- err
-				return
-			}
-
-			if len(selectedFields) < len(t.Columns) {
-				// Load full row before delete, this is so we have all indexed values available
-				// for proper index cleanup as well as any overflow data that needs to be freed.
-				fullRow, err := cursor.fetchRow(ctx, false, fieldsFromColumns(t.Columns...)...)
-				if err != nil {
-					errorsPipe <- err
-					return
-				}
-				row = fullRow
-			}
-
-			if err := cursor.delete(ctx, row); err != nil {
-				errorsPipe <- err
-				return
-			}
-
-			result.RowsAffected += 1
-		}
-	}(filteredPipe)
-
-	select {
-	case <-ctx.Done():
-		return result, fmt.Errorf("context done: %w", ctx.Err())
-	case err := <-errorsPipe:
+	// Collect all rows first, then delete. We must collect before deleting because
+	// a delete can cause B-tree node splits/merges that move cells around, which
+	// would corrupt an in-progress scan.
+	var rows []Row
+	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+		rows = append(rows, row)
+		return nil
+	}); err != nil {
 		return result, err
-	case <-stopChan:
-		t.logger.Sugar().Debugf("deleted %d rows", result.RowsAffected)
-		return result, nil
 	}
+
+	for _, row := range rows {
+		// Row locations can change after each delete, so we seek again for each key
+		// to make sure we have the correct cursor.
+		cursor, err := t.Seek(ctx, row.Key)
+		if err != nil {
+			return result, err
+		}
+
+		if len(selectedFields) < len(t.Columns) {
+			// Load full row before delete, this is so we have all indexed values available
+			// for proper index cleanup as well as any overflow data that needs to be freed.
+			fullRow, err := cursor.fetchRow(ctx, false, fieldsFromColumns(t.Columns...)...)
+			if err != nil {
+				return result, err
+			}
+			row = fullRow
+		}
+
+		if err := cursor.delete(ctx, row); err != nil {
+			return result, err
+		}
+
+		result.RowsAffected += 1
+	}
+
+	t.logger.Sugar().Debugf("deleted %d rows", result.RowsAffected)
+	return result, nil
 }

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -843,15 +843,31 @@ func tryRangeScan(tableName string, indexInfo IndexInfo, filters Conditions, sta
 	return scan, true, nil
 }
 
-// Execute ...
-func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selectedFields []Field, filteredPipe chan<- Row) error {
-	// Handle JOIN queries
+// Execute runs the query plan, calling out for every row produced.
+// out receives each row synchronously on the caller's goroutine; no internal
+// goroutines or channels are created.  JOIN queries are the exception: they
+// still drive executeNestedLoopJoin in a helper goroutine internally so that
+// the nested-loop logic can use a channel, but the rows are forwarded to out
+// before Execute returns.
+func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selectedFields []Field, out func(Row) error) error {
+	// Handle JOIN queries: executeNestedLoopJoin still uses chan<- Row internally,
+	// so we bridge it with a goroutine + channel and forward rows to the callback.
 	if len(p.Joins) > 0 {
-		return p.executeNestedLoopJoin(ctx, provider, selectedFields, filteredPipe)
+		ch := make(chan Row, 128)
+		var joinErr error
+		go func() {
+			defer close(ch)
+			joinErr = p.executeNestedLoopJoin(ctx, provider, selectedFields, ch)
+		}()
+		for row := range ch {
+			if err := out(row); err != nil {
+				return err
+			}
+		}
+		return joinErr
 	}
 
 	if len(p.Scans) == 1 {
-		// Get table for this scan
 		t, ok := provider.GetTable(ctx, p.Scans[0].TableName)
 		if !ok {
 			return fmt.Errorf("%w: %s", errTableDoesNotExist, p.Scans[0].TableName)
@@ -859,23 +875,22 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 
 		switch p.Scans[0].Type {
 		case ScanTypeIndexAll:
-			return t.indexScanAll(ctx, p, p.Scans[0], selectedFields, filteredPipe)
+			return t.indexScanAll(ctx, p, p.Scans[0], selectedFields, out)
 		case ScanTypeIndexRange:
-			return t.indexRangeScan(ctx, p, p.Scans[0], selectedFields, filteredPipe)
+			return t.indexRangeScan(ctx, p, p.Scans[0], selectedFields, out)
 		case ScanTypeIndexPoint:
-			return t.indexPointScan(ctx, p.Scans[0], selectedFields, filteredPipe)
+			return t.indexPointScan(ctx, p.Scans[0], selectedFields, out)
 		case ScanTypeIndexFirst:
-			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, filteredPipe, false)
+			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, false)
 		case ScanTypeIndexLast:
-			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, filteredPipe, true)
+			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, true)
 		case ScanTypeSequential:
-			return t.sequentialScan(ctx, p.Scans[0], selectedFields, filteredPipe)
+			return t.sequentialScan(ctx, p.Scans[0], selectedFields, out)
 		default:
 			return fmt.Errorf("unhandled scan type in single scan: %d", p.Scans[0].Type)
 		}
 	}
 	for _, scan := range p.Scans {
-		// Get table for this scan
 		t, ok := provider.GetTable(ctx, scan.TableName)
 		if !ok {
 			return fmt.Errorf("%w: %s", errTableDoesNotExist, scan.TableName)
@@ -883,11 +898,11 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 
 		switch scan.Type {
 		case ScanTypeIndexRange:
-			if err := t.indexRangeScan(ctx, p, scan, selectedFields, filteredPipe); err != nil {
+			if err := t.indexRangeScan(ctx, p, scan, selectedFields, out); err != nil {
 				return err
 			}
 		case ScanTypeIndexPoint:
-			if err := t.indexPointScan(ctx, scan, selectedFields, filteredPipe); err != nil {
+			if err := t.indexPointScan(ctx, scan, selectedFields, out); err != nil {
 				return err
 			}
 		default:

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -6,6 +6,19 @@ import (
 	"fmt"
 )
 
+// chanRowCallback wraps a buffered channel as a row callback.
+// The goroutine sending to the channel must close it when done.
+func chanRowCallback(ctx context.Context, ch chan<- Row) func(Row) error {
+	return func(row Row) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- row:
+			return nil
+		}
+	}
+}
+
 // planJoinQuery creates an optimized query plan for JOINs
 // (supports star schema: multiple tables joining to base table)
 // Optimizations:
@@ -334,7 +347,7 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 
 	go func() {
 		defer close(baseRowChan)
-		if err := baseTable.sequentialScan(ctx, baseScan, baseFields, baseRowChan); err != nil {
+		if err := baseTable.sequentialScan(ctx, baseScan, baseFields, chanRowCallback(ctx, baseRowChan)); err != nil {
 			baseErrChan <- err
 		}
 	}()
@@ -465,7 +478,7 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 			indexScan.IndexKeys = joinKeyValues
 
 			// Use index scan to find matching rows
-			if err := innerTable.indexPointScan(ctx, indexScan, innerFields, innerRowChan); err != nil {
+			if err := innerTable.indexPointScan(ctx, indexScan, innerFields, chanRowCallback(ctx, innerRowChan)); err != nil {
 				innerErrChan <- err
 			}
 		}()
@@ -473,7 +486,7 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 		// Standard nested loop: sequential scan of inner table
 		go func() {
 			defer close(innerRowChan)
-			if err := innerTable.sequentialScan(ctx, innerScan, innerFields, innerRowChan); err != nil {
+			if err := innerTable.sequentialScan(ctx, innerScan, innerFields, chanRowCallback(ctx, innerRowChan)); err != nil {
 				innerErrChan <- err
 			}
 		}()
@@ -571,7 +584,7 @@ func (p QueryPlan) executeRightJoinPass(ctx context.Context, provider TableProvi
 		rightErrChan := make(chan error, 1)
 		go func() {
 			defer close(rightRowChan)
-			if err := innerTable.sequentialScan(ctx, innerScan, innerFields, rightRowChan); err != nil {
+			if err := innerTable.sequentialScan(ctx, innerScan, innerFields, chanRowCallback(ctx, rightRowChan)); err != nil {
 				rightErrChan <- err
 			}
 		}()
@@ -595,7 +608,7 @@ func (p QueryPlan) executeRightJoinPass(ctx context.Context, provider TableProvi
 			baseErrChan := make(chan error, 1)
 			go func() {
 				defer close(baseRowChan)
-				if err := baseTable.sequentialScan(ctx, baseScan, baseFields, baseRowChan); err != nil {
+				if err := baseTable.sequentialScan(ctx, baseScan, baseFields, chanRowCallback(ctx, baseRowChan)); err != nil {
 					baseErrChan <- err
 				}
 			}()

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 
 	"go.uber.org/zap"
 )
@@ -95,84 +94,51 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
-	var (
-		// Buffered channel reduces goroutine blocking/context switching
-		// Buffer size of 128 is a good balance between memory and performance
-		filteredPipe = make(chan Row, 128)
-		errorsPipe   = make(chan error, len(plan.Scans))
-		wg           = new(sync.WaitGroup)
-	)
-
-	// Execute scans based on plan
-	wg.Go(func() {
-		if err := plan.Execute(ctx, t.provider, selectedFields, filteredPipe); err != nil {
-			errorsPipe <- err
-		}
-	})
-	go func() {
-		wg.Wait()
-		close(filteredPipe)
-	}()
+	// Execute the plan synchronously — no goroutines or channels needed.
+	// plan.Execute calls out for every matching row on the caller's goroutine.
+	// JOIN queries still use an internal goroutine inside plan.Execute but
+	// the rows are forwarded to the callback before Execute returns.
+	var rows []Row
+	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+		rows = append(rows, row)
+		return nil
+	}); err != nil {
+		return StatementResult{}, err
+	}
 
 	if stmt.IsSelectCountAll() {
-		return t.selectCount(ctx, filteredPipe, errorsPipe)
+		return t.selectCount(rows)
 	}
 
 	// Grouped aggregate queries (GROUP BY) materialise all rows and group them.
 	if stmt.IsSelectGroupBy() {
-		return t.selectGroupBy(ctx, stmt, filteredPipe, errorsPipe)
+		return t.selectGroupBy(ctx, stmt, rows)
 	}
 
 	// Aggregate queries (SUM, AVG, MIN, MAX) always materialise all rows.
 	if stmt.IsSelectAggregate() {
-		return t.selectAggregate(ctx, stmt, filteredPipe, errorsPipe)
+		return t.selectAggregate(ctx, stmt, rows)
 	}
 
 	// If we are sorting in memory, it means we are doing sequential scan as we need to
 	// gather all rows first to be able to determine correct order.
 	if plan.SortInMemory {
-		return t.selectWithSort(stmt, plan, filteredPipe, errorsPipe, requestedFields)
+		return t.selectWithSort(stmt, plan, rows, requestedFields)
 	}
 
 	// Stream results (already ordered or no ordering needed)
-	return t.selectStreaming(stmt, filteredPipe, errorsPipe, requestedFields)
+	return t.selectStreaming(stmt, rows, requestedFields)
 }
 
-func (t *Table) selectCount(ctx context.Context, filteredPipe chan Row, errorsPipe chan error) (StatementResult, error) {
-	var count int64
-
-	drainDone := make(chan struct{})
-	go func() {
-		defer close(drainDone)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case _, open := <-filteredPipe:
-				if !open {
-					return
-				}
-				count += 1
-			}
-		}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return StatementResult{}, fmt.Errorf("context done: %w", ctx.Err())
-	case err := <-errorsPipe:
-		return StatementResult{}, err
-	case <-drainDone:
-		return StatementResult{
-			Columns: []Column{
-				{Name: "COUNT(*)"},
-			},
-			Rows: NewSingleRowIterator(NewRowWithValues(
-				[]Column{{Name: "COUNT(*)"}},
-				[]OptionalValue{{Valid: true, Value: count}},
-			)),
-		}, nil
-	}
+func (t *Table) selectCount(rows []Row) (StatementResult, error) {
+	count := int64(len(rows))
+	return StatementResult{
+		Columns: []Column{{Name: "COUNT(*)"}},
+		Rows: NewSingleRowIterator(NewRowWithValues(
+			[]Column{{Name: "COUNT(*)"}},
+			[]OptionalValue{{Valid: true, Value: count}},
+		)),
+	}, nil
 }
 
 // countAllLeafWalk counts every row in the table by walking the B+ tree leaf
@@ -229,7 +195,7 @@ type aggState struct {
 	hasValue  bool // true once a non-NULL value has been seen
 }
 
-func (t *Table) selectAggregate(ctx context.Context, stmt Statement, filteredPipe chan Row, errorsPipe chan error) (StatementResult, error) {
+func (t *Table) selectAggregate(ctx context.Context, stmt Statement, rows []Row) (StatementResult, error) {
 	states := make([]aggState, len(stmt.Aggregates))
 
 	// Determine whether integer or float accumulation should be used for SUM/AVG.
@@ -242,69 +208,58 @@ func (t *Table) selectAggregate(ctx context.Context, stmt Statement, filteredPip
 		}
 	}
 
-	drainDone := make(chan struct{})
-	go func() {
-		defer close(drainDone)
-		for row := range filteredPipe {
-			for i, agg := range stmt.Aggregates {
-				switch agg.Kind {
-				case AggregateCount:
-					states[i].count += 1
+	for _, row := range rows {
+		for i, agg := range stmt.Aggregates {
+			switch agg.Kind {
+			case AggregateCount:
+				states[i].count += 1
 
-				case AggregateSum, AggregateAvg:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue // SQL aggregate functions ignore NULLs
+			case AggregateSum, AggregateAvg:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue // SQL aggregate functions ignore NULLs
+				}
+				states[i].count += 1
+				states[i].hasValue = true
+				if states[i].useIntSum {
+					switch v := val.Value.(type) {
+					case int64:
+						states[i].sumI += v
+					case int32:
+						states[i].sumI += int64(v)
 					}
-					states[i].count += 1
+				} else {
+					switch v := val.Value.(type) {
+					case float64:
+						states[i].sumF += v
+					case float32:
+						states[i].sumF += float64(v)
+					}
+				}
+
+			case AggregateMin:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue
+				}
+				if !states[i].hasValue || compareValues(val, states[i].min) < 0 {
+					states[i].min = val
 					states[i].hasValue = true
-					if states[i].useIntSum {
-						switch v := val.Value.(type) {
-						case int64:
-							states[i].sumI += v
-						case int32:
-							states[i].sumI += int64(v)
-						}
-					} else {
-						switch v := val.Value.(type) {
-						case float64:
-							states[i].sumF += v
-						case float32:
-							states[i].sumF += float64(v)
-						}
-					}
+				}
 
-				case AggregateMin:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue
-					}
-					if !states[i].hasValue || compareValues(val, states[i].min) < 0 {
-						states[i].min = val
-						states[i].hasValue = true
-					}
-
-				case AggregateMax:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue
-					}
-					if !states[i].hasValue || compareValues(val, states[i].max) > 0 {
-						states[i].max = val
-						states[i].hasValue = true
-					}
+			case AggregateMax:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue
+				}
+				if !states[i].hasValue || compareValues(val, states[i].max) > 0 {
+					states[i].max = val
+					states[i].hasValue = true
 				}
 			}
 		}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return StatementResult{}, fmt.Errorf("context done: %w", ctx.Err())
-	case err := <-errorsPipe:
-		return StatementResult{}, err
-	case <-drainDone:
 	}
+	_ = ctx // ctx kept for signature compat; no blocking ops remain
 
 	// Build result columns and a single result row.
 	resultColumns := make([]Column, len(stmt.Aggregates))
@@ -371,7 +326,7 @@ type groupState struct {
 	aggStates   []aggState
 }
 
-func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, filteredPipe chan Row, errorsPipe chan error) (StatementResult, error) {
+func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (StatementResult, error) {
 	// Determine integer vs float accumulation mode for SUM/AVG per aggregate.
 	useIntSum := make([]bool, len(stmt.Aggregates))
 	for i, agg := range stmt.Aggregates {
@@ -394,89 +349,78 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, filteredPipe 
 	groups := make(map[string]*groupState)
 	groupOrder := make([]string, 0)
 
-	drainDone := make(chan struct{})
-	go func() {
-		defer close(drainDone)
-		for row := range filteredPipe {
-			// Compute group key from the GROUP BY columns.
-			groupRow := row.OnlyFields(stmt.GroupBy...)
-			key := groupRow.rowDistinctKey()
+	for _, row := range rows {
+		// Compute group key from the GROUP BY columns.
+		groupRow := row.OnlyFields(stmt.GroupBy...)
+		key := groupRow.rowDistinctKey()
 
-			gs, exists := groups[key]
-			if !exists {
-				states := make([]aggState, len(stmt.Aggregates))
-				for i := range states {
-					states[i].useIntSum = useIntSum[i]
-				}
-				gs = &groupState{
-					groupValues: make([]OptionalValue, len(stmt.GroupBy)),
-					aggStates:   states,
-				}
-				// Record the group column values from this first row.
-				copy(gs.groupValues, groupRow.Values)
-				groups[key] = gs
-				groupOrder = append(groupOrder, key)
+		gs, exists := groups[key]
+		if !exists {
+			states := make([]aggState, len(stmt.Aggregates))
+			for i := range states {
+				states[i].useIntSum = useIntSum[i]
 			}
+			gs = &groupState{
+				groupValues: make([]OptionalValue, len(stmt.GroupBy)),
+				aggStates:   states,
+			}
+			// Record the group column values from this first row.
+			copy(gs.groupValues, groupRow.Values)
+			groups[key] = gs
+			groupOrder = append(groupOrder, key)
+		}
 
-			// Accumulate aggregates for this group.
-			for i, agg := range stmt.Aggregates {
-				switch agg.Kind {
-				case 0:
-					// Non-aggregate GROUP BY column — no accumulation needed.
-				case AggregateCount:
-					gs.aggStates[i].count += 1
-				case AggregateSum, AggregateAvg:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue
+		// Accumulate aggregates for this group.
+		for i, agg := range stmt.Aggregates {
+			switch agg.Kind {
+			case 0:
+				// Non-aggregate GROUP BY column — no accumulation needed.
+			case AggregateCount:
+				gs.aggStates[i].count += 1
+			case AggregateSum, AggregateAvg:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue
+				}
+				gs.aggStates[i].count += 1
+				gs.aggStates[i].hasValue = true
+				if gs.aggStates[i].useIntSum {
+					switch v := val.Value.(type) {
+					case int64:
+						gs.aggStates[i].sumI += v
+					case int32:
+						gs.aggStates[i].sumI += int64(v)
 					}
-					gs.aggStates[i].count += 1
+				} else {
+					switch v := val.Value.(type) {
+					case float64:
+						gs.aggStates[i].sumF += v
+					case float32:
+						gs.aggStates[i].sumF += float64(v)
+					}
+				}
+			case AggregateMin:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue
+				}
+				if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].min) < 0 {
+					gs.aggStates[i].min = val
 					gs.aggStates[i].hasValue = true
-					if gs.aggStates[i].useIntSum {
-						switch v := val.Value.(type) {
-						case int64:
-							gs.aggStates[i].sumI += v
-						case int32:
-							gs.aggStates[i].sumI += int64(v)
-						}
-					} else {
-						switch v := val.Value.(type) {
-						case float64:
-							gs.aggStates[i].sumF += v
-						case float32:
-							gs.aggStates[i].sumF += float64(v)
-						}
-					}
-				case AggregateMin:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue
-					}
-					if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].min) < 0 {
-						gs.aggStates[i].min = val
-						gs.aggStates[i].hasValue = true
-					}
-				case AggregateMax:
-					val, ok := row.GetValue(agg.Column)
-					if !ok || !val.Valid {
-						continue
-					}
-					if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].max) > 0 {
-						gs.aggStates[i].max = val
-						gs.aggStates[i].hasValue = true
-					}
+				}
+			case AggregateMax:
+				val, ok := row.GetValue(agg.Column)
+				if !ok || !val.Valid {
+					continue
+				}
+				if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].max) > 0 {
+					gs.aggStates[i].max = val
+					gs.aggStates[i].hasValue = true
 				}
 			}
 		}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return StatementResult{}, fmt.Errorf("context done: %w", ctx.Err())
-	case err := <-errorsPipe:
-		return StatementResult{}, err
-	case <-drainDone:
 	}
+	_ = ctx // ctx kept for signature compat; no blocking ops remain
 
 	// Build result column metadata.
 	resultColumns := make([]Column, len(stmt.Fields))
@@ -602,88 +546,66 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, filteredPipe 
 	}, nil
 }
 
-func (t *Table) selectStreaming(stmt Statement, filteredPipe chan Row, errorsPipe chan error, requestedFields []Field) (StatementResult, error) {
+func (t *Table) selectStreaming(stmt Statement, scanned []Row, requestedFields []Field) (StatementResult, error) {
 	result := StatementResult{
 		Columns: make([]Column, len(requestedFields)),
 	}
 	for i, field := range requestedFields {
 		if field.Expr != nil {
-			// Computed column: synthesise metadata from the output name.
 			result.Columns[i] = Column{Name: field.OutputName()}
 		} else if colIdx := stmt.ColumnIdx(field.Name); colIdx >= 0 {
 			result.Columns[i] = t.Columns[colIdx]
 		}
 	}
 
-	// Filter rows according to the WHERE conditions. In case of an index scan,
-	// any remaining filtering will happen here. In case of a sequential scan,
-	// this will filter all rows.
-	// LIMIT and OFFSET are also applied here.
-	// Buffered channel reduces blocking when consumer is slower
-	limitedPipe := make(chan Row, 64)
-	go func(in <-chan Row, out chan<- Row) {
-		defer close(out)
-		var limit, offset int64
-		if stmt.Limit.Valid {
-			limit = stmt.Limit.Value.(int64)
+	var (
+		limit, offset int64
+		hasLimit      = stmt.Limit.Valid
+		hasOffset     = stmt.Offset.Valid
+	)
+	if hasLimit {
+		limit = stmt.Limit.Value.(int64)
+	}
+	if hasOffset {
+		offset = stmt.Offset.Value.(int64)
+	}
+
+	var seen map[string]struct{}
+	if stmt.Distinct {
+		seen = make(map[string]struct{})
+	}
+
+	projected := make([]Row, 0, len(scanned))
+	for _, row := range scanned {
+		p, err := projectRow(row, requestedFields)
+		if err != nil {
+			return StatementResult{}, err
 		}
-		if stmt.Offset.Valid {
-			offset = stmt.Offset.Value.(int64)
-		}
-		var seen map[string]struct{}
 		if stmt.Distinct {
-			seen = make(map[string]struct{})
-		}
-		for row := range in {
-			projected, err := projectRow(row, requestedFields)
-			if err != nil {
-				// Send error and stop — the error channel is checked by the caller.
-				select {
-				case out <- Row{}:
-				default:
-				}
-				return
-			}
-			if stmt.Distinct {
-				key := projected.rowDistinctKey()
-				if _, dup := seen[key]; dup {
-					continue
-				}
-				seen[key] = struct{}{}
-			}
-			if stmt.Limit.Valid && limit == 0 {
-				return
-			}
-			if stmt.Offset.Valid && offset > 0 {
-				offset -= 1
+			key := p.rowDistinctKey()
+			if _, dup := seen[key]; dup {
 				continue
 			}
-			if stmt.Limit.Valid {
-				limit -= 1
-			}
-			out <- projected
+			seen[key] = struct{}{}
 		}
-	}(filteredPipe, limitedPipe)
-
-	result.Rows = NewIterator(func(ctx context.Context) (Row, error) {
-		select {
-		case <-ctx.Done():
-			return Row{}, fmt.Errorf("context done: %w", ctx.Err())
-		case err := <-errorsPipe:
-			return Row{}, err
-		case row, open := <-limitedPipe:
-			if !open {
-				return Row{}, ErrNoMoreRows
-			}
-
-			return row, nil
+		if hasOffset && offset > 0 {
+			offset--
+			continue
 		}
-	})
+		projected = append(projected, p)
+		if hasLimit {
+			limit--
+			if limit == 0 {
+				break
+			}
+		}
+	}
 
+	result.Rows = NewSliceIterator(projected)
 	return result, nil
 }
 
-func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, unfilteredPipe <-chan Row, errorsPipe chan error, requestedFields []Field) (StatementResult, error) {
+func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, allRows []Row, requestedFields []Field) (StatementResult, error) {
 	// Check if we can use heap optimization for LIMIT queries
 	var limit int
 	hasLimit := stmt.Limit.Valid
@@ -696,42 +618,20 @@ func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, unfilteredPipe <-
 		offset = int(stmt.Offset.Value.(int64))
 	}
 
-	// For queries with LIMIT (and optional OFFSET), use a heap to keep only top N+offset rows
-	// This is much more memory efficient than collecting all rows.
+	// For queries with LIMIT (and optional OFFSET), use a heap to keep only top N+offset rows.
 	// However, when DISTINCT is enabled we must see all rows before deduplication, so the
 	// heap optimisation cannot be used in that case.
-	var allRows []Row
 	if hasLimit && len(plan.OrderBy) > 0 && !stmt.Distinct {
-		// Use heap-based approach for memory efficiency
 		maxRows := offset + limit
 		h := newRowHeap(plan.OrderBy, maxRows)
-
-		for row := range unfilteredPipe {
+		for _, row := range allRows {
 			h.PushRow(row)
 		}
-
 		allRows = h.ExtractSorted()
 	} else {
-		// No LIMIT or no ORDER BY - collect all rows
-		// Pre-allocate with a reasonable initial capacity
-		allRows = make([]Row, 0, 1024)
-		for row := range unfilteredPipe {
-			allRows = append(allRows, row)
-		}
-
-		// Sort in memory
 		if err := t.sortRows(allRows, plan.OrderBy); err != nil {
 			return StatementResult{}, err
 		}
-	}
-
-	// Check for errors
-	select {
-	case err := <-errorsPipe:
-		if err != nil {
-			return StatementResult{}, err
-		}
-	default:
 	}
 
 	// Apply DISTINCT deduplication before OFFSET/LIMIT
@@ -778,7 +678,7 @@ func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, unfilteredPipe <-
 	return result, nil
 }
 
-func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out chan<- Row) error {
+func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
@@ -831,12 +731,10 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case out <- row:
-			return nil
+		if err := ctx.Err(); err != nil {
+			return err
 		}
+		return out(row)
 	}); err != nil {
 		return err
 	}
@@ -844,7 +742,7 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 	return nil
 }
 
-func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out chan<- Row) error {
+func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
@@ -897,12 +795,10 @@ func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, 
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case out <- row:
-			return nil
+		if err := ctx.Err(); err != nil {
+			return err
 		}
+		return out(row)
 	}); err != nil {
 		return err
 	}
@@ -910,7 +806,7 @@ func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, 
 	return nil
 }
 
-func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []Field, out chan<- Row) error {
+func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
@@ -972,11 +868,11 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 				}
 			}
 
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case out <- row:
-				continue
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := out(row); err != nil {
+				return err
 			}
 		}
 	}
@@ -992,7 +888,7 @@ var errStopScan = errors.New("stop scan")
 // the first (smallest) entry when reverse=false (MIN), or the last (largest) entry
 // when reverse=true (MAX).  It uses the index's in-order traversal, stopping as
 // soon as the first qualifying row has been sent to out.
-func (t *Table) indexEndpointScan(ctx context.Context, scan Scan, selectedFields []Field, out chan<- Row, reverse bool) error {
+func (t *Table) indexEndpointScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error, reverse bool) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for endpoint scan: %s", scan.IndexName)
@@ -1021,10 +917,11 @@ func (t *Table) indexEndpointScan(ctx context.Context, scan Scan, selectedFields
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case out <- row:
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := out(row); err != nil {
+			return err
 		}
 
 		// Stop after the first qualifying row.
@@ -1160,7 +1057,7 @@ func deduplicateRows(rows []Row, fields []Field) []Row {
 	return out
 }
 
-func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []Field, out chan<- Row) error {
+func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
 	cursor, err := t.SeekFirst(ctx)
 	if err != nil {
 		return err
@@ -1173,6 +1070,10 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	cursor.EndOfTable = page.LeafNode.Header.Cells == 0
 
 	for !cursor.EndOfTable {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		row, err := cursor.fetchRow(ctx, true, selectedFields...)
 		if err != nil {
 			return err
@@ -1187,11 +1088,8 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 			continue // Skip this row
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case out <- row:
-			continue
+		if err := out(row); err != nil {
+			return err
 		}
 	}
 

--- a/internal/minisql/stmt_result.go
+++ b/internal/minisql/stmt_result.go
@@ -20,6 +20,19 @@ func NewIterator(rowFunc func(ctx context.Context) (Row, error)) Iterator {
 	}
 }
 
+// NewSliceIterator returns an Iterator that yields rows from rows in order.
+func NewSliceIterator(rows []Row) Iterator {
+	idx := 0
+	return NewIterator(func(ctx context.Context) (Row, error) {
+		if idx >= len(rows) {
+			return Row{}, ErrNoMoreRows
+		}
+		row := rows[idx]
+		idx++
+		return row, nil
+	})
+}
+
 // NewSingleRowIterator ...
 func NewSingleRowIterator(row Row) Iterator {
 	i := Iterator{}

--- a/internal/minisql/transaction.go
+++ b/internal/minisql/transaction.go
@@ -46,13 +46,18 @@ type WriteInfo struct {
 type Transaction struct {
 	ID            TransactionID
 	StartTime     time.Time
-	ReadSet       map[PageIndex]uint64    // pageIdx -> version when read
+	ReadSet       map[PageIndex]uint64    // pageIdx -> version when read; nil when ReadOnly
 	WriteSet      map[PageIndex]WriteInfo // pageIdx -> modified page copy (+ table name, index name)
-	DBHeaderRead  *uint64                 // version of DB header when read
+	DBHeaderRead  *uint64                 // version of DB header when read; nil when ReadOnly
 	DBHeaderWrite *DatabaseHeader         // modified DB header
 	DDLChanges    DDLChanges
 	Status        TransactionStatus
-	mu            sync.RWMutex
+	// ReadOnly marks a transaction that will never write.  When true, TrackRead
+	// is a no-op, the ReadSet is never allocated, and conflict validation is
+	// skipped at commit time.  This eliminates per-page map writes and mutex
+	// acquisitions on read-heavy queries (e.g. COUNT(*), full-table scans).
+	ReadOnly bool
+	mu       sync.RWMutex
 }
 
 // TransactionStatus represents the lifecycle state of a transaction.
@@ -81,11 +86,17 @@ func (tx *Transaction) Abort() {
 }
 
 // TrackRead records that the given page was read at the given version.
+// It is a no-op for read-only transactions.
 func (tx *Transaction) TrackRead(pageIdx PageIndex, version uint64) {
+	if tx.ReadOnly {
+		return
+	}
 	tx.mu.Lock()
-	defer tx.mu.Unlock()
-
+	if tx.ReadSet == nil {
+		tx.ReadSet = make(map[PageIndex]uint64, 16)
+	}
 	tx.ReadSet[pageIdx] = version
+	tx.mu.Unlock()
 }
 
 // TrackWrite records a modified page in the transaction write set.
@@ -101,7 +112,11 @@ func (tx *Transaction) TrackWrite(pageIdx PageIndex, page *Page, table, index st
 }
 
 // TrackDBHeaderRead records the version of the database header when it was read.
+// It is a no-op for read-only transactions.
 func (tx *Transaction) TrackDBHeaderRead(version uint64) {
+	if tx.ReadOnly {
+		return
+	}
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -106,6 +106,30 @@ func (tm *TransactionManager) CheckpointWAL(dbFile DBFile) error {
 // transaction manager that is not in WAL mode.
 var ErrNotWALMode = errors.New("WAL mode is not enabled")
 
+// ExecuteReadOnlyTransaction runs fn within a read-only transaction.  Read
+// tracking is disabled so no ReadSet is built and conflict validation is
+// skipped at commit time.  fn must not perform any writes.
+func (tm *TransactionManager) ExecuteReadOnlyTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
+	if TxFromContext(ctx) != nil {
+		return fn(ctx)
+	}
+
+	tx := tm.BeginReadOnlyTransaction(ctx)
+	ctx = WithTransaction(ctx, tx)
+
+	if err := fn(ctx); err != nil {
+		tm.RollbackTransaction(ctx, tx)
+		return err
+	}
+
+	if err := tm.CommitTransaction(ctx, tx); err != nil {
+		tm.RollbackTransaction(ctx, tx)
+		return err
+	}
+
+	return nil
+}
+
 // ExecuteInTransaction runs fn within a transaction, committing on success or rolling back on failure.
 func (tm *TransactionManager) ExecuteInTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
 	// If there is a transaction already in context, use it.
@@ -137,9 +161,10 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context) *Transaction
 	tx := &Transaction{
 		ID:        tm.nextTxID,
 		StartTime: time.Now(),
-		ReadSet:   make(map[PageIndex]uint64),
 		WriteSet:  make(map[PageIndex]WriteInfo),
 		Status:    TxActive,
+		// ReadSet is lazily allocated in TrackRead to avoid the map allocation
+		// for read-only transactions.
 	}
 	tm.nextTxID++
 	tm.transactions[tx.ID] = tx
@@ -147,6 +172,15 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context) *Transaction
 
 	tm.logger.Debug("begin transaction", zap.Uint64("tx_id", uint64(tx.ID)))
 
+	return tx
+}
+
+// BeginReadOnlyTransaction starts a read-only transaction.  TrackRead calls
+// are no-ops, so the ReadSet is never allocated.  Conflict validation is
+// skipped at commit time.  Use this for SELECT queries.
+func (tm *TransactionManager) BeginReadOnlyTransaction(ctx context.Context) *Transaction {
+	tx := tm.BeginTransaction(ctx)
+	tx.ReadOnly = true
 	return tx
 }
 
@@ -173,17 +207,19 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 		return fmt.Errorf("transaction %d is not active", tx.ID)
 	}
 
-	// OCC conflict check
-	for pageIdx, readVersion := range tx.GetReadVersions() {
-		if tm.globalPageVersions[pageIdx] > readVersion {
-			tx.Abort()
-			return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+	// OCC conflict check (skip for ReadOnly transactions — ReadSet is never populated).
+	if !tx.ReadOnly {
+		for pageIdx, readVersion := range tx.GetReadVersions() {
+			if tm.globalPageVersions[pageIdx] > readVersion {
+				tx.Abort()
+				return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+			}
 		}
-	}
-	if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
-		if tm.globalDBHeaderVersion > readDBHeaderVersion {
-			tx.Abort()
-			return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+		if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
+			if tm.globalDBHeaderVersion > readDBHeaderVersion {
+				tx.Abort()
+				return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+			}
 		}
 	}
 
@@ -256,18 +292,22 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 	writeInfos := tx.GetWriteVersions()
 	isReadOnly := len(writeInfos) == 0 && !tx.DDLChanges.HasChanges()
 	if isReadOnly {
-		for pageIdx, readVersion := range tx.GetReadVersions() {
-			if tm.globalPageVersions[pageIdx] > readVersion {
-				tx.Abort()
-				tm.mu.Unlock()
-				return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+		// For read-only transactions (ReadOnly flag set), the ReadSet was never
+		// populated, so there is nothing to validate — skip the conflict check.
+		if !tx.ReadOnly {
+			for pageIdx, readVersion := range tx.GetReadVersions() {
+				if tm.globalPageVersions[pageIdx] > readVersion {
+					tx.Abort()
+					tm.mu.Unlock()
+					return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+				}
 			}
-		}
-		if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
-			if tm.globalDBHeaderVersion > readDBHeaderVersion {
-				tx.Abort()
-				tm.mu.Unlock()
-				return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+			if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
+				if tm.globalDBHeaderVersion > readDBHeaderVersion {
+					tx.Abort()
+					tm.mu.Unlock()
+					return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+				}
 			}
 		}
 		tx.Commit()

--- a/internal/minisql/transaction_manager_test.go
+++ b/internal/minisql/transaction_manager_test.go
@@ -33,9 +33,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		// Let's simulate some reads but no writes
 		tx.DBHeaderRead = new(uint64)
 		*tx.DBHeaderRead = 4
-		tx.ReadSet[2] = 0
-		tx.ReadSet[3] = 2
-		tx.ReadSet[4] = 1
+		tx.ReadSet = map[PageIndex]uint64{2: 0, 3: 2, 4: 1}
 
 		err := txManager.CommitTransaction(ctx, tx)
 		require.NoError(t, err)
@@ -70,9 +68,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		tx.DBHeaderRead = new(uint64)
 		*tx.DBHeaderRead = 3
 		tx.DBHeaderWrite = &DatabaseHeader{FirstFreePage: 2, FreePageCount: 10}
-		tx.ReadSet[2] = 0
-		tx.ReadSet[3] = 2
-		tx.ReadSet[4] = 5
+		tx.ReadSet = map[PageIndex]uint64{2: 0, 3: 2, 4: 5}
 		tx.WriteSet[4] = WriteInfo{
 			&Page{Index: PageIndex(4)},
 			"users",
@@ -124,9 +120,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		// Let's simulate some reads for first tx
 		readTx.DBHeaderRead = new(uint64)
 		*readTx.DBHeaderRead = 4
-		readTx.ReadSet[2] = 0
-		readTx.ReadSet[3] = 2
-		readTx.ReadSet[4] = 1
+		readTx.ReadSet = map[PageIndex]uint64{2: 0, 3: 2, 4: 1}
 
 		// Let's simulate a write for second tx that will conflict
 		writeTx.WriteSet[3] = WriteInfo{
@@ -185,9 +179,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		writeTx1.DBHeaderRead = new(uint64)
 		*writeTx1.DBHeaderRead = 3
 		writeTx1.DBHeaderWrite = &DatabaseHeader{FirstFreePage: 2, FreePageCount: 10}
-		writeTx1.ReadSet[2] = 0
-		writeTx1.ReadSet[3] = 2
-		writeTx1.ReadSet[4] = 5
+		writeTx1.ReadSet = map[PageIndex]uint64{2: 0, 3: 2, 4: 5}
 		writeTx1.WriteSet[4] = WriteInfo{
 			&Page{Index: PageIndex(4)},
 			"orders",
@@ -195,7 +187,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		}
 
 		// Second tx will modify the same page to cause conflict
-		writeTx2.ReadSet[4] = 5
+		writeTx2.ReadSet = map[PageIndex]uint64{4: 5}
 		writeTx2.WriteSet[4] = WriteInfo{
 			&Page{Index: PageIndex(4)},
 			"orders",
@@ -251,9 +243,7 @@ func TestTransactionManager_Rollback(t *testing.T) {
 	tx.DBHeaderRead = new(uint64)
 	*tx.DBHeaderRead = 3
 	tx.DBHeaderWrite = &DatabaseHeader{FirstFreePage: 2, FreePageCount: 10}
-	tx.ReadSet[2] = 0
-	tx.ReadSet[3] = 2
-	tx.ReadSet[4] = 5
+	tx.ReadSet = map[PageIndex]uint64{2: 0, 3: 2, 4: 5}
 	tx.WriteSet[4] = WriteInfo{
 		&Page{Index: PageIndex(4)},
 		"users",
@@ -289,8 +279,7 @@ func TestTransactionManager_WAL_Commit(t *testing.T) {
 		tx := txManager.BeginTransaction(ctx)
 		tx.DBHeaderRead = new(uint64)
 		*tx.DBHeaderRead = 4
-		tx.ReadSet[2] = 0
-		tx.ReadSet[3] = 2
+		tx.ReadSet = map[PageIndex]uint64{2: 0, 3: 2}
 
 		err := txManager.CommitTransaction(ctx, tx)
 		require.NoError(t, err)
@@ -317,7 +306,7 @@ func TestTransactionManager_WAL_Commit(t *testing.T) {
 		txManager.globalPageVersions[4] = 5
 
 		tx := txManager.BeginTransaction(ctx)
-		tx.ReadSet[4] = 5
+		tx.ReadSet = map[PageIndex]uint64{4: 5}
 		tx.WriteSet[4] = WriteInfo{
 			Page:  &Page{Index: PageIndex(4), LeafNode: NewLeafNode()},
 			Table: "users",
@@ -389,14 +378,14 @@ func TestTransactionManager_WAL_Commit(t *testing.T) {
 		txManager.globalPageVersions[5] = 3
 
 		txA := txManager.BeginTransaction(ctx)
-		txA.ReadSet[5] = 3
+		txA.ReadSet = map[PageIndex]uint64{5: 3}
 		txA.WriteSet[5] = WriteInfo{
 			Page:  &Page{Index: PageIndex(5), LeafNode: NewLeafNode()},
 			Table: "items",
 		}
 
 		txB := txManager.BeginTransaction(ctx)
-		txB.ReadSet[5] = 3
+		txB.ReadSet = map[PageIndex]uint64{5: 3}
 		txB.WriteSet[5] = WriteInfo{
 			Page:  &Page{Index: PageIndex(5), LeafNode: NewLeafNode()},
 			Table: "items",

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -3,7 +3,6 @@ package minisql
 import (
 	"context"
 	"fmt"
-	"sync"
 )
 
 // Update executes an UPDATE statement on the table and returns the result.
@@ -23,128 +22,98 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 
 	t.logger.Sugar().With("query type", "UPDATE", "plan", plan).Debug("query plan")
 
-	var (
-		filteredPipe   = make(chan Row)
-		chunkPipe      = make(chan []Row)
-		errorsPipe     = make(chan error, 1)
-		stopChan       = make(chan bool)
-		wg             = new(sync.WaitGroup)
-		selectedFields = fieldsFromColumns(t.Columns...)
-	)
-
-	// Execute scans based on plan
-	wg.Go(func() {
-		if err := plan.Execute(ctx, t.provider, selectedFields, filteredPipe); err != nil {
-			errorsPipe <- err
-		}
-	})
-	go func() {
-		wg.Wait()
-		close(filteredPipe)
-	}()
+	selectedFields := fieldsFromColumns(t.Columns...)
 
 	result := StatementResult{
 		Columns: t.Columns,
 	}
 
-	// Instead of collecting all rows from pipe and then updating, we can first check, if the
-	// update affects indexed columns. If not, and row size does not increase, we can update rows
-	// in place as we read them from the pipe. This can significantly improve performance for
-	// large updates. In case indexed values are changing or row size increases, we have to collect
-	// all rows and then update them after that to avoid issues with changing row locations.
-	go func(in <-chan Row, out chan<- []Row) {
-		defer close(out)
-		cantUpdateInPlace := make([]Row, 0, 10)
-		for row := range in {
-			size := row.Size()
-			// We will calculate new size after update
-			newSize := size
+	// Instead of collecting all rows and then updating, we check whether the update
+	// affects indexed columns. If not, and the row size does not increase, we update
+	// rows in-place as we encounter them. Otherwise we collect all rows first and
+	// update them afterwards to avoid conflicts with B-tree structural changes.
+	var cantUpdateInPlace []Row
 
-			indexChanges := false
-			for colName, newValue := range stmt.Updates {
-				col, _ := stmt.ColumnByName(colName)
-				oldValue, _ := row.GetValue(colName)
+	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+		size := row.Size()
+		newSize := size
 
-				// Expression values are evaluated at execution time — their actual value
-				// and size are unknown statically, so we must use the full update path.
-				if _, isExpr := newValue.Value.(*Expr); isExpr {
-					indexChanges = true
-					break
-				}
+		indexChanges := false
+		for colName, newValue := range stmt.Updates {
+			col, _ := stmt.ColumnByName(colName)
+			oldValue, _ := row.GetValue(colName)
 
-				if t.HasIndexOnColumn(colName) && !compareValue(col.Kind, oldValue, newValue) {
-					// Updating indexed column, can't update in place
-					indexChanges = true
-					break
-				}
-
-				switch {
-				case col.Kind.IsText():
-					if oldValue.Valid {
-						newSize -= uint64(oldValue.Value.(TextPointer).Size())
-					}
-					if newValue.Valid {
-						newSize += uint64(newValue.Value.(TextPointer).Size())
-					}
-					continue
-				case !oldValue.Valid && newValue.Valid:
-					// NULL -> NOT NULL
-					newSize += uint64(col.Size)
-				case oldValue.Valid && !newValue.Valid:
-					// NOT NULL -> NULL
-					newSize -= uint64(col.Size)
-				}
+			// Expression values are evaluated at execution time — their actual value
+			// and size are unknown statically, so we must use the full update path.
+			if _, isExpr := newValue.Value.(*Expr); isExpr {
+				indexChanges = true
+				break
 			}
 
-			// If we are not changing indexed values and row size does not increase,
-			// we can update in place, just send it to output channel directly.
-			if !indexChanges && newSize <= size {
-				// Can update in place
-				out <- []Row{row}
+			if t.HasIndexOnColumn(colName) && !compareValue(col.Kind, oldValue, newValue) {
+				// Updating indexed column, can't update in place
+				indexChanges = true
+				break
+			}
+
+			switch {
+			case col.Kind.IsText():
+				if oldValue.Valid {
+					newSize -= uint64(oldValue.Value.(TextPointer).Size())
+				}
+				if newValue.Valid {
+					newSize += uint64(newValue.Value.(TextPointer).Size())
+				}
 				continue
-			}
-
-			// Otherwise collect rows and send them all once reading from filtered pipe is done.
-			cantUpdateInPlace = append(cantUpdateInPlace, row)
-		}
-		if len(cantUpdateInPlace) > 0 {
-			out <- cantUpdateInPlace
-		}
-	}(filteredPipe, chunkPipe)
-
-	go func(in <-chan []Row) {
-		defer close(stopChan)
-		for rowChunk := range in {
-			for _, row := range rowChunk {
-				// Row locations can change after each update in case row grows larger
-				// and causes a page split (for example setting NULL values),
-				// so we seek again for each key to make sure we have the correct cursor.
-				cursor, err := t.Seek(ctx, row.Key)
-				if err != nil {
-					errorsPipe <- err
-					return
-				}
-
-				changed, err := cursor.update(ctx, stmt, row)
-				if err != nil {
-					errorsPipe <- err
-					return
-				}
-
-				if changed {
-					result.RowsAffected += 1
-				}
+			case !oldValue.Valid && newValue.Valid:
+				// NULL -> NOT NULL
+				newSize += uint64(col.Size)
+			case oldValue.Valid && !newValue.Valid:
+				// NOT NULL -> NULL
+				newSize -= uint64(col.Size)
 			}
 		}
-	}(chunkPipe)
 
-	select {
-	case err := <-errorsPipe:
+		if !indexChanges && newSize <= size {
+			// Can update in place immediately
+			cursor, err := t.Seek(ctx, row.Key)
+			if err != nil {
+				return err
+			}
+			changed, err := cursor.update(ctx, stmt, row)
+			if err != nil {
+				return err
+			}
+			if changed {
+				result.RowsAffected++
+			}
+			return nil
+		}
+
+		// Cannot update in place — collect and defer.
+		cantUpdateInPlace = append(cantUpdateInPlace, row)
+		return nil
+	}); err != nil {
 		return result, err
-	case <-ctx.Done():
-		return result, fmt.Errorf("context done: %w", ctx.Err())
-	case <-stopChan:
-		t.logger.Sugar().Debugf("updated %d rows", result.RowsAffected)
-		return result, nil
 	}
+
+	// Apply deferred updates for rows that couldn't be updated in place.
+	for _, row := range cantUpdateInPlace {
+		cursor, err := t.Seek(ctx, row.Key)
+		if err != nil {
+			return result, err
+		}
+
+		changed, err := cursor.update(ctx, stmt, row)
+		if err != nil {
+			return result, err
+		}
+
+		if changed {
+			result.RowsAffected++
+		}
+	}
+
+	t.logger.Sugar().Debugf("updated %d rows", result.RowsAffected)
+	return result, nil
 }

--- a/internal/minisql/wal.go
+++ b/internal/minisql/wal.go
@@ -72,7 +72,8 @@ type WAL struct {
 	pageSize   uint32
 	salt1      uint32
 	salt2      uint32
-	nextOffset int64 // byte offset at which the next frame will be written
+	nextOffset int64  // byte offset at which the next frame will be written
+	writeBuf   []byte // reusable write buffer; grown on demand, never shrunk
 }
 
 // CreateWAL creates a new WAL file (truncating any existing file at that path).
@@ -146,7 +147,11 @@ func (w *WAL) AppendTransaction(pages []WALPage) error {
 
 	commitSize := uint32(len(pages))
 	frameSize := int(WALFrameHeaderSize) + int(w.pageSize)
-	buf := make([]byte, frameSize*len(pages))
+	need := frameSize * len(pages)
+	if cap(w.writeBuf) < need {
+		w.writeBuf = make([]byte, need)
+	}
+	buf := w.writeBuf[:need]
 
 	for i, page := range pages {
 		if uint32(len(page.Data)) != w.pageSize {
@@ -269,18 +274,70 @@ func (w *WAL) ReadAllFrames() ([]WALReadFrame, error) {
 // appears in multiple transactions) and then fsyncs the database file.
 // Callers should call Truncate after a successful checkpoint.
 func (w *WAL) Checkpoint(dbFile DBFile) error {
-	frames, err := w.ReadAllFrames()
-	if err != nil {
-		return fmt.Errorf("read WAL frames for checkpoint: %w", err)
-	}
-	if len(frames) == 0 {
-		return nil
+	// Build a latest-page map directly from the WAL file without an intermediate
+	// []WALReadFrame slice.  A single shared read buffer (pageData) is reused for
+	// every frame; we only allocate a fresh 4 KB slice when we need to keep (or
+	// overwrite) the data for a given page index.
+	if _, err := w.file.Seek(WALFileHeaderSize, io.SeekStart); err != nil {
+		return fmt.Errorf("seek to first WAL frame for checkpoint: %w", err)
 	}
 
-	// Collect the latest data per page index (later frame wins).
-	latest := make(map[PageIndex][]byte, len(frames))
-	for _, f := range frames {
-		latest[f.PageIndex] = f.Data
+	latest := make(map[PageIndex][]byte)
+	fhBuf := make([]byte, WALFrameHeaderSize)
+	pageData := make([]byte, w.pageSize)
+	var pending []PageIndex // page indices in the current uncommitted group
+
+	for {
+		if _, err := io.ReadFull(w.file, fhBuf); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return fmt.Errorf("read WAL frame header for checkpoint: %w", err)
+		}
+		if _, err := io.ReadFull(w.file, pageData); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				break
+			}
+			return fmt.Errorf("read WAL frame data for checkpoint: %w", err)
+		}
+
+		// Salt validation
+		if unmarshalUint32(fhBuf, 8) != w.salt1 || unmarshalUint32(fhBuf, 12) != w.salt2 {
+			break
+		}
+		if crc32.ChecksumIEEE(fhBuf[0:16]) != unmarshalUint32(fhBuf, 16) {
+			break
+		}
+		if crc32.ChecksumIEEE(pageData) != unmarshalUint32(fhBuf, 20) {
+			break
+		}
+
+		pageIdx := PageIndex(unmarshalUint32(fhBuf, 0))
+		commitSize := unmarshalUint32(fhBuf, 4)
+
+		// Store page data: reuse an existing buffer for this page if one exists,
+		// otherwise allocate a fresh one.
+		buf, exists := latest[pageIdx]
+		if !exists {
+			buf = make([]byte, w.pageSize)
+		}
+		copy(buf, pageData)
+		latest[pageIdx] = buf
+		pending = append(pending, pageIdx)
+
+		if commitSize > 0 {
+			// Commit frame: all pending frames are confirmed; reset tracking slice.
+			pending = pending[:0]
+		}
+	}
+
+	// Discard pages that belong to an uncommitted trailing group.
+	for _, idx := range pending {
+		delete(latest, idx)
+	}
+
+	if len(latest) == 0 {
+		return nil
 	}
 
 	// Write each page to the correct offset in the database file.

--- a/internal/minisql/wal_index.go
+++ b/internal/minisql/wal_index.go
@@ -33,32 +33,26 @@ func NewWALIndex() *WALIndex {
 }
 
 // Update records the latest raw page bytes for pageIdx.
-// A defensive copy of data is stored so the caller may reuse or free its slice.
-// If a prior entry exists for pageIdx it is overwritten (later write wins).
+// Update takes ownership of data — the caller must not read or write the slice
+// after this call.  If a prior entry exists for pageIdx it is overwritten
+// (later write wins).
 func (wi *WALIndex) Update(pageIdx PageIndex, data []byte) {
-	cp := make([]byte, len(data))
-	copy(cp, data)
-
 	wi.mu.Lock()
-	wi.pages[pageIdx] = cp
+	wi.pages[pageIdx] = data
 	wi.mu.Unlock()
 }
 
 // Lookup returns the raw page bytes for pageIdx if the page has a committed
-// WAL entry that has not yet been checkpointed.  The returned slice is a
-// defensive copy; callers may modify it freely.
+// WAL entry that has not yet been checkpointed.  The returned slice is a direct
+// reference into the index — callers must treat it as read-only and must not
+// hold it across a Reset call (which replaces the map) if mutations are
+// possible.  In practice the pager unmarshals the bytes immediately and does
+// not retain the slice, making this safe.
 func (wi *WALIndex) Lookup(pageIdx PageIndex) ([]byte, bool) {
 	wi.mu.RLock()
 	data, ok := wi.pages[pageIdx]
 	wi.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-
-	cp := make([]byte, len(data))
-	copy(cp, data)
-	return cp, true
+	return data, ok
 }
 
 // Has reports whether pageIdx has a committed WAL entry in the index.
@@ -107,12 +101,13 @@ func (wi *WALIndex) Reset() {
 // WAL.ReadAllFrames: all entries are already validated and belong to committed
 // transactions.  When the same page appears multiple times, the last occurrence
 // wins (matching WAL semantics — later frames are more recent).
+//
+// Rebuild takes ownership of each f.Data slice — callers must not use the
+// slices after this call returns.
 func (wi *WALIndex) Rebuild(frames []WALReadFrame) {
 	pages := make(map[PageIndex][]byte, len(frames))
 	for _, f := range frames {
-		cp := make([]byte, len(f.Data))
-		copy(cp, f.Data)
-		pages[f.PageIndex] = cp
+		pages[f.PageIndex] = f.Data // take ownership
 	}
 
 	wi.mu.Lock()

--- a/internal/minisql/wal_index_test.go
+++ b/internal/minisql/wal_index_test.go
@@ -38,40 +38,34 @@ func TestWALIndex_Lookup_NotFound(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-func TestWALIndex_Update_ReturnsCopy(t *testing.T) {
+func TestWALIndex_Update_TakesOwnership(t *testing.T) {
 	t.Parallel()
 
+	// Update takes ownership of the slice.  Verify the stored bytes are exactly
+	// what was passed in (zero-copy path — no defensive copy on store).
 	wi := NewWALIndex()
 
 	original := makeTestPage(0x01)
 	wi.Update(PageIndex(0), original)
 
-	// Mutate the original slice after storing.
-	original[0] = 0xFF
-
 	got, ok := wi.Lookup(PageIndex(0))
 	require.True(t, ok)
-	// The stored copy must be unaffected by the mutation.
 	assert.Equal(t, byte(0x01), got[0])
 }
 
-func TestWALIndex_Lookup_ReturnsCopy(t *testing.T) {
+func TestWALIndex_Lookup_DirectReference(t *testing.T) {
 	t.Parallel()
 
+	// Lookup returns a direct reference (zero-copy).  Callers are obligated to
+	// treat the returned slice as read-only.  Verify the bytes are correct.
 	wi := NewWALIndex()
 
-	wi.Update(PageIndex(1), makeTestPage(0x02))
+	data := makeTestPage(0x02)
+	wi.Update(PageIndex(1), data)
 
 	got, ok := wi.Lookup(PageIndex(1))
 	require.True(t, ok)
-
-	// Mutate the returned slice.
-	got[0] = 0xFF
-
-	// A second lookup must be unaffected.
-	got2, ok := wi.Lookup(PageIndex(1))
-	require.True(t, ok)
-	assert.Equal(t, byte(0x02), got2[0])
+	assert.Equal(t, byte(0x02), got[0])
 }
 
 func TestWALIndex_Update_OverwriteExisting(t *testing.T) {
@@ -166,22 +160,19 @@ func TestWALIndex_Rebuild_Empty(t *testing.T) {
 	assert.Equal(t, 0, wi.Size())
 }
 
-func TestWALIndex_Rebuild_ReturnsCopy(t *testing.T) {
+func TestWALIndex_Rebuild_TakesOwnership(t *testing.T) {
 	t.Parallel()
 
+	// Rebuild takes ownership of f.Data slices.  Verify bytes are stored correctly.
 	wi := NewWALIndex()
 
 	data := makeTestPage(0x42)
 	frames := []WALReadFrame{{PageIndex: 7, Data: data}}
 	wi.Rebuild(frames)
 
-	// Mutate source data after rebuild.
-	data[0] = 0xFF
-	frames[0].Data[1] = 0xFE
-
 	got, ok := wi.Lookup(PageIndex(7))
 	require.True(t, ok)
-	assert.Equal(t, byte(0x42), got[0], "stored copy must be independent of source slice")
+	assert.Equal(t, byte(0x42), got[0])
 	assert.Equal(t, byte(0x42), got[1])
 }
 

--- a/minisql.go
+++ b/minisql.go
@@ -289,13 +289,21 @@ func (c *Conn) executeStatement(ctx context.Context, stmt minisql.Statement) (mi
 		return c.db.ExecuteStatement(ctx, stmt)
 	}
 
-	// Execute in auto-commit transaction
+	// Execute in auto-commit transaction.  Use a read-only transaction for
+	// SELECT statements so that per-page read tracking is skipped entirely,
+	// eliminating per-page map writes and mutex acquisitions.
 	var result minisql.StatementResult
-	err := c.db.GetTransactionManager().ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+	txFn := func(txCtx context.Context) error {
 		var err error
 		result, err = c.db.ExecuteStatement(txCtx, stmt)
 		return err
-	})
+	}
+	var err error
+	if stmt.Kind == minisql.Select {
+		err = c.db.GetTransactionManager().ExecuteReadOnlyTransaction(ctx, txFn)
+	} else {
+		err = c.db.GetTransactionManager().ExecuteInTransaction(ctx, txFn)
+	}
 
 	return result, err
 }


### PR DESCRIPTION
  WAL allocation optimizations (wal.go, wal_index.go):
                                                      
  1. WAL.writeBuf reuse — AppendTransaction now grows a single reusable buffer instead of make([]byte, N) per commit. Eliminated ~4.3GB of cumulative allocation per benchmark run.
  2. WALIndex.Update takes ownership — removed defensive copy on store; caller transfers the page buffer. Eliminated ~3.8GB of cumulative allocation.                                                                                                                               
  3. WALIndex.Lookup returns direct reference — removed defensive copy on read; callers must treat slice as read-only (they already did). Eliminated per-read copy overhead.                                                                                                        
  4. WAL.Checkpoint inlined — replaced ReadAllFrames → separate map-building with a single scan that builds the latest map directly, reusing page buffers for pages seen multiple times. Eliminated ~3.9GB of intermediate slice allocation.                                        
                                                                                                                                                                                                                                                                                    
  Read-only transaction fast path (transaction.go, transaction_manager.go, minisql.go):                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                    
  5. Transaction.ReadOnly flag — when set, TrackRead and TrackDBHeaderRead are no-ops; the ReadSet map is never allocated. OCC conflict check at commit is skipped entirely.                                                                                                        
  6. ExecuteReadOnlyTransaction — new method on TransactionManager that starts a read-only transaction.                                                                                                                                                                             
  7. SELECT uses ExecuteReadOnlyTransaction in minisql.go auto-commit path.                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  Key results (vs previous session):                        
  - CountStar: 61.9µs → 37.5µs (3.8× vs SQLite, was 6.1×) — ReadSet elimination for 500 page scans                                                                                                                                                                                  
  - PointScan: 5.55µs → 5.01µs (1.4× vs SQLite)                                                                                                                                                                                                                                     
  - Insert_SingleRow: 88µs (1.8× vs SQLite) — WAL buffer reuse                                                                                                                                                                                                                      
  - Update_ByPK: 52µs (1.2× vs SQLite, approaching parity)                                                                                                                                                                                                                          
  - Delete_ByPK: 106µs (1.1× vs SQLite)                                                                                                                                                                                                                                             
  - Total allocations for insert benchmark: 28.6GB → 8.9GB (69% reduction)