### PR TITLE
refactor: optimising write paths

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,34 @@
+### 2026-04-22 (latest)
+
+`AppendCells` pre-growth + `Clone` extra capacity + `insert.go` fieldPositions map elimination:
+- `IndexNode.AppendCells`: replaced per-cell `NewIndexCell`+append loop with a single bulk pre-grow, eliminating O(N) slice reallocations when many cells are moved at once (common during B+ tree splits/merges).
+- `IndexNode.Clone`: allocate `Header.Keys+4` capacity instead of exact `Header.Keys`, so `splitChild` median-key append and `AppendCells` don't immediately trigger a reallocation.
+- `insert.go`: eliminated `fieldPositions` map when `prepareInsert` has been called (detected by `len(values) == len(t.Columns)`); falls back to map for direct-call paths (tests).
+
+The `AppendCells` and `Clone` changes benefit the delete and update paths heavily — delete rebalancing (`merge`/`fill`/`borrowFromLeft/Right`) moves many cells at once, previously triggering repeated slice reallocations.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 81.5 µs/op | 88.3 µs/op | **0.9×** |
+| Insert_SingleRow | 70.1 µs/op | 41.5 µs/op | 1.7× |
+| Insert_Batch | 590.0 µs/op | 222.0 µs/op | 2.7× |
+| Select_PointScan | 4.5 µs/op | 3.3 µs/op | 1.4× |
+| Select_Limit | 7.5 µs/op | 7.8 µs/op | 1.0× |
+| Select_FullScan | 5.1 ms/op | 5.1 ms/op | 1.0× |
+| Select_CountStar | 33.7 µs/op | 9.7 µs/op | 3.5× |
+| Select_IndexRangeScan | 722.0 µs/op | 736.0 µs/op | 1.0× |
+| Select_RangeScan | 2.83 ms/op | 869.0 µs/op | 3.3× |
+| Txn_NInserts | 343.0 µs/op | 137.6 µs/op | 2.5× |
+| Update_ByPK | 51.5 µs/op | 62.0 µs/op | **0.8×** |
+
+#### Memory (B/op)
+
+_(not measured this run)_
+
+---
+
 ### 2026-04-22 00:42 UTC
 
 #### Timing

--- a/internal/minisql/index_node.go
+++ b/internal/minisql/index_node.go
@@ -509,10 +509,18 @@ func (n *IndexNode[T]) PrependCell(cell IndexCell[T]) {
 
 // AppendCells ...
 func (n *IndexNode[T]) AppendCells(cells ...IndexCell[T]) {
-	for _, cell := range cells {
-		if len(n.Cells) <= int(n.Header.Keys) {
-			n.Cells = append(n.Cells, NewIndexCell[T](n.Cells[0].unique))
+	needed := int(n.Header.Keys) + len(cells)
+	if needed > len(n.Cells) {
+		// Grow the slice in one shot instead of one cell at a time.
+		n.Cells = append(n.Cells, make([]IndexCell[T], needed-len(n.Cells))...)
+		if len(n.Cells) > 0 {
+			unique := n.Cells[0].unique
+			for i := int(n.Header.Keys); i < len(n.Cells); i++ {
+				n.Cells[i].unique = unique
+			}
 		}
+	}
+	for _, cell := range cells {
 		n.Cells[n.Header.Keys] = cell
 		n.Header.Keys += 1
 	}
@@ -551,7 +559,10 @@ func (n *IndexNode[T]) Clone() *IndexNode[T] {
 	if n.Header.Keys == 0 {
 		return nodeCopy
 	}
-	nodeCopy.Cells = make([]IndexCell[T], n.Header.Keys)
+	// Allocate a few extra slots so that splitChild (which appends one median key
+	// to the parent) and AppendCells (which appends up to rightCount cells to the
+	// new right child) don't immediately trigger a slice reallocation.
+	nodeCopy.Cells = make([]IndexCell[T], n.Header.Keys, n.Header.Keys+4)
 	for i := range n.Header.Keys {
 		nodeCopy.Cells[i] = n.Cells[i].Clone()
 	}

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -22,24 +22,9 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	// Build a field-name → values-index map once for the whole Insert call.
-	//
-	// After prepareInsert, stmt.Fields covers every table column (in some order)
-	// followed by any ON CONFLICT DO UPDATE SET fields.  The values slice for each
-	// row only covers the insert portion (len == len(t.Columns)).  We cap the map
-	// at len(values) to exclude the update fields whose indices would be out of
-	// range for values.
-	//
-	// The map lets us assemble row.Values in column order with one O(C) pass per
-	// row instead of an O(C²) nested scan.
-	nInsertFields := len(t.Columns) // same as len(values) after prepareInsert
-	fieldPositions := make(map[string]int, nInsertFields)
-	for i, f := range stmt.Fields {
-		if i >= nInsertFields {
-			break // stop before any appended DO UPDATE fields
-		}
-		fieldPositions[f.Name] = i
-	}
+	// After prepareInsert, stmt.Fields[i].Name == t.Columns[i].Name for i < len(t.Columns),
+	// so stmt.Inserts[insertIdx][i] directly corresponds to t.Columns[i].
+	// No map is needed — values[i] is already the value for t.Columns[i].
 
 	rowsInserted := 0
 	for insertIdx, values := range stmt.Inserts {
@@ -119,14 +104,24 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 			}
 		}
 
-		// Build row values in column order using the pre-computed field-position map.
-		// One allocation (the rowValues slice) and O(C) map lookups.
+		// Assemble row values in table-column order.
+		// Fast path: after prepareInsert, values[i] == value for t.Columns[i] — just copy.
+		// Slow path: direct Insert call without prepareInsert — use field-name lookup.
 		rowValues := make([]OptionalValue, len(t.Columns))
-		for i, col := range t.Columns {
-			if fi, ok := fieldPositions[col.Name]; ok {
-				rowValues[i] = values[fi]
+		if len(values) == len(t.Columns) {
+			// prepareInsert was called; values are already in column order.
+			copy(rowValues, values)
+		} else {
+			// Direct call without prepareInsert; resolve by field name.
+			fieldPositions := make(map[string]int, len(stmt.Fields))
+			for i, f := range stmt.Fields {
+				fieldPositions[f.Name] = i
 			}
-			// else: leave as OptionalValue{} = NULL (zero value)
+			for i, col := range t.Columns {
+				if fi, ok := fieldPositions[col.Name]; ok && fi < len(values) {
+					rowValues[i] = values[fi]
+				}
+			}
 		}
 		row := NewRowWithValues(t.Columns, rowValues)
 


### PR DESCRIPTION
`AppendCells` pre-growth + `Clone` extra capacity + `insert.go` fieldPositions map elimination:
- `IndexNode.AppendCells`: replaced per-cell `NewIndexCell`+append loop with a single bulk pre-grow, eliminating O(N) slice reallocations when many cells are moved at once (common during B+ tree splits/merges).
- `IndexNode.Clone`: allocate `Header.Keys+4` capacity instead of exact `Header.Keys`, so `splitChild` median-key append and `AppendCells` don't immediately trigger a reallocation.
- `insert.go`: eliminated `fieldPositions` map when `prepareInsert` has been called (detected by `len(values) == len(t.Columns)`); falls back to map for direct-call paths (tests).

The `AppendCells` and `Clone` changes benefit the delete and update paths heavily — delete rebalancing (`merge`/`fill`/`borrowFromLeft/Right`) moves many cells at once, previously triggering repeated slice reallocations.