### PR TITLE
refactor: stop using sugarred logger to reduce allocations

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,46 @@
+### 2026-04-21 09:30 UTC
+
+Replace `Sugar().With(...).Debug(...)` with zero-allocation typed zap fields in all hot-path logging:
+- `insert.go`: `Sugar().With(...).Debug("inserting row")` → `logger.Debug("inserting row", zap.Int(...))`
+- `cursor.go`: `LeafNodeSplitInsert` split log
+- `table.go`: `createNewRoot` and `internalNodeSplitInsert` logs
+- `table_primary_key.go`: primary key insert/autoincrement logs (3 call sites)
+- `table_secondary_index.go`, `table_unique_index.go`: index insert logs
+- `delete.go`, `update.go`, `select.go`: query-plan and row-count logs
+- zap's `Sugar().With()` allocates a field buffer + clones the logger even when the debug level is disabled; the typed API (`zap.Int`, `zap.String`, `zap.Any`) stack-allocates `zap.Field` structs and short-circuits immediately on disabled levels
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 165.68 µs/op | 60.69 µs/op | 2.7× |
+| Insert_SingleRow | 101.25 µs/op | 48.99 µs/op | 2.1× |
+| Insert_Batch | 722.73 µs/op | 281.12 µs/op | 2.6× |
+| Select_PointScan | 5.70 µs/op | 4.32 µs/op | **1.32×** |
+| Select_FullScan | 9.83 ms/op | 6.23 ms/op | **1.58×** |
+| Select_CountStar | 37.47 µs/op | 10.91 µs/op | 3.4× |
+| Select_IndexRangeScan | 1006 µs/op | 908 µs/op | **1.11×** |
+| Select_RangeScan (no index) | 3.98 ms/op | 1.00 ms/op | 3.97× |
+| Txn_NInserts | 375.35 µs/op | 154.69 µs/op | 2.4× |
+| Update_ByPK | 59.04 µs/op | 44.99 µs/op | **1.31×** |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 84.4 KiB | 447 B |
+| Insert_SingleRow | 61.8 KiB | 312 B |
+| Insert_Batch | 438 KiB | 31.1 KiB |
+| Select_PointScan | 4.3 KiB | 679 B |
+| Select_FullScan | 9.6 MiB | 1.3 MiB |
+| Select_CountStar | 5.8 KiB | 400 B |
+| Select_IndexRangeScan | 835 KiB | 85.9 KiB |
+| Select_RangeScan (no index) | 2.1 MiB | 85.9 KiB |
+| Txn_NInserts | 253 KiB | 15.9 KiB |
+| Update_ByPK | 12.7 KiB | 263 B |
+
+---
+
 ### 2026-04-20 10:00 UTC
 
 Remove `Row.columnCache` entirely — replace with O(n) linear scan in `GetColumn`/`GetValue`/`SetValue`:

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -3,6 +3,8 @@ package minisql
 import (
 	"context"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // Cursor is a position within a table's B+ tree used to traverse or modify rows.
@@ -67,11 +69,11 @@ func (c *Cursor) LeafNodeSplitInsert(ctx context.Context, key RowID, row Row) er
 		return fmt.Errorf("get new page: %w", err)
 	}
 
-	c.Table.logger.Sugar().With(
-		"key", int(key),
-		"old_max_key", int(originalMaxKey),
-		"new_page_index", int(newPage.Index),
-	).Debug("leaf node split insert")
+	c.Table.logger.Debug("leaf node split insert",
+		zap.Int("key", int(key)),
+		zap.Int("old_max_key", int(originalMaxKey)),
+		zap.Int("new_page_index", int(newPage.Index)),
+	)
 
 	newPage.LeafNode = NewLeafNode()
 	newPage.LeafNode.Header.Parent = splitPage.LeafNode.Header.Parent

--- a/internal/minisql/delete.go
+++ b/internal/minisql/delete.go
@@ -3,6 +3,8 @@ package minisql
 import (
 	"context"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // Delete ...
@@ -20,7 +22,7 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	t.logger.Sugar().With("query type", "DELETE", "plan", plan).Debug("query plan")
+	t.logger.Debug("query plan", zap.String("query type", "DELETE"), zap.Any("plan", plan))
 
 	// Always select all columns so the full row is available for index cleanup on delete.
 	selectedFields := fieldsFromColumns(t.Columns...)
@@ -65,6 +67,6 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 		result.RowsAffected += 1
 	}
 
