### PR TITLE
refactor: multiple performance improvements

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,39 @@
+### 2026-04-22 00:03 UTC
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 201.27 µs/op | 143.77 µs/op | 1.4× |
+| Insert_SingleRow | 88.20 µs/op | 45.46 µs/op | 1.9× |
+| Insert_Batch | 587.77 µs/op | 222.94 µs/op | 2.6× |
+| Select_PointScan | 4.44 µs/op | 3.31 µs/op | 1.3× |
+| Select_Limit | 7.39 µs/op | 7.94 µs/op | 0.9× |
+| Select_FullScan | 5.04 ms/op | 5.55 ms/op | 0.9× |
+| Select_CountStar | 32.68 µs/op | 9.66 µs/op | 3.4× |
+| Select_IndexRangeScan | 728.41 µs/op | 747.02 µs/op | 1.0× |
+| Select_RangeScan | 2.83 ms/op | 928.63 µs/op | 3.0× |
+| Txn_NInserts | 341.37 µs/op | 140.91 µs/op | 2.4× |
+| Update_ByPK | 61.60 µs/op | 40.56 µs/op | 1.5× |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 82.4 KiB | 447 B |
+| Insert_SingleRow | 46.8 KiB | 311 B |
+| Insert_Batch | 366.1 KiB | 31.0 KiB |
+| Select_PointScan | 4.5 KiB | 679 B |
+| Select_Limit | 6.3 KiB | 1.7 KiB |
+| Select_FullScan | 5.7 MiB | 1.3 MiB |
+| Select_CountStar | 5.8 KiB | 400 B |
+| Select_IndexRangeScan | 772.4 KiB | 85.9 KiB |
+| Select_RangeScan | 2.0 MiB | 85.9 KiB |
+| Txn_NInserts | 209.1 KiB | 15.8 KiB |
+| Update_ByPK | 9.0 KiB | 263 B |
+
+---
+
 ### 2026-04-21 22:32 UTC
 
 `IndexCell.UniqueRowID` inline storage — eliminate heap-allocated `[]RowID` slice for unique index cells:

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -149,6 +149,10 @@ func (c *Cursor) LeafNodeSplitInsert(ctx context.Context, key RowID, row Row) er
 }
 
 func (c *Cursor) fetchRow(ctx context.Context, advance bool, selectedFields ...Field) (Row, error) {
+	return c.fetchRowWithMask(ctx, advance, selectedColumnsMask(c.Table.Columns, selectedFields))
+}
+
+func (c *Cursor) fetchRowWithMask(ctx context.Context, advance bool, selectedMask []bool) (Row, error) {
 	page, err := c.Table.pager.ReadPage(ctx, c.PageIdx)
 	if err != nil {
 		return Row{}, fmt.Errorf("read page: %w", err)
@@ -158,7 +162,7 @@ func (c *Cursor) fetchRow(ctx context.Context, advance bool, selectedFields ...F
 	if c.CellIdx > page.LeafNode.Header.Cells-1 || len(page.LeafNode.Cells) == 0 {
 		return Row{}, fmt.Errorf("cell index %d out of bounds, max %d", c.CellIdx, page.LeafNode.Header.Cells-1)
 	}
-	row, err = row.Unmarshal(page.LeafNode.Cells[c.CellIdx], selectedFields...)
+	row, err = row.UnmarshalWithMask(page.LeafNode.Cells[c.CellIdx], selectedMask)
 	if err != nil {
 		return Row{}, err
 	}

--- a/internal/minisql/row.go
+++ b/internal/minisql/row.go
@@ -87,6 +87,11 @@ func (r Row) Size() uint64 {
 // (Rows.Next, rowDistinctKey, selectGroupBy, deduplicateRows).  Name-based
 // lookups via GetColumn/GetValue fall back to a linear scan if needed.
 func (r Row) OnlyFields(fields ...Field) Row {
+	// Fast path: requested fields already match the row layout exactly.
+	if rowMatchesRequestedFieldsInOrder(r, fields) {
+		return r
+	}
+
 	filteredRow := Row{
 		Key:     r.Key,
 		Columns: make([]Column, len(fields)),
@@ -119,6 +124,21 @@ func (r Row) OnlyFields(fields ...Field) Row {
 	}
 
 	return filteredRow
+}
+
+func rowMatchesRequestedFieldsInOrder(row Row, fields []Field) bool {
+	if len(fields) != len(row.Columns) {
+		return false
+	}
+	for i, f := range fields {
+		if f.Expr != nil || f.AliasPrefix != "" {
+			return false
+		}
+		if f.Name != row.Columns[i].Name {
+			return false
+		}
+	}
+	return true
 }
 
 // GetColumn returns the column and its index for the given name via linear scan.
@@ -289,9 +309,16 @@ func (r Row) Marshal() ([]byte, error) {
 // Unmarshal decodes cell into a Row. For columns not in selectedFields, an empty
 // OptionalValue is inserted to maintain index alignment.
 func (r Row) Unmarshal(cell Cell, selectedFields ...Field) (Row, error) {
+	return r.UnmarshalWithMask(cell, selectedColumnsMask(r.Columns, selectedFields))
+}
+
+// UnmarshalWithMask decodes cell into a Row using a precomputed column-selection mask.
+// selectedMask must have len == len(r.Columns). A nil/empty mask means "no fields selected"
+// (keys only; values remain zero-value placeholders).
+func (r Row) UnmarshalWithMask(cell Cell, selectedMask []bool) (Row, error) {
 	r.Key = cell.Key
 
-	if len(selectedFields) == 0 {
+	if len(selectedMask) == 0 {
 		r.Values = make([]OptionalValue, len(r.Columns))
 		return r, nil
 	}
@@ -304,8 +331,8 @@ func (r Row) Unmarshal(cell Cell, selectedFields ...Field) (Row, error) {
 		// Check if column is NULL
 		isNull := bitwise.IsSet(cell.NullBitmask, i)
 
-		// If column not selected, skip it but track offset (inline linear search, zero allocation)
-		if !isColumnSelected(col.Name, selectedFields) {
+		// If column not selected, skip it but track offset.
+		if !selectedMask[i] {
 			r.Values[i] = OptionalValue{Valid: false}
 			if !isNull {
 				// Skip over the data without unmarshaling
@@ -359,15 +386,20 @@ func (r Row) Unmarshal(cell Cell, selectedFields ...Field) (Row, error) {
 	return r, nil
 }
 
-// isColumnSelected reports whether colName appears in selectedFields.
-// It uses a linear scan so that callers avoid allocating a map for small field lists.
-func isColumnSelected(colName string, selectedFields []Field) bool {
-	for j := range selectedFields {
-		if selectedFields[j].Name == colName {
-			return true
-		}
+func selectedColumnsMask(columns []Column, selectedFields []Field) []bool {
+	if len(selectedFields) == 0 {
+		return nil
 	}
-	return false
+	mask := make([]bool, len(columns))
+	selected := make(map[string]struct{}, len(selectedFields))
+	for _, f := range selectedFields {
+		selected[f.Name] = struct{}{}
+	}
+	for i := range columns {
+		_, ok := selected[columns[i].Name]
+		mask[i] = ok
+	}
+	return mask
 }
 
 func (r Row) getColumnSize(col Column, data []byte, offset int) uint64 {
@@ -412,6 +444,26 @@ func (r Row) CheckOneOrMore(conditions OneOrMore) (bool, error) {
 	return false, nil
 }
 
+// CheckOneOrMoreWithColumnIndexes is like CheckOneOrMore but uses pre-resolved
+// column indexes for field lookups to avoid repeated linear scans by name.
+func (r Row) CheckOneOrMoreWithColumnIndexes(conditions OneOrMore, columnIndexes map[string]int) (bool, error) {
+	if len(conditions) == 0 {
+		return true, nil
+	}
+
+	for _, condGroup := range conditions {
+		ok, err := r.checkConditionsWithColumnIndexes(condGroup, columnIndexes)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // CheckConditions ...
 func (r Row) CheckConditions(condGroup Conditions) (bool, error) {
 	if len(condGroup) == 0 {
@@ -438,6 +490,24 @@ func (r Row) CheckConditions(condGroup Conditions) (bool, error) {
 	return false, nil
 }
 
+func (r Row) checkConditionsWithColumnIndexes(condGroup Conditions, columnIndexes map[string]int) (bool, error) {
+	if len(condGroup) == 0 {
+		return true, nil
+	}
+
+	for _, cond := range condGroup {
+		ok, err := r.checkConditionWithColumnIndexes(cond, columnIndexes)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 func (r Row) checkCondition(cond Condition) (bool, error) {
 	// left side is field, right side is literal value
 	if cond.Operand1.IsField() && !cond.Operand2.IsField() {
@@ -452,6 +522,26 @@ func (r Row) checkCondition(cond Condition) (bool, error) {
 	// both left and right are fields, compare 2 row values
 	if cond.Operand1.IsField() && cond.Operand2.IsField() {
 		return r.compareFields(cond.Operand1, cond.Operand2, cond.Operator)
+	}
+
+	// both left and right are literal values, compare them
+	return cond.Operand1.Value == cond.Operand2.Value, nil
+}
+
+func (r Row) checkConditionWithColumnIndexes(cond Condition, columnIndexes map[string]int) (bool, error) {
+	// left side is field, right side is literal value
+	if cond.Operand1.IsField() && !cond.Operand2.IsField() {
+		return r.compareFieldValueWithColumnIndexes(cond.Operand1, cond.Operand2, cond.Operator, columnIndexes)
+	}
+
+	// left side is literal value, right side is field
+	if cond.Operand2.IsField() && !cond.Operand1.IsField() {
+		return r.compareFieldValueWithColumnIndexes(cond.Operand2, cond.Operand1, cond.Operator, columnIndexes)
+	}
+
+	// both left and right are fields, compare 2 row values
+	if cond.Operand1.IsField() && cond.Operand2.IsField() {
+		return r.compareFieldsWithColumnIndexes(cond.Operand1, cond.Operand2, cond.Operator, columnIndexes)
 	}
 
 	// both left and right are literal values, compare them
@@ -601,6 +691,150 @@ func (r Row) compareFieldValue(fieldOperand, valueOperand Operand, operator Oper
 	}
 }
 
+func (r Row) compareFieldValueWithColumnIndexes(fieldOperand, valueOperand Operand, operator Operator, columnIndexes map[string]int) (bool, error) {
+	if fieldOperand.Type != OperandField {
+		return false, fmt.Errorf("field operand invalid, type '%d'", fieldOperand.Type)
+	}
+	if valueOperand.Type == OperandField {
+		return false, errors.New("cannot compare column value against field operand")
+	}
+
+	field := fieldOperand.Value.(Field)
+	name := field.Name
+	colIdx, ok := columnIndexes[name]
+	if !ok {
+		return false, fmt.Errorf("row does not contain column '%s'", name)
+	}
+	col := r.Columns[colIdx]
+	if colIdx >= len(r.Values) {
+		return false, fmt.Errorf("row does not have '%s' column", name)
+	}
+	fieldValue := r.Values[colIdx]
+
+	switch valueOperand.Type {
+	case OperandNull:
+		switch operator {
+		case Eq:
+			return !fieldValue.Valid, nil
+		case Ne:
+			return fieldValue.Valid, nil
+		default:
+			return false, errors.New("only '=' and '!=' operators supported when comparing against NULL")
+		}
+	case OperandList:
+		switch operator {
+		case In, NotIn:
+			switch col.Kind {
+			case Boolean:
+				return false, errors.New("IN / NOT IN operator not supported for boolean columns")
+			case Int4:
+				foundInList, err := isInListInt4(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			case Int8:
+				foundInList, err := isInListInt8(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			case Real:
+				foundInList, err := isInListReal(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			case Double:
+				foundInList, err := isInListDouble(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			case Varchar, Text:
+				foundInList, err := isInListText(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			case Timestamp:
+				foundInList, err := isInListTimestamp(fieldValue.Value, valueOperand.Value)
+				if operator == In {
+					return foundInList, err
+				}
+				return !foundInList, err
+			default:
+				return false, fmt.Errorf("unknown column kind '%s'", col.Kind)
+			}
+
+		case Between, NotBetween:
+			list, ok := valueOperand.Value.([]any)
+			if !ok || len(list) != 2 {
+				return false, errors.New("BETWEEN requires exactly 2 bounds")
+			}
+			var (
+				inRange bool
+				err     error
+			)
+			switch col.Kind {
+			case Boolean:
+				return false, errors.New("BETWEEN operator not supported for boolean columns")
+			case Int4:
+				inRange, err = isBetweenInt4(int64(fieldValue.Value.(int32)), list[0], list[1])
+			case Int8:
+				inRange, err = isBetweenInt8(fieldValue.Value, list[0], list[1])
+			case Real:
+				inRange, err = isBetweenReal(float64(fieldValue.Value.(float32)), list[0], list[1])
+			case Double:
+				inRange, err = isBetweenDouble(fieldValue.Value, list[0], list[1])
+			case Varchar, Text:
+				inRange, err = isBetweenText(fieldValue.Value, list[0], list[1])
+			case Timestamp:
+				inRange, err = isBetweenTimestamp(fieldValue.Value, list[0], list[1])
+			default:
+				return false, fmt.Errorf("unknown column kind '%s'", col.Kind)
+			}
+			if err != nil {
+				return false, err
+			}
+			if operator == Between {
+				return inRange, nil
+			}
+			return !inRange, nil
+
+		default:
+			return false, errors.New("only 'IN', 'NOT IN', 'BETWEEN', and 'NOT BETWEEN' operators supported when comparing against list")
+		}
+	}
+
+	if !fieldValue.Valid {
+		return false, nil // NULL cannot be compared to non-NULL value
+	}
+
+	if (operator == Like || operator == NotLike) && col.Kind != Varchar && col.Kind != Text {
+		return false, errors.New("LIKE / NOT LIKE operator only supported for TEXT and VARCHAR columns")
+	}
+
+	switch col.Kind {
+	case Boolean:
+		return compareBoolean(fieldValue.Value.(bool), valueOperand.Value.(bool), operator)
+	case Int4:
+		return compareInt4(int64(fieldValue.Value.(int32)), valueOperand.Value.(int64), operator)
+	case Int8:
+		return compareInt8(fieldValue.Value.(int64), valueOperand.Value.(int64), operator)
+	case Real:
+		return compareReal(float64(fieldValue.Value.(float32)), valueOperand.Value.(float64), operator)
+	case Double:
+		return compareDouble(fieldValue.Value.(float64), valueOperand.Value.(float64), operator)
+	case Varchar, Text:
+		return compareText(fieldValue.Value, valueOperand.Value, operator)
+	case Timestamp:
+		return compareTimestamp(fieldValue.Value, valueOperand.Value, operator)
+	default:
+		return false, fmt.Errorf("unknown column kind '%s'", col.Kind)
+	}
+}
+
 func (r Row) compareFields(field1, field2 Operand, operator Operator) (bool, error) {
 	if !field1.IsField() {
 		return false, fmt.Errorf("field 1 operand invalid, type '%d'", field1.Type)
@@ -664,6 +898,70 @@ func (r Row) compareFields(field1, field2 Operand, operator Operator) (bool, err
 		return compareTimestamp(value1.Value, value2.Value, operator)
 	default:
 		return false, fmt.Errorf("unknown column kind '%s'", aColumn1.Kind)
+	}
+}
+
+func (r Row) compareFieldsWithColumnIndexes(field1, field2 Operand, operator Operator, columnIndexes map[string]int) (bool, error) {
+	if !field1.IsField() {
+		return false, fmt.Errorf("field 1 operand invalid, type '%d'", field1.Type)
+	}
+	if !field2.IsField() {
+		return false, fmt.Errorf("field 2 operand invalid, type '%d'", field2.Type)
+	}
+
+	if field1.Value == field2.Value {
+		return true, nil
+	}
+
+	f1 := field1.Value.(Field)
+	name1 := f1.Name
+	if f1.AliasPrefix != "" {
+		name1 = f1.AliasPrefix + "." + f1.Name
+	}
+	idx1, ok := columnIndexes[name1]
+	if !ok {
+		return false, fmt.Errorf("row does not contain column '%s'", name1)
+	}
+
+	f2 := field2.Value.(Field)
+	name2 := f2.Name
+	if f2.AliasPrefix != "" {
+		name2 = f2.AliasPrefix + "." + f2.Name
+	}
+	idx2, ok := columnIndexes[name2]
+	if !ok {
+		return false, fmt.Errorf("row does not contain column '%s'", name2)
+	}
+
+	col1 := r.Columns[idx1]
+	col2 := r.Columns[idx2]
+	if col1.Kind != col2.Kind {
+		return false, nil
+	}
+	if idx1 >= len(r.Values) || idx2 >= len(r.Values) {
+		return false, errors.New("row values out of bounds for field comparison")
+	}
+
+	value1 := r.Values[idx1]
+	value2 := r.Values[idx2]
+
+	switch col1.Kind {
+	case Boolean:
+		return compareBoolean(value1.Value, value2.Value, operator)
+	case Int4:
+		return compareInt4(value1.Value, value2.Value, operator)
+	case Int8:
+		return compareInt8(value1.Value, value2.Value, operator)
+	case Real:
+		return compareReal(value1.Value, value2.Value, operator)
+	case Double:
+		return compareDouble(value1.Value, value2.Value, operator)
+	case Varchar, Text:
+		return compareText(value1.Value, value2.Value, operator)
+	case Timestamp:
+		return compareTimestamp(value1.Value, value2.Value, operator)
+	default:
+		return false, fmt.Errorf("unknown column kind '%s'", col1.Kind)
 	}
 }
 

--- a/internal/minisql/row_test.go
+++ b/internal/minisql/row_test.go
@@ -8,6 +8,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRow_OnlyFields_FastPathExactMatch(t *testing.T) {
+	t.Parallel()
+
+	row := gen.Row()
+	fields := fieldsFromColumns(row.Columns...)
+
+	got := row.OnlyFields(fields...)
+	require.NotEmpty(t, got.Columns)
+	require.NotEmpty(t, row.Columns)
+	assert.Equal(t, row, got)
+	assert.Equal(t, &row.Columns[0], &got.Columns[0], "fast path should reuse column slice")
+	assert.Equal(t, &row.Values[0], &got.Values[0], "fast path should reuse value slice")
+}
+
+func TestSelectedColumnsMask(t *testing.T) {
+	t.Parallel()
+
+	mask := selectedColumnsMask(testColumns, []Field{
+		{Name: "id"},
+		{Name: "verified"},
+	})
+	require.Len(t, mask, len(testColumns))
+	assert.True(t, mask[0])  // id
+	assert.False(t, mask[1]) // email
+	assert.False(t, mask[2]) // age
+	assert.True(t, mask[3])  // verified
+	assert.False(t, mask[4]) // score
+	assert.False(t, mask[5]) // created
+
+	assert.Nil(t, selectedColumnsMask(testColumns, nil))
+}
+
 func TestRow_Marshal(t *testing.T) {
 	t.Parallel()
 
@@ -51,6 +83,29 @@ func TestRow_Marshal(t *testing.T) {
 		assert.False(t, partialRow.Values[4].Valid)
 		assert.False(t, partialRow.Values[5].Valid)
 	})
+}
+
+func TestRow_UnmarshalWithMask(t *testing.T) {
+	t.Parallel()
+
+	row := gen.Row()
+	data, err := row.Marshal()
+	require.NoError(t, err)
+
+	mask := selectedColumnsMask(testColumns, []Field{
+		{Name: "id"},
+		{Name: "age"},
+	})
+	actual := NewRow(testColumns)
+	actual, err = actual.UnmarshalWithMask(Cell{Value: data}, mask)
+	require.NoError(t, err)
+
+	assert.Equal(t, row.Values[0], actual.Values[0]) // id
+	assert.False(t, actual.Values[1].Valid)          // email skipped
+	assert.Equal(t, row.Values[2], actual.Values[2]) // age
+	assert.False(t, actual.Values[3].Valid)
+	assert.False(t, actual.Values[4].Valid)
+	assert.False(t, actual.Values[5].Valid)
 }
 
 func TestRow_CheckOneOrMore(t *testing.T) {
@@ -638,6 +693,172 @@ func TestRow_CheckOneOrMore(t *testing.T) {
 			assert.Equal(t, aTestCase.Expected, actual)
 		})
 	}
+}
+
+func TestRow_CheckOneOrMoreWithColumnIndexes(t *testing.T) {
+	t.Parallel()
+
+	row := gen.Row()
+	conditions := OneOrMore{
+		{
+			{
+				Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+				Operator: Eq,
+				Operand2: Operand{Type: OperandInteger, Value: row.Values[0].Value.(int64)},
+			},
+			{
+				Operand1: Operand{Type: OperandField, Value: Field{Name: "age"}},
+				Operator: Gte,
+				Operand2: Operand{Type: OperandInteger, Value: int64(row.Values[2].Value.(int32))},
+			},
+		},
+	}
+
+	columnIndexes := map[string]int{
+		"id":       0,
+		"email":    1,
+		"age":      2,
+		"verified": 3,
+		"score":    4,
+		"created":  5,
+	}
+
+	got, err := row.CheckOneOrMoreWithColumnIndexes(conditions, columnIndexes)
+	require.NoError(t, err)
+
+	want, err := row.CheckOneOrMore(conditions)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, got)
+}
+
+func TestRow_CompareFieldValueWithColumnIndexes_Errors(t *testing.T) {
+	t.Parallel()
+
+	row := NewRowWithValues(
+		[]Column{
+			{Name: "id", Kind: Int8, Size: 8},
+			{Name: "age", Kind: Int4, Size: 4},
+			{Name: "verified", Kind: Boolean, Size: 1},
+		},
+		[]OptionalValue{
+			{Value: int64(10), Valid: true},
+			{Value: int32(5), Valid: true},
+			{Value: true, Valid: true},
+		},
+	)
+	columnIndexes := map[string]int{
+		"id":       0,
+		"age":      1,
+		"verified": 2,
+	}
+
+	t.Run("invalid field operand type", func(t *testing.T) {
+		_, err := row.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandInteger, Value: int64(1)},
+			Operand{Type: OperandInteger, Value: int64(1)},
+			Eq,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("value operand cannot be field", func(t *testing.T) {
+		_, err := row.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandField, Value: Field{Name: "id"}},
+			Operand{Type: OperandField, Value: Field{Name: "age"}},
+			Eq,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing column index", func(t *testing.T) {
+		_, err := row.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandField, Value: Field{Name: "missing"}},
+			Operand{Type: OperandInteger, Value: int64(1)},
+			Eq,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("row values out of bounds", func(t *testing.T) {
+		shortValuesRow := NewRowWithValues(row.Columns, []OptionalValue{{Value: int64(10), Valid: true}})
+		_, err := shortValuesRow.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandField, Value: Field{Name: "age"}},
+			Operand{Type: OperandInteger, Value: int64(5)},
+			Eq,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("null comparison with unsupported operator", func(t *testing.T) {
+		_, err := row.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandField, Value: Field{Name: "id"}},
+			Operand{Type: OperandNull},
+			Gt,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("IN not supported for boolean", func(t *testing.T) {
+		_, err := row.compareFieldValueWithColumnIndexes(
+			Operand{Type: OperandField, Value: Field{Name: "verified"}},
+			Operand{Type: OperandList, Value: []any{true, false}},
+			In,
+			columnIndexes,
+		)
+		assert.Error(t, err)
+	})
+}
+
+func TestRow_CompareFieldsWithColumnIndexes_Errors(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "a", Kind: Int8, Size: 8},
+		{Name: "b", Kind: Int8, Size: 8},
+		{Name: "c", Kind: Int4, Size: 4},
+	}
+	row := NewRowWithValues(cols, []OptionalValue{
+		{Value: int64(1), Valid: true},
+		{Value: int64(2), Valid: true},
+		{Value: int32(3), Valid: true},
+	})
+	columnIndexes := map[string]int{"a": 0, "b": 1, "c": 2}
+
+	field := func(name string) Operand {
+		return Operand{Type: OperandField, Value: Field{Name: name}}
+	}
+
+	t.Run("invalid field1 operand", func(t *testing.T) {
+		_, err := row.compareFieldsWithColumnIndexes(Operand{Type: OperandInteger, Value: int64(1)}, field("b"), Eq, columnIndexes)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid field2 operand", func(t *testing.T) {
+		_, err := row.compareFieldsWithColumnIndexes(field("a"), Operand{Type: OperandInteger, Value: int64(1)}, Eq, columnIndexes)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing first column", func(t *testing.T) {
+		_, err := row.compareFieldsWithColumnIndexes(field("missing"), field("b"), Eq, columnIndexes)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing second column", func(t *testing.T) {
+		_, err := row.compareFieldsWithColumnIndexes(field("a"), field("missing"), Eq, columnIndexes)
+		assert.Error(t, err)
+	})
+
+	t.Run("row values out of bounds", func(t *testing.T) {
+		shortValuesRow := NewRowWithValues(cols, []OptionalValue{{Value: int64(1), Valid: true}})
+		_, err := shortValuesRow.compareFieldsWithColumnIndexes(field("a"), field("b"), Eq, columnIndexes)
+		assert.Error(t, err)
+	})
 }
 
 func TestRow_GetValue(t *testing.T) {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -92,21 +92,18 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
-	// Fast path: streaming queries WITH a LIMIT that require no sort, no GROUP BY,
-	// and no aggregates, and have no JOINs.  A LIMIT lets us stop the scan the
-	// moment enough projected rows have been collected — avoiding a full table read.
-	// The projected slice is pre-sized to exactly the LIMIT so there are zero
-	// reallocs and no wasted capacity.
+	// Fast path: streaming queries that require no sort, no GROUP BY, and no
+	// aggregates, and have no JOINs. This avoids materializing an intermediate
+	// []Row buffer from the plan scan.
 	//
-	// Queries without a LIMIT are excluded: without early termination the only
-	// saving would be eliminating the raw-rows intermediate buffer, which is not
-	// worth the dynamic-growth reallocs that replace the old exact-sized allocation.
+	// With LIMIT, scanning can stop early once enough rows are projected.
+	// Without LIMIT, we still benefit by eliminating one full intermediate
+	// allocation (rows), even though projected rows keep growing dynamically.
 	//
 	// JOIN queries are excluded because plan.Execute launches a goroutine internally;
 	// returning errLimitReached from the callback while that goroutine is still
 	// writing to the channel would leak the goroutine.
-	if stmt.Limit.Valid &&
-		!stmt.IsSelectCountAll() &&
+	if !stmt.IsSelectCountAll() &&
 		!stmt.IsSelectGroupBy() &&
 		!stmt.IsSelectAggregate() &&
 		!plan.SortInMemory &&
@@ -618,10 +615,14 @@ func (t *Table) selectStreamingDirect(
 		seen = make(map[string]struct{})
 	}
 
-	// Pre-size projected slice to exactly the LIMIT so append never reallocates.
-	// selectStreamingDirect is only called when stmt.Limit.Valid is true, so
-	// hasLimit is always true here and remaining holds the requested row count.
-	projected := make([]Row, 0, int(remaining))
+	// When LIMIT is present, pre-size to exactly the limit so append never reallocates.
+	// Without LIMIT, start empty and grow as needed.
+	var projected []Row
+	if hasLimit {
+		projected = make([]Row, 0, int(remaining))
+	} else {
+		projected = make([]Row, 0)
+	}
 
 	err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
 		p, projErr := projectRow(row, requestedFields)
@@ -794,6 +795,11 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
 	}
+	var (
+		selectedMask   = selectedColumnsMask(t.Columns, selectedFields)
+		tableFilter    = compileScanFilter(t.Columns, scan.Filters)
+		coveringFilter = compileScanFilter(scan.IndexColumns, scan.Filters)
+	)
 
 	// Scan index in order (or reverse order)
 	if err := idx.ScanAll(ctx, aPlan.SortReverse, func(key any, rowID RowID) error {
@@ -814,26 +820,28 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 				row.Key = rowID
 			} else {
 				var err error
-				row, err = cursor.fetchRow(ctx, false, selectedFields...)
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
 				if err != nil {
 					return fmt.Errorf("fetch row failed: %w", err)
 				}
 
 				// Apply remaining filters
-				ok, err := scan.FilterRow(row)
-				if err != nil {
-					return err
-				}
-				if !ok {
-					return nil // Skip this row
+				if tableFilter != nil {
+					ok, err := tableFilter(row)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil // Skip this row
+					}
 				}
 			}
 		}
 
 		// For covering index scans, filters still need to be applied
 		// (all filter columns are guaranteed to be in the index).
-		if scan.CoveringIndex && len(scan.Filters) > 0 {
-			ok, err := scan.FilterRow(row)
+		if scan.CoveringIndex && coveringFilter != nil {
+			ok, err := coveringFilter(row)
 			if err != nil {
 				return err
 			}
@@ -858,6 +866,9 @@ func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, 
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
 	}
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	coveringFilter := compileScanFilter(scan.IndexColumns, scan.Filters)
 
 	// Scan index within range (forward or reverse)
 	if err := idx.ScanRange(ctx, scan.RangeCondition, aPlan.SortReverse, func(key any, rowID RowID) error {
@@ -878,26 +889,28 @@ func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, 
 				row.Key = rowID
 			} else {
 				var err error
-				row, err = cursor.fetchRow(ctx, false, selectedFields...)
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
 				if err != nil {
 					return fmt.Errorf("fetch row failed: %w", err)
 				}
 
 				// Apply remaining filters
-				ok, err := scan.FilterRow(row)
-				if err != nil {
-					return err
-				}
-				if !ok {
-					return nil // Skip this row
+				if tableFilter != nil {
+					ok, err := tableFilter(row)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil // Skip this row
+					}
 				}
 			}
 		}
 
 		// For covering index scans, filters still need to be applied
 		// (all filter columns are guaranteed to be in the index).
-		if scan.CoveringIndex && len(scan.Filters) > 0 {
-			ok, err := scan.FilterRow(row)
+		if scan.CoveringIndex && coveringFilter != nil {
+			ok, err := coveringFilter(row)
 			if err != nil {
 				return err
 			}
@@ -922,6 +935,9 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
 	}
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	coveringFilter := compileScanFilter(scan.IndexColumns, scan.Filters)
 
 	// Lookup each primary key value
 	for _, indexValue := range scan.IndexKeys {
@@ -952,25 +968,27 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 				}
 
 				// Fetch the row
-				row, err = cursor.fetchRow(ctx, false, selectedFields...)
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
 				if err != nil {
 					return fmt.Errorf("fetch row failed: %w", err)
 				}
 
 				// Apply remaining filters
-				ok, err := scan.FilterRow(row)
-				if err != nil {
-					return err
-				}
-				if !ok {
-					continue // Skip this row
+				if tableFilter != nil {
+					ok, err := tableFilter(row)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						continue // Skip this row
+					}
 				}
 			}
 
 			// For covering index scans, filters still need to be applied
 			// (all filter columns are guaranteed to be in the index).
-			if scan.CoveringIndex && len(scan.Filters) > 0 {
-				ok, err := scan.FilterRow(row)
+			if scan.CoveringIndex && coveringFilter != nil {
+				ok, err := coveringFilter(row)
 				if err != nil {
 					return err
 				}
@@ -1004,6 +1022,7 @@ func (t *Table) indexEndpointScan(ctx context.Context, scan Scan, selectedFields
 	if !ok {
 		return fmt.Errorf("no index found for endpoint scan: %s", scan.IndexName)
 	}
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
 
 	err := idx.ScanAll(ctx, reverse, func(key any, rowID RowID) error {
 		var row Row
@@ -1021,7 +1040,7 @@ func (t *Table) indexEndpointScan(ctx context.Context, scan Scan, selectedFields
 				row = NewRowWithValues(t.Columns, nil)
 				row.Key = rowID
 			} else {
-				row, err = cursor.fetchRow(ctx, false, selectedFields...)
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
 				if err != nil {
 					return fmt.Errorf("fetch row failed: %w", err)
 				}
@@ -1173,6 +1192,8 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	if err != nil {
 		return err
 	}
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
 
 	page, err := t.pager.ReadPage(ctx, cursor.PageIdx)
 	if err != nil {
@@ -1185,18 +1206,20 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 			return err
 		}
 
-		row, err := cursor.fetchRow(ctx, true, selectedFields...)
+		row, err := cursor.fetchRowWithMask(ctx, true, selectedMask)
 		if err != nil {
 			return err
 		}
 
 		// Apply remaining filters
-		ok, err := scan.FilterRow(row)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			continue // Skip this row
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue // Skip this row
+			}
 		}
 
 		if err := out(row); err != nil {
@@ -1205,4 +1228,17 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	}
 
 	return nil
+}
+
+func compileScanFilter(columns []Column, filters OneOrMore) func(Row) (bool, error) {
+	if len(filters) == 0 {
+		return nil
+	}
+	columnIndexes := make(map[string]int, len(columns))
+	for i := range columns {
+		columnIndexes[columns[i].Name] = i
+	}
+	return func(row Row) (bool, error) {
+		return row.CheckOneOrMoreWithColumnIndexes(filters, columnIndexes)
+	}
 }

--- a/internal/minisql/select_test.go
+++ b/internal/minisql/select_test.go
@@ -528,6 +528,34 @@ func TestTable_Select(t *testing.T) {
 	})
 }
 
+func TestCompileScanFilter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil when no filters", func(t *testing.T) {
+		f := compileScanFilter(testColumns, nil)
+		assert.Nil(t, f)
+	})
+
+	t.Run("evaluates with precompiled column indexes", func(t *testing.T) {
+		row := gen.Row()
+		filters := OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandInteger, Value: row.Values[0].Value.(int64)},
+				},
+			},
+		}
+		f := compileScanFilter(testColumns, filters)
+		require.NotNil(t, f)
+
+		ok, err := f(row)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
 func TestTable_Select_Overflow(t *testing.T) {
 	table, txManager, _ := newTestTable(t, testOverflowColumns)
 	var (


### PR DESCRIPTION
Various performance improvements:
- Make non-LIMIT simple selects stream instead of materializing full []Row.
- Avoid Row.OnlyFields per-row allocation in hot scan paths.
- Decode only needed columns in Unmarshal using precomputed selected-column mask/index map.
- Precompile WHERE condition evaluators per statement to cut per-row dynamic/type-switch overhead.
