### PR TITLE
refactor: use buffer pool when doing WAL commit

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,44 @@
+### 2026-04-21 11:00 UTC
+
+Phase 3 — WAL page buffer pooling via `sync.Pool`:
+- `pageDataPool sync.Pool` at package level in `transaction_manager.go` pools `[]byte` slices of `PageSize` (4 KB)
+- `serializeWritesForWAL`: replaces `make([]byte, PageSize)` per dirty page with `pageDataPool.Get()`
+- `serializePage0ForWAL`: uses pool for temporary `pageBuf` (copied into the combined frame, then returned)
+- `WALIndex.Update` now returns old `[]byte` (if any); `commitWithWAL` recycles displaced buffers back to pool
+- Net effect: reduces GC-visible heap allocations for dirty-page serialization on every commit
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 214.83 µs/op | 174.67 µs/op | 1.2× |
+| Insert_SingleRow | 106.35 µs/op | 47.81 µs/op | 2.2× |
+| Insert_Batch | 612.52 µs/op | 221.60 µs/op | 2.8× |
+| Select_PointScan | 4.43 µs/op | 3.32 µs/op | **1.33×** |
+| Select_FullScan | 6.56 ms/op | 5.09 ms/op | **1.29×** |
+| Select_CountStar | 32.64 µs/op | 9.57 µs/op | 3.4× |
+| Select_IndexRangeScan | 751 µs/op | 756 µs/op | **0.99×** ✓ parity with SQLite |
+| Select_RangeScan (no index) | 3.07 ms/op | 867 µs/op | 3.5× |
+| Txn_NInserts | 356.71 µs/op | 138.21 µs/op | 2.6× |
+| Update_ByPK | 57.47 µs/op | 38.87 µs/op | **1.48×** |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 80.9 KiB | 437 B |
+| Insert_SingleRow | 42.6 KiB | 304 B |
+| Insert_Batch | 406 KiB | 31.0 KiB |
+| Select_PointScan | 4.3 KiB | 664 B |
+| Select_FullScan | 9.6 MiB | 1.3 MiB |
+| Select_CountStar | 5.8 KiB | 391 B |
+| Select_IndexRangeScan | 836 KiB | 85.9 KiB |
+| Select_RangeScan (no index) | 2.1 MiB | 85.9 KiB |
+| Txn_NInserts | 228 KiB | 15.8 KiB |
+| Update_ByPK | 8.9 KiB | 257 B |
+
+---
+
 ### 2026-04-21 09:30 UTC
 
 Replace `Sugar().With(...).Debug(...)` with zero-allocation typed zap fields in all hot-path logging:

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -10,6 +10,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// pageDataPool is a package-level pool for PageSize-byte slices used during WAL
+// serialization. A single pool is shared across all TransactionManagers (there
+// is normally only one per database). Buffers returned to the pool via
+// WALIndex.Update are safe to reuse: walWriteMu serialises all writers, so by
+// the time a buffer is recycled the pager has finished unmarshalling it.
+var pageDataPool = sync.Pool{
+	New: func() any { return make([]byte, PageSize) },
+}
+
 // TransactionManager coordinates optimistic concurrency control for the database.
 type TransactionManager struct {
 	mu                    sync.RWMutex
@@ -388,8 +397,11 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 	tm.walWriteMu.Unlock()
 
 	// Step 6: Update WAL index so subsequent reads see the latest committed data.
+	// Recycle old page buffers that are displaced by newer commits.
 	for _, wp := range walPages {
-		tm.walIndex.Update(wp.Index, wp.Data)
+		if old := tm.walIndex.Update(wp.Index, wp.Data); old != nil {
+			pageDataPool.Put(old)
+		}
 	}
 
 	tm.logger.Debug("commit transaction (WAL)", zap.Uint64("tx_id", uint64(tx.ID)))
@@ -428,8 +440,9 @@ func (tm *TransactionManager) serializeWritesForWAL(ctx context.Context, tx *Tra
 		if pageIdx == 0 {
 			continue // already included above
 		}
-		buf := make([]byte, PageSize)
+		buf := pageDataPool.Get().([]byte)
 		if err := marshalPage(info.Page, buf); err != nil {
+			pageDataPool.Put(buf)
 			return nil, fmt.Errorf("marshal page %d for WAL: %w", pageIdx, err)
 		}
 		pages = append(pages, WALPage{Index: pageIdx, Data: buf})
@@ -480,11 +493,13 @@ func (tm *TransactionManager) serializePage0ForWAL(ctx context.Context, page0 *P
 			return nil, fmt.Errorf("read page 0 B-tree for WAL: %w", err)
 		}
 	}
-	pageBuf := make([]byte, PageSize)
+	pageBuf := pageDataPool.Get().([]byte)
 	if err := marshalPage(btreePage, pageBuf); err != nil {
+		pageDataPool.Put(pageBuf)
 		return nil, fmt.Errorf("marshal page 0 B-tree for WAL: %w", err)
 	}
 	copy(frame[RootPageConfigSize:], pageBuf[0:PageSize-RootPageConfigSize])
+	pageDataPool.Put(pageBuf)
 
 	return frame, nil
 }

--- a/internal/minisql/wal_index.go
+++ b/internal/minisql/wal_index.go
@@ -32,14 +32,17 @@ func NewWALIndex() *WALIndex {
 	}
 }
 
-// Update records the latest raw page bytes for pageIdx.
+// Update records the latest raw page bytes for pageIdx and returns the
+// previous buffer (if any) so the caller can recycle it.
 // Update takes ownership of data — the caller must not read or write the slice
 // after this call.  If a prior entry exists for pageIdx it is overwritten
 // (later write wins).
-func (wi *WALIndex) Update(pageIdx PageIndex, data []byte) {
+func (wi *WALIndex) Update(pageIdx PageIndex, data []byte) []byte {
 	wi.mu.Lock()
+	old := wi.pages[pageIdx]
 	wi.pages[pageIdx] = data
 	wi.mu.Unlock()
+	return old
 }
 
 // Lookup returns the raw page bytes for pageIdx if the page has a committed


### PR DESCRIPTION
Phase 3 — WAL page buffer pooling via `sync.Pool`:
- `pageDataPool sync.Pool` at package level in `transaction_manager.go` pools `[]byte` slices of `PageSize` (4 KB)
- `serializeWritesForWAL`: replaces `make([]byte, PageSize)` per dirty page with `pageDataPool.Get()`
- `serializePage0ForWAL`: uses pool for temporary `pageBuf` (copied into the combined frame, then returned)
- `WALIndex.Update` now returns old `[]byte` (if any); `commitWithWAL` recycles displaced buffers back to pool
- Net effect: reduces GC-visible heap allocations for dirty-page serialization on every commit