-	t.logger.Sugar().Debugf("deleted %d rows", result.RowsAffected)
+	t.logger.Debug("deleted rows", zap.Int("count", result.RowsAffected))
 	return result, nil
 }

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // Insert ...
@@ -111,11 +113,11 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 			return StatementResult{}, errors.New("trying to insert into non leaf node")
 		}
 
-		t.logger.Sugar().With(
-			"page_index", int(cursor.PageIdx),
-			"cell_index", int(cursor.CellIdx),
-			"row_id", int(nextRowID),
-		).Debug("inserting row")
+		t.logger.Debug("inserting row",
+			zap.Int("page_index", int(cursor.PageIdx)),
+			zap.Int("cell_index", int(cursor.CellIdx)),
+			zap.Int("row_id", int(nextRowID)),
+		)
 
 		if cursor.CellIdx < page.LeafNode.Header.Cells {
 			if page.LeafNode.Cells[cursor.CellIdx].Key == nextRowID {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -33,9 +33,7 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	if t.logger.Core().Enabled(zap.DebugLevel) {
-		t.logger.Sugar().With("query type", "SELECT", "plan", plan).Debug("query plan")
-	}
+	t.logger.Debug("query plan", zap.String("query type", "SELECT"), zap.Any("plan", plan))
 
 	// Only fetch fields included in the SELECT query or fields needed for WHERE conditions
 	// TODO - handle * plus other fields, for example SELECT *, a, b FROM table WHERE c = 1

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -379,10 +379,10 @@ func (t *Table) createNewRoot(ctx context.Context, rightChildPageIdx PageIndex) 
 		return nil, fmt.Errorf("get left child page: %w", err)
 	}
 
-	t.logger.Sugar().With(
-		"left_child_index", int(leftChildPage.Index),
-		"right_child_index", int(rightChildPageIdx),
-	).Debug("create new root")
+	t.logger.Debug("create new root",
+		zap.Int("left_child_index", int(leftChildPage.Index)),
+		zap.Int("right_child_index", int(rightChildPageIdx)),
+	)
 
 	// Copy all node contents to left child
 	if oldRootPage.LeafNode != nil {
@@ -545,10 +545,10 @@ func (t *Table) InternalNodeSplitInsert(ctx context.Context, pageIdx, childPageI
 	newPage.InternalNode = NewInternalNode()
 	newPage.LeafNode = nil
 
-	t.logger.Sugar().With(
-		"page_index", int(pageIdx),
-		"new_page_index", int(newPage.Index),
-	).Debug("internal node split insert")
+	t.logger.Debug("internal node split insert",
+		zap.Int("page_index", int(pageIdx)),
+		zap.Int("new_page_index", int(newPage.Index)),
+	)
 
 	if splittingRoot {
 		/*

--- a/internal/minisql/table_primary_key.go
+++ b/internal/minisql/table_primary_key.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 // IndexInfo ...
@@ -74,10 +76,10 @@ func (t *Table) insertPrimaryKey(ctx context.Context, keyParts []OptionalValue, 
 		return 0, fmt.Errorf("failed to cast primary key value for %s: %w", t.PrimaryKey.Name, err)
 	}
 
-	t.logger.Sugar().With(
-		"index", t.PrimaryKey.Name,
-		"key", castedKey,
-	).Debug("inserting primary key")
+	t.logger.Debug("inserting primary key",
+		zap.String("index", t.PrimaryKey.Name),
+		zap.Any("key", castedKey),
+	)
 
 	if err := t.PrimaryKey.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
@@ -101,10 +103,10 @@ func (t *Table) insertAutoincrementedPrimaryKey(ctx context.Context, rowID RowID
 	}
 	newPrimaryKey := lastPrimaryKey + 1
 
-	t.logger.Sugar().With(
-		"index", t.PrimaryKey.Name,
-		"key", int(newPrimaryKey),
-	).Debug("inserting autoincremented primary key")
+	t.logger.Debug("inserting autoincremented primary key",
+		zap.String("index", t.PrimaryKey.Name),
+		zap.Int("key", int(newPrimaryKey)),
+	)
 
 	if err := t.PrimaryKey.Index.Insert(ctx, newPrimaryKey, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
@@ -132,9 +134,9 @@ func (t *Table) insertCompositePrimaryKey(ctx context.Context, keyParts []Option
 
 	ck := NewCompositeKey(t.PrimaryKey.Columns, keyValues...)
 
-	t.logger.Sugar().With(
-		"index", t.PrimaryKey.Name,
-	).Debug("inserting composite primary key")
+	t.logger.Debug("inserting composite primary key",
+		zap.String("index", t.PrimaryKey.Name),
+	)
 
 	if err := t.PrimaryKey.Index.Insert(ctx, ck, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -3,6 +3,8 @@ package minisql
 import (
 	"context"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // SecondaryIndex ...
@@ -34,7 +36,10 @@ func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 			keyValues = append(keyValues, castedKey)
 		}
 		ck := NewCompositeKey(secondaryIndex.Columns, keyValues...)
-		t.logger.Sugar().With("index", secondaryIndex.Name, "key", ck).Debug("inserting secondary index key")
+		t.logger.Debug("inserting secondary index key",
+			zap.String("index", secondaryIndex.Name),
+			zap.Any("key", ck),
+		)
 		if err := secondaryIndex.Index.Insert(ctx, ck, rowID); err != nil {
 			return fmt.Errorf("failed to insert key for secondary index %s: %w", secondaryIndex.Name, err)
 		}
@@ -53,10 +58,10 @@ func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 		return fmt.Errorf("failed to cast key value for secondary index  %s: %w", secondaryIndex.Name, err)
 	}
 
-	t.logger.Sugar().With(
-		"index", secondaryIndex.Name,
-		"key", castedKey,
-	).Debug("inserting secondary index key")
+	t.logger.Debug("inserting secondary index key",
+		zap.String("index", secondaryIndex.Name),
+		zap.Any("key", castedKey),
+	)
 
 	if err := secondaryIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for secondary index %s: %w", secondaryIndex.Name, err)

--- a/internal/minisql/table_unique_index.go
+++ b/internal/minisql/table_unique_index.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 // UniqueIndex ...
@@ -50,10 +52,10 @@ func (t *Table) insertUniqueIndexKey(ctx context.Context, uniqueIndex UniqueInde
 		return fmt.Errorf("failed to cast key value for unique index  %s: %w", uniqueIndex.Name, err)
 	}
 
-	t.logger.Sugar().With(
-		"index", uniqueIndex.Name,
-		"key", castedKey,
-	).Debug("inserting unique index key")
+	t.logger.Debug("inserting unique index key",
+		zap.String("index", uniqueIndex.Name),
+		zap.Any("key", castedKey),
+	)
 
 	if err := uniqueIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
@@ -87,10 +89,10 @@ func (t *Table) insertUniqueCompositeIndexKey(ctx context.Context, uniqueIndex U
 
 	ck := NewCompositeKey(uniqueIndex.Columns[0:len(keyValues)], keyValues...)
 
-	t.logger.Sugar().With(
-		"index", uniqueIndex.Name,
-		"key", ck,
-	).Debug("inserting unique index key")
+	t.logger.Debug("inserting unique index key",
+		zap.String("index", uniqueIndex.Name),
+		zap.Any("key", ck),
+	)
 
 	if err := uniqueIndex.Index.Insert(ctx, ck, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -3,6 +3,8 @@ package minisql
 import (
 	"context"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // Update executes an UPDATE statement on the table and returns the result.
@@ -20,7 +22,7 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	t.logger.Sugar().With("query type", "UPDATE", "plan", plan).Debug("query plan")
+	t.logger.Debug("query plan", zap.String("query type", "UPDATE"), zap.Any("plan", plan))
 
 	selectedFields := fieldsFromColumns(t.Columns...)
 
@@ -114,6 +116,6 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
-	t.logger.Sugar().Debugf("updated %d rows", result.RowsAffected)
+	t.logger.Debug("updated rows", zap.Int("count", result.RowsAffected))
 	return result, nil
 }


### PR DESCRIPTION
Sugar().With(...).Debug(...) in zap allocates a field buffer and clones the logger on every call, even when the debug level is disabled. This was 46% of all allocations in the insert hot path.