### PR TITLE
refactor: inline row ID for unique index to avoid allocating []RowID

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ Setting the `LOG_LEVEL` to `info` makes sure to supress debug logs and makes pot
 
 ### Benchmarking & Profiling
 
-See the [benchmarks/README.md](https://github.com/RichardKnop/minisql/blob/main/benchmarks/RESULTS.md).
+See the [benchmarks/README.md](https://github.com/RichardKnop/minisql/blob/main/benchmarks/README.md) and [benchmarks/RESULTS.md](https://github.com/RichardKnop/minisql/blob/main/benchmarks/RESULTS.md).
 
 ## Acknowledgements 
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,54 @@
+### 2026-04-21 22:32 UTC
+
+`IndexCell.UniqueRowID` inline storage — eliminate heap-allocated `[]RowID` slice for unique index cells:
+- Added `UniqueRowID RowID` field to `IndexCell`; for unique indexes (primary key, unique indexes) the single RowID is stored inline in the struct rather than in a `[]RowID` slice.
+- `NewIndexCell`: skips `make([]RowID, 0, 1)` for unique cells.
+- `Clone()`: for unique cells, copies the scalar `UniqueRowID` — no `make([]RowID, N)` per cell.
+- `Marshal`/`Unmarshal`: reads/writes `UniqueRowID` directly.
+- All B+ tree mutation sites updated: `insertNotFull`, `splitChild`, `removeFromInternal`, `borrowFromLeft`, `borrowFromRight`, `merge`, `scanAscending/Descending/Range*`.
+- Primary win: each `ModifyPage` on an index page with K unique-index cells previously did K×`make([]RowID,1)` in `IndexNode.Clone`. For a 10K-row table the root had ~85 cells → 85 allocs saved per cloned page.
+
+#### Alloc improvement (stable across 5 runs)
+
+| Benchmark | Before | After | Δ |
+|---|---|---|---|
+| Insert_SingleRow | 262 allocs/op | **59 allocs/op** | **−77%** |
+| Insert_Batch (100 rows) | ~4170 allocs/op | ~3369 allocs/op | −19% |
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 185.19 µs/op | 71.99 µs/op | 2.6× |
+| Insert_SingleRow | 86.10 µs/op | 41.79 µs/op | 2.1× |
+| Insert_Batch | 588.82 µs/op | 225.33 µs/op | 2.6× |
+| Select_PointScan | 4.28 µs/op | 3.25 µs/op | 1.3× |
+| Select_Limit | 8.45 µs/op | 7.66 µs/op | 1.1× |
+| Select_FullScan | 6.36 ms/op | 4.93 ms/op | 1.3× |
+| Select_CountStar | 31.76 µs/op | 9.41 µs/op | 3.4× |
+| Select_IndexRangeScan | 708.43 µs/op | 723.12 µs/op | 1.0× |
+| Select_RangeScan | 3.00 ms/op | 855.50 µs/op | 3.5× |
+| Txn_NInserts | 322.63 µs/op | 134.91 µs/op | 2.4× |
+| Update_ByPK | 58.35 µs/op | 67.15 µs/op | 0.9× |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 82.4 KiB | 447 B |
+| Insert_SingleRow | 46.5 KiB | 311 B |
+| Insert_Batch | 366.2 KiB | 31.0 KiB |
+| Select_PointScan | 4.3 KiB | 679 B |
+| Select_Limit | 9.8 KiB | 1.7 KiB |
+| Select_FullScan | 9.6 MiB | 1.3 MiB |
+| Select_CountStar | 5.8 KiB | 400 B |
+| Select_IndexRangeScan | 835.9 KiB | 85.9 KiB |
+| Select_RangeScan | 2.1 MiB | 85.9 KiB |
+| Txn_NInserts | 209.3 KiB | 15.8 KiB |
+| Update_ByPK | 9.0 KiB | 263 B |
+
+---
+
 ### 2026-04-21 18:43 UTC
 
 #### Timing
@@ -31,5 +82,3 @@
 | Select_RangeScan | 2.1 MiB | 85.9 KiB |
 | Txn_NInserts | 205.5 KiB | 15.8 KiB |
 | Update_ByPK | 9.0 KiB | 263 B |
-
-

--- a/internal/minisql/covering_index_test.go
+++ b/internal/minisql/covering_index_test.go
@@ -19,8 +19,10 @@ var coveringIndexTestColumns = []Column{
 func TestCoveringIndexEligible(t *testing.T) {
 	t.Parallel()
 
-	emailCol := coveringIndexTestColumns[1:2] // [email]
-	idCol := coveringIndexTestColumns[0:1]    // [id]
+	var (
+		emailCol = coveringIndexTestColumns[1:2] // [email]
+		idCol    = coveringIndexTestColumns[0:1] // [id]
+	)
 
 	tests := []struct {
 		name         string
@@ -155,8 +157,10 @@ func TestCoveringIndexEligible(t *testing.T) {
 func TestRowFromIndexKey(t *testing.T) {
 	t.Parallel()
 
-	idCol := Column{Kind: Int8, Size: 8, Name: "id"}
-	emailCol := Column{Kind: Varchar, Size: MaxInlineVarchar, Name: "email", Nullable: true}
+	var (
+		idCol    = Column{Kind: Int8, Size: 8, Name: "id"}
+		emailCol = Column{Kind: Varchar, Size: MaxInlineVarchar, Name: "email", Nullable: true}
+	)
 
 	t.Run("single-column index key", func(t *testing.T) {
 		t.Parallel()
@@ -192,13 +196,14 @@ func TestRowFromIndexKey(t *testing.T) {
 func TestMarkCoveringIndexes(t *testing.T) {
 	t.Parallel()
 
-	indexName := "key__test_table__email"
-	emailCol := coveringIndexTestColumns[1:2]
-
-	table := NewTable(zap.NewNop(), nil, nil, testTableName, coveringIndexTestColumns, 0, nil,
-		WithUniqueIndex(UniqueIndex{
-			IndexInfo: IndexInfo{Name: indexName, Columns: emailCol},
-		}),
+	var (
+		indexName = "key__test_table__email"
+		emailCol  = coveringIndexTestColumns[1:2]
+		table     = NewTable(zap.NewNop(), nil, nil, testTableName, coveringIndexTestColumns, 0, nil,
+			WithUniqueIndex(UniqueIndex{
+				IndexInfo: IndexInfo{Name: indexName, Columns: emailCol},
+			}),
+		)
 	)
 
 	t.Run("SELECT indexed column sets CoveringIndex", func(t *testing.T) {

--- a/internal/minisql/index.go
+++ b/internal/minisql/index.go
@@ -81,8 +81,12 @@ func (ui *Index[T]) Insert(ctx context.Context, keyAny any, rowID RowID) error {
 	if rootNode.Header.Keys == 0 {
 		rootNode.Cells = append(rootNode.Cells, NewIndexCell[T](ui.unique))
 		rootNode.Cells[0].Key = key
-		rootNode.Cells[0].InlineRowIDs = 1
-		rootNode.Cells[0].RowIDs = append(rootNode.Cells[0].RowIDs, rowID)
+		if ui.unique {
+			rootNode.Cells[0].UniqueRowID = rowID
+		} else {
+			rootNode.Cells[0].InlineRowIDs = 1
+			rootNode.Cells[0].RowIDs = append(rootNode.Cells[0].RowIDs, rowID)
+		}
 		rootNode.Header.IsRoot = true
 		rootNode.Header.IsLeaf = true
 		rootNode.Header.Keys += 1
@@ -197,12 +201,17 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 			node.Cells[i+1].Key = node.Cells[i].Key
 			node.Cells[i+1].InlineRowIDs = node.Cells[i].InlineRowIDs
 			node.Cells[i+1].RowIDs = node.Cells[i].RowIDs
+			node.Cells[i+1].UniqueRowID = node.Cells[i].UniqueRowID
 			node.Cells[i+1].Overflow = node.Cells[i].Overflow
 			i -= 1
 		}
 		node.Cells[i+1].Key = key
-		node.Cells[i+1].InlineRowIDs = 1
-		node.Cells[i+1].RowIDs = []RowID{rowID}
+		if ui.unique {
+			node.Cells[i+1].UniqueRowID = rowID
+		} else {
+			node.Cells[i+1].InlineRowIDs = 1
+			node.Cells[i+1].RowIDs = []RowID{rowID}
+		}
 		node.Header.Keys += 1
 		return nil
 	}
@@ -288,6 +297,7 @@ func (ui *Index[T]) splitChild(ctx context.Context, parentPage, splitPage *Page,
 		parentNode.Cells[j+1].Key = parentNode.Cells[j].Key
 		parentNode.Cells[j+1].InlineRowIDs = parentNode.Cells[j].InlineRowIDs
 		parentNode.Cells[j+1].RowIDs = parentNode.Cells[j].RowIDs
+		parentNode.Cells[j+1].UniqueRowID = parentNode.Cells[j].UniqueRowID
 		parentNode.Cells[j+1].Overflow = parentNode.Cells[j].Overflow
 	}
 	parentNode.Header.Keys += 1
@@ -297,6 +307,7 @@ func (ui *Index[T]) splitChild(ctx context.Context, parentPage, splitPage *Page,
 	parentNode.Cells[indexInParent].Key = cellToMoveToParent.Key
 	parentNode.Cells[indexInParent].InlineRowIDs = cellToMoveToParent.InlineRowIDs
 	parentNode.Cells[indexInParent].RowIDs = cellToMoveToParent.RowIDs
+	parentNode.Cells[indexInParent].UniqueRowID = cellToMoveToParent.UniqueRowID
 	parentNode.Cells[indexInParent].Overflow = cellToMoveToParent.Overflow
 	splitNode.Cells[leftCount] = NewIndexCell[T](ui.unique)
 
@@ -490,6 +501,7 @@ func (ui *Index[T]) removeFromInternal(ctx context.Context, page *Page, idx int,
 		node.Cells[idx].Key = predecessor.Key
 		node.Cells[idx].InlineRowIDs = predecessor.InlineRowIDs
 		node.Cells[idx].RowIDs = predecessor.RowIDs
+		node.Cells[idx].UniqueRowID = predecessor.UniqueRowID
 		node.Cells[idx].Overflow = predecessor.Overflow
 		if err := ui.remove(ctx, leftChildPage, predecessor.Key, rowID); err != nil {
 			return fmt.Errorf("remove predecessor key: %w", err)
@@ -503,6 +515,7 @@ func (ui *Index[T]) removeFromInternal(ctx context.Context, page *Page, idx int,
 		node.Cells[idx].Key = successor.Key
 		node.Cells[idx].InlineRowIDs = successor.InlineRowIDs
 		node.Cells[idx].RowIDs = successor.RowIDs
+		node.Cells[idx].UniqueRowID = successor.UniqueRowID
 		node.Cells[idx].Overflow = successor.Overflow
 		if err := ui.remove(ctx, rightChildPage, successor.Key, rowID); err != nil {
 			return fmt.Errorf("remove successor key: %w", err)
@@ -621,6 +634,7 @@ func (ui *Index[T]) borrowFromLeft(ctx context.Context, parent, page, left *Page
 		Key:          parentNode.Cells[idx-1].Key,
 		InlineRowIDs: parentNode.Cells[idx-1].InlineRowIDs,
 		RowIDs:       parentNode.Cells[idx-1].RowIDs,
+		UniqueRowID:  parentNode.Cells[idx-1].UniqueRowID,
 		Overflow:     parentNode.Cells[idx-1].Overflow,
 		Child:        leftNode.Header.RightChild,
 		unique:       ui.unique,
@@ -637,6 +651,7 @@ func (ui *Index[T]) borrowFromLeft(ctx context.Context, parent, page, left *Page
 	parentNode.Cells[idx-1].Key = leftNode.LastCell().Key
 	parentNode.Cells[idx-1].InlineRowIDs = leftNode.LastCell().InlineRowIDs
 	parentNode.Cells[idx-1].RowIDs = leftNode.LastCell().RowIDs
+	parentNode.Cells[idx-1].UniqueRowID = leftNode.LastCell().UniqueRowID
 	parentNode.Cells[idx-1].Overflow = leftNode.LastCell().Overflow
 
 	leftNode.RemoveLastCell()
@@ -656,6 +671,7 @@ func (ui *Index[T]) borrowFromRight(ctx context.Context, parent, page, right *Pa
 		Key:          parentNode.Cells[idx].Key,
 		InlineRowIDs: parentNode.Cells[idx].InlineRowIDs,
 		RowIDs:       parentNode.Cells[idx].RowIDs,
+		UniqueRowID:  parentNode.Cells[idx].UniqueRowID,
 		Overflow:     parentNode.Cells[idx].Overflow,
 		Child:        node.Header.RightChild,
 		unique:       ui.unique,
@@ -673,6 +689,7 @@ func (ui *Index[T]) borrowFromRight(ctx context.Context, parent, page, right *Pa
 	parentNode.Cells[idx].Key = rightNode.FirstCell().Key
 	parentNode.Cells[idx].InlineRowIDs = rightNode.FirstCell().InlineRowIDs
 	parentNode.Cells[idx].RowIDs = rightNode.FirstCell().RowIDs
+	parentNode.Cells[idx].UniqueRowID = rightNode.FirstCell().UniqueRowID
 	parentNode.Cells[idx].Overflow = rightNode.FirstCell().Overflow
 
 	rightNode.RemoveFirstCell()
@@ -717,6 +734,7 @@ func (ui *Index[T]) merge(ctx context.Context, parent, left, right *Page, idx ui
 		Key:          parentNode.Cells[idx].Key,
 		InlineRowIDs: parentNode.Cells[idx].InlineRowIDs,
 		RowIDs:       parentNode.Cells[idx].RowIDs,
+		UniqueRowID:  parentNode.Cells[idx].UniqueRowID,
 		Overflow:     parentNode.Cells[idx].Overflow,
 		unique:       ui.unique,
 	}

--- a/internal/minisql/index_cursor.go
+++ b/internal/minisql/index_cursor.go
@@ -46,6 +46,10 @@ func (ui *Index[T]) FindRowIDs(ctx context.Context, keyAny any) ([]RowID, error)
 		return nil, fmt.Errorf("invalid cell index: %d", cursor.CellIdx)
 	}
 
+	if node.Cells[cursor.CellIdx].unique {
+		return []RowID{node.Cells[cursor.CellIdx].UniqueRowID}, nil
+	}
+
 	if len(node.Cells[cursor.CellIdx].RowIDs) == 0 {
 		return nil, fmt.Errorf("no row IDs for key: %v", key)
 	}

--- a/internal/minisql/index_insert_nonunique_test.go
+++ b/internal/minisql/index_insert_nonunique_test.go
@@ -169,6 +169,10 @@ func collectAllKeysAndRowIDs[T IndexKey](ctx context.Context, t *testing.T, idx 
 		for cellIdx := uint32(0); cellIdx < node.Header.Keys; cellIdx++ {
 			cell := node.Cells[cellIdx]
 			actualKeys = append(actualKeys, cell.Key)
+			if cell.unique {
+				actualRowIDs = append(actualRowIDs, cell.UniqueRowID)
+				continue
+			}
 			actualRowIDs = append(actualRowIDs, cell.RowIDs...)
 			if cell.Overflow != 0 {
 				overflowRowIDs, err := readOverflowRowIDs[T](ctx, idx.pager, cell.Overflow)

--- a/internal/minisql/index_node.go
+++ b/internal/minisql/index_node.go
@@ -67,8 +67,9 @@ func (h *IndexNodeHeader) Unmarshal(buf []byte) (uint64, error) {
 // IndexCell holds a single key entry within an index node, along with its associated row IDs and child pointer.
 type IndexCell[T IndexKey] struct {
 	Key          T
-	InlineRowIDs uint32 // only for non-unique indexes
-	RowIDs       []RowID
+	UniqueRowID  RowID     // only for unique indexes, stored inline without heap allocation
+	InlineRowIDs uint32    // only for non-unique indexes
+	RowIDs       []RowID   // only for non-unique indexes
 	Overflow     PageIndex // 0 if not used (only for non-unique indexes)
 	Child        PageIndex
 	unique       bool // true for non-unique index cells
@@ -76,15 +77,18 @@ type IndexCell[T IndexKey] struct {
 
 // NewIndexCell ...
 func NewIndexCell[T IndexKey](unique bool) IndexCell[T] {
-	return IndexCell[T]{
-		unique: unique,
-		RowIDs: make([]RowID, 0, 1),
+	c := IndexCell[T]{unique: unique}
+	if !unique {
+		// Pre-allocate RowIDs slice only for non-unique cells.
+		// Unique cells use inlineRowID instead (no heap allocation needed).
+		c.RowIDs = make([]RowID, 0, 1)
 	}
+	return c
 }
 
 // Size ...
 func (c *IndexCell[T]) Size() uint64 {
-	// Key size  + child pointer size
+	// Key size + child pointer size
 	size := keySize(c.Key) + 4
 	if c.unique {
 		// Single row ID
@@ -150,8 +154,8 @@ func (c *IndexCell[T]) Marshal(buf []byte) error {
 	}
 
 	if c.unique {
-		// Single row ID
-		marshalUint64(buf, uint64(c.RowIDs[0]), i)
+		// Single row ID stored inline — no slice allocation.
+		marshalUint64(buf, uint64(c.UniqueRowID), i)
 		i += 8
 	} else {
 		// Row IDs length prefix
@@ -215,7 +219,8 @@ func (c *IndexCell[T]) Unmarshal(columns []Column, buf []byte) (uint64, error) {
 	}
 
 	if c.unique {
-		c.RowIDs = []RowID{RowID(unmarshalUint64(buf, i))}
+		// Store directly in UniqueRowID — no heap allocation.
+		c.UniqueRowID = RowID(unmarshalUint64(buf, i))
 		i += 8
 	} else {
 		c.InlineRowIDs = unmarshalUint32(buf, i)
@@ -403,7 +408,11 @@ func (n *IndexNode[T]) Keys() []T {
 func (n *IndexNode[T]) RowIDs() []RowID {
 	rowIDs := make([]RowID, 0, n.Header.Keys)
 	for i := range n.Header.Keys {
-		rowIDs = append(rowIDs, n.Cells[i].RowIDs...)
+		if n.Cells[i].unique {
+			rowIDs = append(rowIDs, n.Cells[i].UniqueRowID)
+		} else {
+			rowIDs = append(rowIDs, n.Cells[i].RowIDs...)
+		}
 	}
 	return rowIDs
 }
@@ -557,12 +566,14 @@ func (c *IndexCell[T]) Clone() IndexCell[T] {
 		Overflow:     c.Overflow,
 		Child:        c.Child,
 		unique:       c.unique,
+		UniqueRowID:  c.UniqueRowID, // zero for non-unique; populated for unique
 	}
-	if len(c.RowIDs) == 0 {
-		return nodeCopy
+	// For unique cells, RowIDs is nil — UniqueRowID already copied above.
+	// For non-unique cells, deep-copy the RowIDs slice.
+	if len(c.RowIDs) > 0 {
+		nodeCopy.RowIDs = make([]RowID, len(c.RowIDs))
+		copy(nodeCopy.RowIDs, c.RowIDs)
 	}
-	nodeCopy.RowIDs = make([]RowID, len(c.RowIDs))
-	copy(nodeCopy.RowIDs, c.RowIDs)
 	return nodeCopy
 }
 

--- a/internal/minisql/index_node_test.go
+++ b/internal/minisql/index_node_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIndexNode_Int8_Marshal(t *testing.T) {
+func TestIndexNode_Int8_Unique_Marshal(t *testing.T) {
 	t.Parallel()
 
 	node := NewIndexNode[int64](true)
@@ -23,10 +23,10 @@ func TestIndexNode_Int8_Marshal(t *testing.T) {
 	}
 
 	node.Cells[0].Key = int64(125)
-	node.Cells[0].RowIDs = []RowID{125}
+	node.Cells[0].UniqueRowID = 125
 	node.Cells[0].Child = 7
 	node.Cells[1].Key = int64(126)
-	node.Cells[1].RowIDs = []RowID{126}
+	node.Cells[1].UniqueRowID = 126
 	node.Cells[1].Child = 8
 
 	buf := make([]byte, node.Size())
@@ -44,7 +44,46 @@ func TestIndexNode_Int8_Marshal(t *testing.T) {
 	}
 }
 
-func TestIndexNode_Varchar_Marshal(t *testing.T) {
+func TestIndexNode_Int8_Marshal(t *testing.T) {
+	t.Parallel()
+
+	node := NewIndexNode[int64](false)
+
+	// Populate with values that don't necessarily make sense, we are
+	// just testing marshal/unmarshal of non zero values
+	node.Header = IndexNodeHeader{
+		IsRoot:     true,
+		IsLeaf:     true,
+		Parent:     3,
+		Keys:       2,
+		RightChild: 4,
+	}
+
+	node.Cells[0].Key = int64(125)
+	node.Cells[0].RowIDs = []RowID{125, 126}
+	node.Cells[0].InlineRowIDs = 2
+	node.Cells[0].Child = 7
+	node.Cells[1].Key = int64(127)
+	node.Cells[1].RowIDs = []RowID{127, 128, 129}
+	node.Cells[1].InlineRowIDs = 3
+	node.Cells[1].Child = 8
+
+	buf := make([]byte, node.Size())
+	err := node.Marshal(buf)
+	require.NoError(t, err)
+
+	recreatedNode := NewIndexNode[int64](false)
+	_, err = recreatedNode.Unmarshal(nil, buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, node, recreatedNode)
+
+	for idx := 0; idx < len(node.Cells); idx++ {
+		assert.Equal(t, node.Cells[idx], recreatedNode.Cells[idx])
+	}
+}
+
+func TestIndexNode_Varchar_Unique_Marshal(t *testing.T) {
 	t.Parallel()
 
 	node := NewIndexNode[string](true)
@@ -60,10 +99,10 @@ func TestIndexNode_Varchar_Marshal(t *testing.T) {
 	}
 
 	node.Cells[0].Key = "foo"
-	node.Cells[0].RowIDs = []RowID{125}
+	node.Cells[0].UniqueRowID = 125
 	node.Cells[0].Child = 7
 	node.Cells[1].Key = "bar qux"
-	node.Cells[1].RowIDs = []RowID{126}
+	node.Cells[1].UniqueRowID = 126
 	node.Cells[1].Child = 8
 
 	buf := make([]byte, node.Size())
@@ -83,5 +122,50 @@ func TestIndexNode_Varchar_Marshal(t *testing.T) {
 	expectedSize := int(15 + // header
 		(varcharLengthPrefixSize + 3) + 12 + // cell 1
 		(varcharLengthPrefixSize + 7) + 12) // cell 2
+	assert.Equal(t, expectedSize, int(recreatedNode.Size()))
+}
+
+func TestIndexNode_Varchar_Marshal(t *testing.T) {
+	t.Parallel()
+
+	node := NewIndexNode[string](false)
+
+	// Populate with values that don't necessarily make sense, we are
+	// just testing marshal/unmarshal of non zero values
+	node.Header = IndexNodeHeader{
+		IsRoot:     true,
+		IsLeaf:     true,
+		Parent:     3,
+		Keys:       2,
+		RightChild: 4,
+	}
+
+	node.Cells[0].Key = "foo"
+	node.Cells[0].RowIDs = []RowID{125}
+	node.Cells[0].InlineRowIDs = 1
+	node.Cells[0].Child = 7
+	node.Cells[1].Key = "bar qux"
+	node.Cells[1].RowIDs = []RowID{126, 127}
+	node.Cells[1].InlineRowIDs = 2
+	node.Cells[1].Child = 8
+
+	buf := make([]byte, node.Size())
+	err := node.Marshal(buf)
+	require.NoError(t, err)
+
+	recreatedNode := NewIndexNode[string](false)
+	_, err = recreatedNode.Unmarshal(nil, buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, node, recreatedNode)
+
+	for idx := 0; idx < len(node.Cells); idx++ {
+		assert.Equal(t, node.Cells[idx], recreatedNode.Cells[idx])
+	}
+
+	// Non-unique cell layout: key + child_ptr(4) + rowIDs_count(4) + N×rowID(8) + overflow_ptr(4)
+	expectedSize := int(15 + // header
+		(varcharLengthPrefixSize + 3) + 4 + rowIDsLengthPrefixSize + 1*8 + 4 + // cell 1: "foo", 1 rowID
+		(varcharLengthPrefixSize + 7) + 4 + rowIDsLengthPrefixSize + 2*8 + 4) // cell 2: "bar qux", 2 rowIDs
 	assert.Equal(t, expectedSize, int(recreatedNode.Size()))
 }

--- a/internal/minisql/index_scan.go
+++ b/internal/minisql/index_scan.go
@@ -30,19 +30,25 @@ func (ui *Index[T]) scanAscending(ctx context.Context, pageIdx PageIndex, callba
 		// Leaf node: just visit all keys in order
 		for i := uint32(0); i < node.Header.Keys; i++ {
 			cell := node.Cells[i]
-			for _, rowID := range cell.RowIDs {
-				if err := callback(cell.Key, rowID); err != nil {
+			if cell.unique {
+				if err := callback(cell.Key, cell.UniqueRowID); err != nil {
 					return err
 				}
-			}
-			if cell.Overflow != 0 {
-				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-				if err != nil {
-					return err
-				}
-				for _, rowID := range rowIDs {
+			} else {
+				for _, rowID := range cell.RowIDs {
 					if err := callback(cell.Key, rowID); err != nil {
 						return err
+					}
+				}
+				if cell.Overflow != 0 {
+					rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+					if err != nil {
+						return err
+					}
+					for _, rowID := range rowIDs {
+						if err := callback(cell.Key, rowID); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -62,19 +68,25 @@ func (ui *Index[T]) scanAscending(ctx context.Context, pageIdx PageIndex, callba
 		}
 
 		// Visit the key itself
-		for _, rowID := range cell.RowIDs {
-			if err := callback(cell.Key, rowID); err != nil {
+		if cell.unique {
+			if err := callback(cell.Key, cell.UniqueRowID); err != nil {
 				return err
 			}
-		}
-		if cell.Overflow != 0 {
-			rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-			if err != nil {
-				return err
-			}
-			for _, rowID := range rowIDs {
+		} else {
+			for _, rowID := range cell.RowIDs {
 				if err := callback(cell.Key, rowID); err != nil {
 					return err
+				}
+			}
+			if cell.Overflow != 0 {
+				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+				if err != nil {
+					return err
+				}
+				for _, rowID := range rowIDs {
+					if err := callback(cell.Key, rowID); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -103,19 +115,25 @@ func (ui *Index[T]) scanDescending(ctx context.Context, pageIdx PageIndex, callb
 		// Leaf node: visit all keys in reverse order
 		for i := int(node.Header.Keys) - 1; i >= 0; i-- {
 			cell := node.Cells[i]
-			for _, rowID := range cell.RowIDs {
-				if err := callback(cell.Key, rowID); err != nil {
+			if cell.unique {
+				if err := callback(cell.Key, cell.UniqueRowID); err != nil {
 					return err
 				}
-			}
-			if cell.Overflow != 0 {
-				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-				if err != nil {
-					return err
-				}
-				for _, rowID := range rowIDs {
+			} else {
+				for _, rowID := range cell.RowIDs {
 					if err := callback(cell.Key, rowID); err != nil {
 						return err
+					}
+				}
+				if cell.Overflow != 0 {
+					rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+					if err != nil {
+						return err
+					}
+					for _, rowID := range rowIDs {
+						if err := callback(cell.Key, rowID); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -136,19 +154,25 @@ func (ui *Index[T]) scanDescending(ctx context.Context, pageIdx PageIndex, callb
 		cell := node.Cells[i]
 
 		// Visit the key
-		for _, rowID := range cell.RowIDs {
-			if err := callback(cell.Key, rowID); err != nil {
+		if cell.unique {
+			if err := callback(cell.Key, cell.UniqueRowID); err != nil {
 				return err
 			}
-		}
-		if cell.Overflow != 0 {
-			rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-			if err != nil {
-				return err
-			}
-			for _, rowID := range rowIDs {
+		} else {
+			for _, rowID := range cell.RowIDs {
 				if err := callback(cell.Key, rowID); err != nil {
 					return err
+				}
+			}
+			if cell.Overflow != 0 {
+				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+				if err != nil {
+					return err
+				}
+				for _, rowID := range rowIDs {
+					if err := callback(cell.Key, rowID); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -251,19 +275,25 @@ func (ui *Index[T]) scanRangeFrom(
 		}
 
 		// Key is within range
-		for _, rowID := range cell.RowIDs {
-			if err := callback(key, rowID); err != nil {
+		if cell.unique {
+			if err := callback(key, cell.UniqueRowID); err != nil {
 				return err
 			}
-		}
-		if cell.Overflow != 0 {
-			rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-			if err != nil {
-				return err
-			}
-			for _, rowID := range rowIDs {
+		} else {
+			for _, rowID := range cell.RowIDs {
 				if err := callback(key, rowID); err != nil {
 					return err
+				}
+			}
+			if cell.Overflow != 0 {
+				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+				if err != nil {
+					return err
+				}
+				for _, rowID := range rowIDs {
+					if err := callback(key, rowID); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -323,19 +353,25 @@ func (ui *Index[T]) scanRangeFrom(
 				key  = cell.Key
 			)
 
-			for _, rowID := range cell.RowIDs {
-				if err := callback(key, rowID); err != nil {
+			if cell.unique {
+				if err := callback(key, cell.UniqueRowID); err != nil {
 					return err
 				}
-			}
-			if cell.Overflow != 0 {
-				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-				if err != nil {
-					return err
-				}
-				for _, rowID := range rowIDs {
+			} else {
+				for _, rowID := range cell.RowIDs {
 					if err := callback(key, rowID); err != nil {
 						return err
+					}
+				}
+				if cell.Overflow != 0 {
+					rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+					if err != nil {
+						return err
+					}
+					for _, rowID := range rowIDs {
+						if err := callback(key, rowID); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -390,19 +426,25 @@ func (ui *Index[T]) scanRangeRecursive(ctx context.Context, pageIdx PageIndex, r
 		}
 
 		// Key is within range
-		for _, rowID := range cell.RowIDs {
-			if err := callback(key, rowID); err != nil {
+		if cell.unique {
+			if err := callback(key, cell.UniqueRowID); err != nil {
 				return err
 			}
-		}
-		if cell.Overflow != 0 {
-			rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-			if err != nil {
-				return err
-			}
-			for _, rowID := range rowIDs {
+		} else {
+			for _, rowID := range cell.RowIDs {
 				if err := callback(key, rowID); err != nil {
 					return err
+				}
+			}
+			if cell.Overflow != 0 {
+				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+				if err != nil {
+					return err
+				}
+				for _, rowID := range rowIDs {
+					if err := callback(key, rowID); err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -466,19 +508,25 @@ func (ui *Index[T]) scanRangeRecursiveReverse(ctx context.Context, pageIdx PageI
 
 		// Emit key if it's within range
 		if includeKey {
-			for _, rowID := range cell.RowIDs {
-				if err := callback(key, rowID); err != nil {
+			if cell.unique {
+				if err := callback(key, cell.UniqueRowID); err != nil {
 					return err
 				}
-			}
-			if cell.Overflow != 0 {
-				rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
-				if err != nil {
-					return err
-				}
-				for _, rowID := range rowIDs {
+			} else {
+				for _, rowID := range cell.RowIDs {
 					if err := callback(key, rowID); err != nil {
 						return err
+					}
+				}
+				if cell.Overflow != 0 {
+					rowIDs, err := readOverflowRowIDs[T](ctx, ui.pager, cell.Overflow)
+					if err != nil {
+						return err
+					}
+					for _, rowID := range rowIDs {
+						if err := callback(key, rowID); err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/internal/minisql/interval_test.go
+++ b/internal/minisql/interval_test.go
@@ -34,8 +34,10 @@ func TestParseIntervalString(t *testing.T) {
 		{"500 microseconds", Interval{Micros: 500}},
 		{"-1 day", Interval{Micros: -msInDay}},
 		{"-2 months", Interval{Months: -2}},
-		{"1 year 2 months 3 days 4 hours 5 minutes 6 seconds",
-			Interval{Months: 14, Micros: 3*msInDay + 4*msInHour + 5*msInMin + 6*msInSec}},
+		{
+			"1 year 2 months 3 days 4 hours 5 minutes 6 seconds",
+			Interval{Months: 14, Micros: 3*msInDay + 4*msInHour + 5*msInMin + 6*msInSec},
+		},
 	}
 	for _, tc := range cases {
 		iv, err := ParseIntervalString(tc.input)

--- a/internal/minisql/mocks_test.go
+++ b/internal/minisql/mocks_test.go
@@ -15,7 +15,8 @@ import (
 func NewMockParser(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockParser {
+},
+) *MockParser {
 	mock := &MockParser{}
 	mock.Mock.Test(t)
 
@@ -110,7 +111,8 @@ func (_c *MockParser_Parse_Call) RunAndReturn(run func(context1 context.Context,
 func NewMockPager(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockPager {
+},
+) *MockPager {
 	mock := &MockPager{}
 	mock.Mock.Test(t)
 
@@ -300,7 +302,8 @@ func (_c *MockPager_TotalPages_Call) RunAndReturn(run func() uint32) *MockPager_
 func NewMockPageSaver(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockPageSaver {
+},
+) *MockPageSaver {
 	mock := &MockPageSaver{}
 	mock.Mock.Test(t)
 
@@ -667,7 +670,8 @@ func (_c *MockPageSaver_TotalPages_Call) RunAndReturn(run func() uint32) *MockPa
 func NewMockTxPager(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockTxPager {
+},
+) *MockTxPager {
 	mock := &MockTxPager{}
 	mock.Mock.Test(t)
 

--- a/internal/minisql/row.go
+++ b/internal/minisql/row.go
@@ -205,7 +205,6 @@ func (r Row) Clone() Row {
 	return rowCopy
 }
 
-
 // Marshal ...
 func (r Row) Marshal() ([]byte, error) {
 	// Single allocation: allocate exact size upfront instead of using append


### PR DESCRIPTION
`IndexCell.UniqueRowID` inline storage — eliminate heap-allocated `[]RowID` slice for unique index cells:
- Added `UniqueRowID RowID` field to `IndexCell`; for unique indexes (primary key, unique indexes) the single RowID is stored inline in the struct rather than in a `[]RowID` slice.
- `NewIndexCell`: skips `make([]RowID, 0, 1)` for unique cells.
- `Clone()`: for unique cells, copies the scalar `UniqueRowID` — no `make([]RowID, N)` per cell.
- `Marshal`/`Unmarshal`: reads/writes `UniqueRowID` directly.
- All B+ tree mutation sites updated: `insertNotFull`, `splitChild`, `removeFromInternal`, `borrowFromLeft`, `borrowFromRight`, `merge`, `scanAscending/Descending/Range*`.
- Primary win: each `ModifyPage` on an index page with K unique-index cells previously did K×`make([]RowID,1)` in `IndexNode.Clone`. For a 10K-row table the root had ~85 cells → 85 allocs saved per cloned page.