### PR TITLE
refactor: async auto checkpoint, row conversion path cleanup

### DIFF
--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -169,6 +169,11 @@ func (d *Database) PrepareStatement(ctx context.Context, query string) (Statemen
 
 // Close flushes and closes the underlying page storage.
 func (d *Database) Close() error {
+	// Prevent background auto-checkpoint goroutines from racing with close.
+	if d.txManager != nil {
+		d.txManager.StopAutoCheckpoint()
+	}
+
 	// Passive checkpoint on close (mirrors SQLite behaviour): if there are
 	// committed WAL frames that have not yet been written to the DB file, flush
 	// them now so the DB file is a complete snapshot.  This limits WAL growth
@@ -208,6 +213,11 @@ func (d *Database) Checkpoint(_ context.Context) error {
 
 // Reopen replaces the pager and transaction manager with fresh instances backed by the given factory and saver.
 func (d *Database) Reopen(ctx context.Context, factory PagerFactory, saver PageSaver) error {
+	// Stop any background auto-checkpoint work tied to the old saver/file.
+	if d.txManager != nil {
+		d.txManager.StopAutoCheckpoint()
+	}
+
 	d.factory = factory
 	d.saver = saver
 	d.tables = make(map[string]*Table)

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,6 +35,9 @@ type TransactionManager struct {
 	walIndex            *WALIndex
 	checkpointThreshold int          // auto-checkpoint after this many WAL frames (0 = disabled)
 	checkpointFn        func() error // called by runAutoCheckpoint; set via SetCheckpointFunc
+	autoCheckpointBusy  atomic.Bool  // true while an async auto-checkpoint is running
+	autoCheckpointStop  atomic.Bool  // true after shutdown; prevents new auto-checkpoints
+	autoCheckpointWG    sync.WaitGroup
 	factory             TxPagerFactory
 	saver               PageSaver
 	ddlSaver            DDLSaver
@@ -67,6 +71,13 @@ func NewTransactionManager(logger *zap.Logger, dbFilePath string, factory TxPage
 // Database.Checkpoint so the auto-checkpoint path mirrors the manual one.
 func (tm *TransactionManager) SetCheckpointFunc(fn func() error) {
 	tm.checkpointFn = fn
+}
+
+// StopAutoCheckpoint prevents new asynchronous auto-checkpoints from starting
+// and waits for any in-flight auto-checkpoint to finish.
+func (tm *TransactionManager) StopAutoCheckpoint() {
+	tm.autoCheckpointStop.Store(true)
+	tm.autoCheckpointWG.Wait()
 }
 
 // CheckpointWAL checkpoints the WAL into dbFile, then truncates it.
@@ -505,22 +516,43 @@ func (tm *TransactionManager) serializePage0ForWAL(ctx context.Context, page0 *P
 }
 
 // runAutoCheckpoint triggers a WAL checkpoint when the frame count exceeds the
-// configured threshold.  The checkpoint is performed via checkpointFn (set by
-// SetCheckpointFunc).  If no function is registered the call is a no-op.
+// configured threshold. The checkpoint runs asynchronously via checkpointFn
+// (set by SetCheckpointFunc), and at most one auto-checkpoint may run at a
+// time. If no function is registered the call is a no-op.
+//
 // Failures are logged but do not propagate — the commit already succeeded.
 func (tm *TransactionManager) runAutoCheckpoint(_ context.Context) {
 	if tm.checkpointThreshold <= 0 || tm.wal == nil || tm.checkpointFn == nil {
 		return
 	}
-	if tm.wal.FrameCount() < int64(tm.checkpointThreshold) {
+	if tm.autoCheckpointStop.Load() {
 		return
 	}
-	if err := tm.checkpointFn(); err != nil {
-		tm.logger.Warn("WAL auto-checkpoint failed",
-			zap.Int64("frame_count", tm.wal.FrameCount()),
-			zap.Int("threshold", tm.checkpointThreshold),
-			zap.Error(err))
+	frameCount := tm.wal.FrameCount()
+	if frameCount < int64(tm.checkpointThreshold) {
+		return
 	}
+
+	// Keep commit path non-blocking and avoid concurrent checkpoint storms.
+	if !tm.autoCheckpointBusy.CompareAndSwap(false, true) {
+		return
+	}
+
+	checkpointFn := tm.checkpointFn
+	tm.autoCheckpointWG.Add(1)
+	go func(triggerFrameCount int64) {
+		defer tm.autoCheckpointWG.Done()
+		defer tm.autoCheckpointBusy.Store(false)
+		if tm.autoCheckpointStop.Load() {
+			return
+		}
+		if err := checkpointFn(); err != nil {
+			tm.logger.Warn("WAL auto-checkpoint failed",
+				zap.Int64("frame_count", triggerFrameCount),
+				zap.Int("threshold", tm.checkpointThreshold),
+				zap.Error(err))
+		}
+	}(frameCount)
 }
 
 // RollbackTransaction aborts the transaction and discards all in-memory changes.

--- a/internal/minisql/transaction_manager_test.go
+++ b/internal/minisql/transaction_manager_test.go
@@ -3,7 +3,9 @@ package minisql
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -406,6 +408,67 @@ func TestTransactionManager_WAL_Commit(t *testing.T) {
 		assert.Equal(t, int64(1), env.wal.FrameCount())
 
 		mock.AssertExpectationsForObjects(t, env.saverMock)
+	})
+
+	t.Run("Auto-checkpoint runs asynchronously and single-flight", func(t *testing.T) {
+		t.Parallel()
+
+		env := newWALCommitEnv(t)
+		ctx := context.Background()
+
+		env.txManager.checkpointThreshold = 1
+
+		started := make(chan struct{}, 1)
+		release := make(chan struct{})
+		var checkpointCalls atomic.Int32
+		env.txManager.SetCheckpointFunc(func() error {
+			checkpointCalls.Add(1)
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		})
+
+		makeWriteTx := func(pageIdx PageIndex) *Transaction {
+			tx := env.txManager.BeginTransaction(ctx)
+			tx.WriteSet[pageIdx] = WriteInfo{
+				Page:  &Page{Index: pageIdx, LeafNode: NewLeafNode()},
+				Table: "t",
+				Index: "pk_t",
+			}
+			env.saverMock.On("SavePage", ctx, pageIdx, tx.WriteSet[pageIdx].Page).Return(nil).Once()
+			return tx
+		}
+
+		// First commit should return even though checkpoint function is blocked.
+		tx1 := makeWriteTx(10)
+		done1 := make(chan error, 1)
+		go func() {
+			done1 <- env.txManager.CommitTransaction(ctx, tx1)
+		}()
+
+		select {
+		case <-started:
+		case <-time.After(1 * time.Second):
+			t.Fatal("auto-checkpoint did not start")
+		}
+
+		select {
+		case err := <-done1:
+			require.NoError(t, err)
+		case <-time.After(1 * time.Second):
+			t.Fatal("commit blocked waiting for auto-checkpoint")
+		}
+
+		// While first checkpoint is still running, a second commit should not start
+		// another checkpoint.
+		tx2 := makeWriteTx(11)
+		require.NoError(t, env.txManager.CommitTransaction(ctx, tx2))
+		assert.Equal(t, int32(1), checkpointCalls.Load(), "auto-checkpoint should be single-flight")
+
+		close(release)
 	})
 }
 

--- a/rows.go
+++ b/rows.go
@@ -20,16 +20,16 @@ type Rows struct {
 // columns of the result is inferred from the length of the
 // slice. If a particular column name isn't known, an empty
 // string should be returned for that entry.
-func (r Rows) Columns() []string {
-	names := make([]string, 0, len(r.columns))
-	for _, aColumn := range r.columns {
-		names = append(names, aColumn.Name)
+func (r *Rows) Columns() []string {
+	names := make([]string, len(r.columns))
+	for i, col := range r.columns {
+		names[i] = col.Name
 	}
 	return names
 }
 
 // Close closes the rows iterator.
-func (r Rows) Close() error {
+func (r *Rows) Close() error {
 	return r.iter.Close()
 }
 
@@ -42,7 +42,7 @@ func (r Rows) Close() error {
 // The dest should not be written to outside of Next. Care
 // should be taken when closing Rows not to modify
 // a buffer held in dest.
-func (r Rows) Next(dest []driver.Value) error {
+func (r *Rows) Next(dest []driver.Value) error {
 	if !r.iter.Next(r.ctx) {
 		if err := r.iter.Err(); err != nil {
 			return err
@@ -50,23 +50,24 @@ func (r Rows) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
-	aRow := r.iter.Row()
-	if len(aRow.Values) != len(dest) {
-		return fmt.Errorf("expected %d values, got %d", len(dest), len(aRow.Values))
+	row := r.iter.Row()
+	if len(row.Values) != len(dest) {
+		return fmt.Errorf("expected %d values, got %d", len(dest), len(row.Values))
 	}
 
 	for i := range dest {
-		if !aRow.Values[i].Valid {
+		if !row.Values[i].Valid {
 			dest[i] = nil
 			continue
 		}
-		switch v := aRow.Values[i].Value.(type) {
+
+		switch v := row.Values[i].Value.(type) {
 		case minisql.TextPointer:
-			dest[i] = string(v.Data)
+			dest[i] = v.String()
 		case minisql.Time:
 			dest[i] = v.GoTime()
 		default:
-			dest[i] = aRow.Values[i].Value
+			dest[i] = row.Values[i].Value
 		}
 	}
 


### PR DESCRIPTION
Async auto-checkpoint (commit path no longer blocks)
- runAutoCheckpoint now runs checkpoint in a background goroutine.
- Added single-flight guard so only one auto-checkpoint runs at a time.
- Added lifecycle safety:
  - StopAutoCheckpoint() on TransactionManager
  - called from Database.Close() and Database.Reopen() to prevent background checkpoint races during shutdown/reopen.

Row conversion path cleanup
- Updated Rows methods to pointer receivers (*Rows) to avoid unnecessary struct copying on hot path.
- Kept robust value-type conversion in Next() (TextPointer/Time) to preserve e2e compatibility.
- Minor Columns() allocation cleanup.