### PR TITLE
refactor: implement proper READ COMITTED transaction isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-MiniSQL is an embedded, single-file SQL database written in Go, inspired by SQLite. It implements a hand-written state-machine SQL parser, a B+ tree storage engine with 4 KB pages, an LRU page cache, a Write-Ahead Log (WAL) for crash recovery, and optimistic concurrency control (OCC). It registers itself as a `database/sql` driver.
+MiniSQL is an embedded, single-file SQL database written in Go, inspired by SQLite. It implements a hand-written state-machine SQL parser, a B+ tree storage engine with 4 KB pages, an LRU page cache, a Write-Ahead Log (WAL) for crash recovery, optimistic concurrency control (OCC) for write transactions, and in-memory MVCC snapshot isolation for read-only transactions. It registers itself as a `database/sql` driver.
 
 **Module:** `github.com/RichardKnop/minisql`
 **Go version:** 1.26
@@ -41,7 +41,7 @@ MiniSQL is an embedded, single-file SQL database written in Go, inspired by SQLi
 │   │   ├── pager.go        # In-memory page cache + LRU eviction
 │   │   ├── page.go         # Page: LeafNode / InternalNode / OverflowPage
 │   │   ├── transaction.go  # Transaction struct + context helpers
-│   │   ├── transaction_manager.go  # OCC manager: read-set tracking, conflict detection
+│   │   ├── transaction_manager.go  # OCC (write txns) + MVCC snapshot isolation (read-only txns)
 │   │   ├── index.go        # B+ tree index (primary, unique, secondary)
 │   │   ├── cursor.go       # Row cursor for B+ tree traversal
 │   │   ├── wal.go          # Write-Ahead Log: append frames, replay, checkpoint
@@ -496,9 +496,21 @@ When adding filtering/transformation stages, insert them as goroutines between `
 
 ### Transactions
 
-- Read operations: call `txPager.ReadPage()` — tracked in the read-set.
-- Write operations: call `txPager.ModifyPage()` — page is copied into the write-set.
-- All Table methods run inside a transaction context supplied by `TransactionManager.ExecuteInTransaction`.
+MiniSQL uses two complementary concurrency mechanisms:
+
+**Write transactions — Optimistic Concurrency Control (OCC)**
+- `txPager.ReadPage()` captures the global page version *before* reading the LRU cache (important: version is read first to avoid a TOCTOU race with concurrent commits), then records it in the read-set.
+- `txPager.ModifyPage()` clones the page into the write-set.  It also performs early conflict detection: if the page was previously read and the global version has advanced since then, it returns `ErrTxConflict` immediately rather than waiting for commit-time validation.
+- At commit time, each read-set version is checked against the current global page version; any mismatch returns `ErrTxConflict`.
+- All Table methods run inside a write transaction context supplied by `TransactionManager.ExecuteInTransaction`.
+
+**Read-only transactions — Snapshot Isolation (MVCC)**
+- `BeginReadOnlyTransaction` captures `tm.commitSeq` as the transaction's `SnapshotSeq` (under `tm.mu` to prevent races with concurrent commits).
+- `ReadPage` for read-only transactions checks `pageLastCommittedSeq[pageIdx]` against `tx.SnapshotSeq`. If the cached page was committed after the snapshot, it retrieves the historical version from `pageVersionHistory` instead.
+- At write commit time, the pre-modification page (`WriteInfo.OriginalPage`) is saved in `pageVersionHistory` with `validUntilSeq = commitSeq - 1` if any snapshot readers need it.
+- `trimPageVersionHistoryLocked` GC's historical versions no longer needed by any active reader (called on each commit/rollback).
+- Checkpoint (WAL truncation) is blocked while snapshot readers are active (`ErrCheckpointBlockedByReaders`).
+- Use `ExecuteReadOnlyTransaction` for the read-only wrapper; `BeginReadOnlyTransaction` + `CommitTransaction` manually if you need the snapshot seq.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,24 +132,38 @@ Notes:
 
 ## Concurrency
 
-MiniSQL uses `Optimistic Concurrency Control` or `OCC`. It is close to PostgreSQL's [SERIALIZABLE isolation](https://www.postgresql.org/docs/current/transaction-iso.html#XACT-SERIALIZABLE) Transaction manager follows a simple process:
+MiniSQL implements two complementary concurrency control mechanisms:
 
-1. Track read versions - Record which version of each page was read
-2. Check at commit time - Verify no pages were modified during the transaction
-3. Abort on conflict - If a page changed, abort with ErrTxConflict
+### Write Transactions — Optimistic Concurrency Control (OCC)
 
-You can use `ErrTxConflict` to control whether to retry because of a tx serialization error or to return error.
+Write transactions use `Optimistic Concurrency Control`. The transaction manager follows a simple process:
 
-SQlite uses a `snapshot isolation` with `MVCC` (`Multi-Version Concurrency Control`). Read how [SQLite handles isolation](https://sqlite.org/isolation.html). I have chosen a basic OCC model for now for its simplicity.
+1. Track read versions — Record the page version at the time each page is first read (captured before the LRU cache read to avoid TOCTOU races with concurrent commits).
+2. Check at commit time — Verify no pages were modified between the first read and the commit.
+3. Abort on conflict — If any tracked page has a newer version at commit time, abort with `ErrTxConflict`.
 
-Example of a snapshot isolation:
+You can use `ErrTxConflict` to decide whether to retry or surface the error to the caller.
+
+### Read-Only Transactions — Snapshot Isolation (MVCC)
+
+Read-only transactions use in-memory `MVCC` (`Multi-Version Concurrency Control`) to provide snapshot isolation: a reader sees the database exactly as it was at the moment `BeginReadOnlyTransaction` was called, regardless of writes that commit afterward.
+
+This is similar to how [SQLite handles isolation](https://sqlite.org/isolation.html). Under the hood:
+
+- A monotonically increasing `commitSeq` counter is incremented on every write commit.
+- Each read-only transaction captures the current `commitSeq` as its `SnapshotSeq` at start time.
+- At write commit time, the pre-modification copy of each modified page is saved in an in-memory version history (`pageVersionHistory`).
+- When a snapshot reader accesses a page whose cached version is newer than its `SnapshotSeq`, it retrieves the appropriate historical version from the version history.
+- Historical versions are garbage-collected once all snapshot readers that needed them have committed.
 
 ```
-Time 0: Read TX1 starts, sees version V1
-Time 1: Write TX2 modifies page and commits → creates version V2
-Time 2: TX1 continues reading, still sees V1 (not V2!)
-Time 3: TX1 completes successfully
+Time 0: Read TX1 starts — SnapshotSeq = 1
+Time 1: Write TX2 modifies page, commits — commitSeq advances to 2; old page saved in version history
+Time 2: TX1 reads the page → sees the historical version at seq 1, not TX2's change
+Time 3: TX1 commits; version history for seq 1 is GC'd
 ```
+
+Checkpoint (WAL truncation) is blocked while any snapshot reader is active, since old page versions are held only in the in-memory version history rather than the WAL.
 
 ## System Table
 

--- a/internal/minisql/snapshot_isolation_test.go
+++ b/internal/minisql/snapshot_isolation_test.go
@@ -1,0 +1,365 @@
+package minisql
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotColumns are a minimal column set used by all snapshot isolation tests.
+var snapshotColumns = []Column{
+	{Kind: Int8, Size: 8, Name: "id"},
+	{Kind: Varchar, Size: MaxInlineVarchar, Name: "name", Nullable: true},
+}
+
+// insertSnapshotRow inserts a single row (id, name) into table inside a new transaction.
+func insertSnapshotRow(
+	ctx context.Context,
+	t *testing.T,
+	table *Table,
+	txManager *TransactionManager,
+	id int64,
+	name string,
+) {
+	t.Helper()
+	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := table.Insert(ctx, Statement{
+			Kind:      Insert,
+			TableName: table.Name,
+			Columns:   snapshotColumns,
+			Fields:    fieldsFromColumns(snapshotColumns...),
+			Inserts: [][]OptionalValue{
+				{
+					{Value: id, Valid: true},
+					{Value: NewTextPointer([]byte(name)), Valid: true},
+				},
+			},
+		})
+		return err
+	})
+	require.NoError(t, err)
+}
+
+// selectAllSnapshot executes a full-table SELECT within the given context (which must
+// carry a transaction) and returns all rows.
+func selectAllSnapshot(
+	ctx context.Context,
+	t *testing.T,
+	table *Table,
+) []Row {
+	t.Helper()
+	stmt := Statement{
+		Kind:      Select,
+		TableName: table.Name,
+		Columns:   snapshotColumns,
+		Fields:    fieldsFromColumns(snapshotColumns...),
+	}
+	result, err := table.Select(ctx, stmt)
+	require.NoError(t, err)
+	var rows []Row
+	for result.Rows.Next(ctx) {
+		rows = append(rows, result.Rows.Row())
+	}
+	require.NoError(t, result.Rows.Err())
+	return rows
+}
+
+// TestSnapshotIsolation_ReadDoesNotSeeWriteAfterStart verifies the primary
+// invariant: a read-only transaction started at snapshot seq N cannot observe
+// a write that commits at seq N+1.
+func TestSnapshotIsolation_ReadDoesNotSeeWriteAfterStart(t *testing.T) {
+	table, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	// Pre-populate one row so the table has at least one leaf page.
+	insertSnapshotRow(ctx, t, table, txManager, 1, "alice")
+
+	// Start a read-only transaction (snapshot seq = 1 after the first insert).
+	readTx := txManager.BeginReadOnlyTransaction(ctx)
+	readCtx := WithTransaction(ctx, readTx)
+
+	snapshotSeq := readTx.SnapshotSeq
+	assert.Equal(t, uint64(1), txManager.commitSeq, "expected one commit so far")
+	assert.Equal(t, uint64(1), snapshotSeq)
+
+	// Write a second row AFTER the read transaction started.
+	insertSnapshotRow(ctx, t, table, txManager, 2, "bob")
+	assert.Equal(t, uint64(2), txManager.commitSeq, "commit seq must advance after write")
+
+	// The read transaction should see only "alice" (the row that existed at snapshot time).
+	rows := selectAllSnapshot(readCtx, t, table)
+	assert.Len(t, rows, 1, "snapshot reader must not see write committed after it started")
+	if len(rows) == 1 {
+		assert.Equal(t, int64(1), rows[0].Values[0].Value)
+	}
+
+	// Commit the read transaction — must always succeed.
+	err := txManager.CommitTransaction(ctx, readTx)
+	require.NoError(t, err)
+
+	// A new read transaction started after the write must see both rows.
+	newReadTx := txManager.BeginReadOnlyTransaction(ctx)
+	newReadCtx := WithTransaction(ctx, newReadTx)
+	assert.Equal(t, uint64(2), newReadTx.SnapshotSeq)
+
+	rows = selectAllSnapshot(newReadCtx, t, table)
+	assert.Len(t, rows, 2, "new snapshot reader must see all committed rows")
+
+	require.NoError(t, txManager.CommitTransaction(ctx, newReadTx))
+}
+
+// TestSnapshotIsolation_MultipleSnapshots verifies that three concurrent
+// readers each see only the rows committed before their respective snapshots.
+func TestSnapshotIsolation_MultipleSnapshots(t *testing.T) {
+	table, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	insertSnapshotRow(ctx, t, table, txManager, 1, "alice") // commitSeq=1
+
+	// Reader A starts after 1 commit — snapshot seq 1.
+	readerA := txManager.BeginReadOnlyTransaction(ctx)
+	ctxA := WithTransaction(ctx, readerA)
+	assert.Equal(t, uint64(1), readerA.SnapshotSeq)
+
+	insertSnapshotRow(ctx, t, table, txManager, 2, "bob") // commitSeq=2
+
+	// Reader B starts after 2 commits — snapshot seq 2.
+	readerB := txManager.BeginReadOnlyTransaction(ctx)
+	ctxB := WithTransaction(ctx, readerB)
+	assert.Equal(t, uint64(2), readerB.SnapshotSeq)
+
+	insertSnapshotRow(ctx, t, table, txManager, 3, "carol") // commitSeq=3
+
+	// Reader C starts after 3 commits — snapshot seq 3.
+	readerC := txManager.BeginReadOnlyTransaction(ctx)
+	ctxC := WithTransaction(ctx, readerC)
+	assert.Equal(t, uint64(3), readerC.SnapshotSeq)
+
+	// Verify each reader sees only the rows committed at or before its snapshot.
+	rowsA := selectAllSnapshot(ctxA, t, table)
+	assert.Len(t, rowsA, 1, "reader A: only alice")
+
+	rowsB := selectAllSnapshot(ctxB, t, table)
+	assert.Len(t, rowsB, 2, "reader B: alice + bob")
+
+	rowsC := selectAllSnapshot(ctxC, t, table)
+	assert.Len(t, rowsC, 3, "reader C: alice + bob + carol")
+
+	// Commit all three in reverse order — all must succeed without conflict.
+	require.NoError(t, txManager.CommitTransaction(ctx, readerC))
+	require.NoError(t, txManager.CommitTransaction(ctx, readerB))
+	require.NoError(t, txManager.CommitTransaction(ctx, readerA))
+}
+
+// TestSnapshotIsolation_VersionHistoryGC verifies that page version history is
+// freed once all snapshot readers have committed.
+func TestSnapshotIsolation_VersionHistoryGC(t *testing.T) {
+	table, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	insertSnapshotRow(ctx, t, table, txManager, 1, "alice") // commitSeq=1
+
+	readTx := txManager.BeginReadOnlyTransaction(ctx)
+
+	// Insert a second row while the read transaction is open.  This should
+	// populate the version history for the modified leaf page.
+	insertSnapshotRow(ctx, t, table, txManager, 2, "bob") // commitSeq=2
+
+	txManager.mu.RLock()
+	historySize := len(txManager.pageVersionHistory)
+	txManager.mu.RUnlock()
+	assert.Greater(t, historySize, 0, "version history must be populated while reader is active")
+
+	// After the read transaction commits, version history must be cleared.
+	require.NoError(t, txManager.CommitTransaction(ctx, readTx))
+
+	txManager.mu.RLock()
+	historySize = len(txManager.pageVersionHistory)
+	txManager.mu.RUnlock()
+	assert.Equal(t, 0, historySize, "version history must be empty after all readers commit")
+}
+
+// TestSnapshotIsolation_CheckpointBlockedByReader verifies that CheckpointWAL
+// returns ErrCheckpointBlockedByReaders while a snapshot reader is active and
+// succeeds once the reader has committed.
+func TestSnapshotIsolation_CheckpointBlockedByReader(t *testing.T) {
+	env := newWALCommitEnv(t)
+	ctx := context.Background()
+
+	// Commit a write so there is something to checkpoint.
+	writeTx := env.txManager.BeginTransaction(ctx)
+	writeTx.WriteSet[2] = WriteInfo{
+		Page:  &Page{Index: PageIndex(2), LeafNode: NewLeafNode()},
+		Table: "t",
+	}
+	env.saverMock.On("SavePage", ctx, PageIndex(2), writeTx.WriteSet[2].Page).Return(nil).Once()
+	require.NoError(t, env.txManager.CommitTransaction(ctx, writeTx))
+
+	// Open a snapshot reader.
+	readTx := env.txManager.BeginReadOnlyTransaction(ctx)
+	assert.True(t, env.txManager.hasActiveSnapshotReadersLocked(), "must have active reader")
+
+	// Checkpoint must be blocked.
+	err := env.txManager.CheckpointWAL(env.dbFile)
+	assert.ErrorIs(t, err, ErrCheckpointBlockedByReaders)
+
+	// After the reader commits, checkpoint must succeed.
+	require.NoError(t, env.txManager.CommitTransaction(ctx, readTx))
+
+	err = env.txManager.CheckpointWAL(env.dbFile)
+	require.NoError(t, err)
+
+	env.saverMock.AssertExpectations(t)
+}
+
+// TestSnapshotIsolation_ConcurrentReadWrite verifies that concurrent reads and
+// writes do not race.  Run with -race to detect data races.
+func TestSnapshotIsolation_ConcurrentReadWrite(t *testing.T) {
+	table, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	// Seed the table.
+	insertSnapshotRow(ctx, t, table, txManager, 1, "seed")
+
+	const (
+		readers = 4
+		writers = 4
+		rounds  = 10
+	)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, readers*rounds+writers*rounds)
+
+	// Concurrent readers.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				err := txManager.ExecuteReadOnlyTransaction(ctx, func(rCtx context.Context) error {
+					selectAllSnapshot(rCtx, t, table)
+					return nil
+				})
+				if err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+
+	// Concurrent writers.  We allow ErrTxConflict (two writers collide) but
+	// not any other error.
+	nextID := int64(100)
+	var idMu sync.Mutex
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				idMu.Lock()
+				id := nextID
+				nextID++
+				idMu.Unlock()
+
+				err := txManager.ExecuteInTransaction(ctx, func(wCtx context.Context) error {
+					_, err := table.Insert(wCtx, Statement{
+						Kind:      Insert,
+						TableName: table.Name,
+						Columns:   snapshotColumns,
+						Fields:    fieldsFromColumns(snapshotColumns...),
+						Inserts: [][]OptionalValue{
+							{
+								{Value: id, Valid: true},
+								{Value: NewTextPointer([]byte("concurrent")), Valid: true},
+							},
+						},
+					})
+					return err
+				})
+				if err != nil && !errors.Is(err, ErrTxConflict) {
+					errs <- err
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// TestSnapshotIsolation_SnapshotSeqMonotonic verifies that SnapshotSeq values
+// are monotonically non-decreasing: a transaction started later never gets a
+// smaller snapshot seq than one started earlier.
+func TestSnapshotIsolation_SnapshotSeqMonotonic(t *testing.T) {
+	_, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	const n = 20
+	txs := make([]*Transaction, n)
+	for i := range txs {
+		txs[i] = txManager.BeginReadOnlyTransaction(ctx)
+	}
+
+	for i := 1; i < n; i++ {
+		assert.GreaterOrEqual(t, txs[i].SnapshotSeq, txs[i-1].SnapshotSeq,
+			"snapshot seq must be non-decreasing")
+	}
+
+	for _, tx := range txs {
+		require.NoError(t, txManager.CommitTransaction(ctx, tx))
+	}
+}
+
+// TestSnapshotIsolation_minActiveSnapshotSeqLocked verifies the helper logic
+// directly, including the MaxUint64 sentinel when no readers are active.
+func TestSnapshotIsolation_minActiveSnapshotSeqLocked(t *testing.T) {
+	_, txManager, _ := newTestTable(t, snapshotColumns)
+	ctx := context.Background()
+
+	// No readers: must return MaxUint64.
+	txManager.mu.Lock()
+	got := txManager.minActiveSnapshotSeqLocked()
+	txManager.mu.Unlock()
+	assert.Equal(t, uint64(math.MaxUint64), got)
+
+	// One reader at seq 0.
+	tx1 := txManager.BeginReadOnlyTransaction(ctx)
+	assert.Equal(t, uint64(0), tx1.SnapshotSeq)
+
+	txManager.mu.Lock()
+	got = txManager.minActiveSnapshotSeqLocked()
+	txManager.mu.Unlock()
+	assert.Equal(t, uint64(0), got)
+
+	// Second reader at seq 0 (no writes in between).
+	tx2 := txManager.BeginReadOnlyTransaction(ctx)
+	assert.Equal(t, uint64(0), tx2.SnapshotSeq)
+
+	txManager.mu.Lock()
+	got = txManager.minActiveSnapshotSeqLocked()
+	txManager.mu.Unlock()
+	assert.Equal(t, uint64(0), got)
+
+	// Commit tx1; min is still 0 (tx2 is still open at seq 0).
+	require.NoError(t, txManager.CommitTransaction(ctx, tx1))
+	txManager.mu.Lock()
+	got = txManager.minActiveSnapshotSeqLocked()
+	txManager.mu.Unlock()
+	assert.Equal(t, uint64(0), got)
+
+	// Commit tx2; no readers → MaxUint64.
+	require.NoError(t, txManager.CommitTransaction(ctx, tx2))
+	txManager.mu.Lock()
+	got = txManager.minActiveSnapshotSeqLocked()
+	txManager.mu.Unlock()
+	assert.Equal(t, uint64(math.MaxUint64), got)
+}

--- a/internal/minisql/transaction.go
+++ b/internal/minisql/transaction.go
@@ -38,8 +38,9 @@ type TransactionID uint64
 // WriteInfo holds a modified page together with the table and index names it belongs to.
 type WriteInfo struct {
 	*Page
-	Table string
-	Index string
+	Table        string
+	Index        string
+	OriginalPage *Page // page as it was before modification; nil for newly-allocated pages
 }
 
 // Transaction tracks the read and write sets for optimistic concurrency control.
@@ -57,7 +58,11 @@ type Transaction struct {
 	// skipped at commit time.  This eliminates per-page map writes and mutex
 	// acquisitions on read-heavy queries (e.g. COUNT(*), full-table scans).
 	ReadOnly bool
-	mu       sync.RWMutex
+	// SnapshotSeq is the value of TransactionManager.commitSeq at the moment
+	// this read-only transaction was registered.  Any write committed after
+	// this point is invisible to the transaction.  Always 0 for write transactions.
+	SnapshotSeq uint64
+	mu          sync.RWMutex
 }
 
 // TransactionStatus represents the lifecycle state of a transaction.
@@ -100,14 +105,18 @@ func (tx *Transaction) TrackRead(pageIdx PageIndex, version uint64) {
 }
 
 // TrackWrite records a modified page in the transaction write set.
-func (tx *Transaction) TrackWrite(pageIdx PageIndex, page *Page, table, index string) {
+// originalPage is the page as it was before modification; it is stored for
+// MVCC snapshot reads and must not be nil for pages that existed prior to
+// this transaction (use nil for newly-allocated pages).
+func (tx *Transaction) TrackWrite(pageIdx PageIndex, page, originalPage *Page, table, index string) {
 	tx.mu.Lock()
 	defer tx.mu.Unlock()
 
 	tx.WriteSet[pageIdx] = WriteInfo{
-		Page:  page,
-		Table: table,
-		Index: index,
+		Page:         page,
+		Table:        table,
+		Index:        index,
+		OriginalPage: originalPage,
 	}
 }
 
@@ -129,6 +138,18 @@ func (tx *Transaction) TrackDBHeaderWrite(header DatabaseHeader) {
 	defer tx.mu.Unlock()
 
 	tx.DBHeaderWrite = &header
+}
+
+// GetReadVersion returns the version recorded when the given page was read, if any.
+func (tx *Transaction) GetReadVersion(pageIdx PageIndex) (uint64, bool) {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+
+	if tx.ReadSet == nil {
+		return 0, false
+	}
+	v, ok := tx.ReadSet[pageIdx]
+	return v, ok
 }
 
 // GetReadVersions returns a copy of the page read-version map.

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 )
+
+// pageVersion is one historical snapshot of a page stored in the version
+// history for MVCC snapshot isolation.  It is valid for read transactions
+// whose SnapshotSeq <= validUntilSeq.
+type pageVersion struct {
+	validUntilSeq uint64
+	page          *Page
+}
 
 // pageDataPool is a package-level pool for PageSize-byte slices used during WAL
 // serialization. A single pool is shared across all TransactionManagers (there
@@ -28,6 +37,24 @@ type TransactionManager struct {
 	globalDBHeaderVersion uint64
 	logger                *zap.Logger
 	dbFilePath            string
+
+	// MVCC snapshot isolation fields.
+	//
+	// commitSeq is a monotonically increasing counter incremented on every write
+	// commit.  Read-only transactions record their SnapshotSeq = commitSeq at
+	// Begin time; writes committed after that point are invisible to them.
+	//
+	// pageLastCommittedSeq tracks the commitSeq at which each page was last
+	// written to the shared page cache (via SavePage).  ReadPage compares this
+	// against tx.SnapshotSeq to decide whether the cached version is safe to use.
+	//
+	// pageVersionHistory stores old *Page versions for active snapshot readers.
+	// Each entry is valid for reads where snapshotSeq <= entry.validUntilSeq.
+	// Entries are GC'd when no active reader needs them any more.
+	commitSeq            uint64
+	pageLastCommittedSeq map[PageIndex]uint64
+	pageVersionHistory   map[PageIndex][]pageVersion
+
 	// WAL fields (non-nil when a WAL is configured)
 	walWriteMu          sync.Mutex // serialises WAL appends — only one writer at a time
 	wal                 *WAL
@@ -51,14 +78,16 @@ const (
 // NewTransactionManager creates and returns a new TransactionManager.
 func NewTransactionManager(logger *zap.Logger, dbFilePath string, factory TxPagerFactory, saver PageSaver, ddlSaver DDLSaver) *TransactionManager {
 	return &TransactionManager{
-		nextTxID:           1,
-		transactions:       make(map[TransactionID]*Transaction),
-		globalPageVersions: make(map[PageIndex]uint64),
-		logger:             logger,
-		factory:            factory,
-		dbFilePath:         dbFilePath,
-		saver:              saver,
-		ddlSaver:           ddlSaver,
+		nextTxID:             1,
+		transactions:         make(map[TransactionID]*Transaction),
+		globalPageVersions:   make(map[PageIndex]uint64),
+		pageLastCommittedSeq: make(map[PageIndex]uint64),
+		pageVersionHistory:   make(map[PageIndex][]pageVersion),
+		logger:               logger,
+		factory:              factory,
+		dbFilePath:           dbFilePath,
+		saver:                saver,
+		ddlSaver:             ddlSaver,
 	}
 }
 
@@ -79,9 +108,22 @@ func (tm *TransactionManager) SetCheckpointFunc(fn func() error) {
 //  4. Reset the in-memory WAL index (under tm.mu).
 //
 // Returns ErrNotWALMode if no WAL is configured.
+// Returns ErrCheckpointBlockedByReaders if any read-only snapshot transaction
+// is currently active.  Callers should retry after the readers have finished.
 func (tm *TransactionManager) CheckpointWAL(dbFile DBFile) error {
 	if tm.wal == nil {
 		return ErrNotWALMode
+	}
+
+	// Block the checkpoint while snapshot readers are active.  After a successful
+	// checkpoint the WAL index is reset and the DB file holds the latest version,
+	// so any reader that started before this checkpoint could see wrong data if
+	// we proceeded.
+	tm.mu.RLock()
+	blocked := tm.hasActiveSnapshotReadersLocked()
+	tm.mu.RUnlock()
+	if blocked {
+		return ErrCheckpointBlockedByReaders
 	}
 
 	tm.walWriteMu.Lock()
@@ -184,17 +226,146 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context) *Transaction
 	return tx
 }
 
-// BeginReadOnlyTransaction starts a read-only transaction.  TrackRead calls
-// are no-ops, so the ReadSet is never allocated.  Conflict validation is
-// skipped at commit time.  Use this for SELECT queries.
+// BeginReadOnlyTransaction starts a read-only transaction with snapshot
+// isolation.  The transaction sees a consistent snapshot of the database as
+// of the moment it begins: any write committed after this call is invisible
+// to it.  TrackRead calls are no-ops; conflict validation is skipped at
+// commit time.  Read-only transactions never return ErrTxConflict.
+//
+// SnapshotSeq is captured inside tm.mu so it is atomic with the transaction
+// registration — preventing a race where a write commits between the map
+// insert and the seq capture.
 func (tm *TransactionManager) BeginReadOnlyTransaction(ctx context.Context) *Transaction {
-	tx := tm.BeginTransaction(ctx)
-	tx.ReadOnly = true
+	tm.mu.Lock()
+	tx := &Transaction{
+		ID:          tm.nextTxID,
+		StartTime:   time.Now(),
+		WriteSet:    make(map[PageIndex]WriteInfo),
+		Status:      TxActive,
+		ReadOnly:    true,
+		SnapshotSeq: tm.commitSeq,
+	}
+	tm.nextTxID++
+	tm.transactions[tx.ID] = tx
+	tm.mu.Unlock()
+
+	tm.logger.Debug("begin read-only transaction",
+		zap.Uint64("tx_id", uint64(tx.ID)),
+		zap.Uint64("snapshot_seq", tx.SnapshotSeq),
+	)
 	return tx
 }
 
 // ErrTxConflict is returned when an optimistic concurrency check fails at commit time.
 var ErrTxConflict = errors.New("transaction conflict detected")
+
+// ErrCheckpointBlockedByReaders is returned when a checkpoint cannot proceed
+// because one or more read-only transactions hold snapshots that predate the
+// current commitSeq.  Callers should retry after the readers have finished.
+var ErrCheckpointBlockedByReaders = errors.New("checkpoint blocked: active snapshot readers")
+
+// ---- MVCC helpers ----
+
+// minActiveSnapshotSeqLocked returns the minimum SnapshotSeq across all active
+// read-only transactions, or math.MaxUint64 when none exist.
+// Caller must hold tm.mu (read or write lock).
+func (tm *TransactionManager) minActiveSnapshotSeqLocked() uint64 {
+	minSeq := uint64(math.MaxUint64)
+	for _, tx := range tm.transactions {
+		if tx.ReadOnly && tx.Status == TxActive && tx.SnapshotSeq < minSeq {
+			minSeq = tx.SnapshotSeq
+		}
+	}
+	return minSeq
+}
+
+// hasActiveSnapshotReadersLocked reports whether any read-only transaction is
+// currently active.  Caller must hold tm.mu (read or write lock).
+func (tm *TransactionManager) hasActiveSnapshotReadersLocked() bool {
+	for _, tx := range tm.transactions {
+		if tx.ReadOnly && tx.Status == TxActive {
+			return true
+		}
+	}
+	return false
+}
+
+// appendPageVersionLocked adds an old page snapshot to the version history for
+// pageIdx.  validUntilSeq is the highest SnapshotSeq for which this version
+// should be served (i.e., the commitSeq of the write that replaced it minus 1).
+// Entries are appended in monotonically increasing validUntilSeq order because
+// commits are serialised.  Caller must hold tm.mu write lock.
+func (tm *TransactionManager) appendPageVersionLocked(pageIdx PageIndex, validUntilSeq uint64, page *Page) {
+	tm.pageVersionHistory[pageIdx] = append(tm.pageVersionHistory[pageIdx], pageVersion{
+		validUntilSeq: validUntilSeq,
+		page:          page,
+	})
+}
+
+// trimPageVersionHistoryLocked removes version-history entries that are no
+// longer needed by any active snapshot reader.  Should be called after a
+// transaction is removed from tm.transactions.  Caller must hold tm.mu write lock.
+func (tm *TransactionManager) trimPageVersionHistoryLocked() {
+	minSnap := tm.minActiveSnapshotSeqLocked()
+	if minSnap == math.MaxUint64 {
+		// No active readers — discard all history immediately.
+		tm.pageVersionHistory = make(map[PageIndex][]pageVersion)
+		return
+	}
+	// Remove entries whose validUntilSeq is strictly less than minSnap: every
+	// active reader has SnapshotSeq >= minSnap, so they will never need a version
+	// that was superseded before minSnap.
+	for pageIdx, versions := range tm.pageVersionHistory {
+		lo := 0
+		for lo < len(versions) && versions[lo].validUntilSeq < minSnap {
+			lo++
+		}
+		if lo > 0 {
+			tm.pageVersionHistory[pageIdx] = versions[lo:]
+		}
+	}
+}
+
+// PageLastCommittedSeq returns the commitSeq at which pageIdx was last updated
+// in the shared page cache.  Used by ReadPage to decide whether the cached
+// version is safe to serve to a snapshot reader.
+func (tm *TransactionManager) PageLastCommittedSeq(pageIdx PageIndex) uint64 {
+	tm.mu.RLock()
+	seq := tm.pageLastCommittedSeq[pageIdx]
+	tm.mu.RUnlock()
+	return seq
+}
+
+// PageVersionAtSnapshot returns the *Page that was current for the given
+// snapshotSeq by binary-searching the version history.  ok is false when no
+// suitable entry exists (page either predates any WAL write or was newly
+// allocated after the snapshot).
+func (tm *TransactionManager) PageVersionAtSnapshot(pageIdx PageIndex, snapshotSeq uint64) (*Page, bool) {
+	tm.mu.RLock()
+	versions := tm.pageVersionHistory[pageIdx]
+	tm.mu.RUnlock()
+
+	if len(versions) == 0 {
+		return nil, false
+	}
+
+	// Versions are ordered by validUntilSeq ascending.  We want the entry with
+	// the smallest validUntilSeq that is still >= snapshotSeq — that is the
+	// version which was current at snapshotSeq.
+	lo, hi := 0, len(versions)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if versions[mid].validUntilSeq < snapshotSeq {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	if lo < len(versions) {
+		return versions[lo].page, true
+	}
+	return nil, false
+}
 
 // CommitTransaction validates the write set for conflicts and, if clean, persists all changes.
 // When a WAL is configured it uses the WAL commit path; otherwise it writes directly to the pager
@@ -237,9 +408,15 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 	if isReadOnly {
 		tx.Commit()
 		delete(tm.transactions, tx.ID)
+		tm.trimPageVersionHistoryLocked()
 		tm.logger.Debug("commit read-only transaction", zap.Uint64("tx_id", uint64(tx.ID)))
 		return nil
 	}
+
+	// Advance the commit sequence for MVCC snapshot isolation.
+	tm.commitSeq++
+	newSeq := tm.commitSeq
+	minSnap := tm.minActiveSnapshotSeqLocked()
 
 	pagesToFlush := make([]PageIndex, 0, len(tx.WriteSet)+1)
 
@@ -249,9 +426,15 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 		tm.globalDBHeaderVersion += 1
 		pagesToFlush = append(pagesToFlush, 0)
 	}
-	// Apply page writes.
+	// Apply page writes.  For each page, save the old version into the history
+	// before overwriting the cache so active snapshot readers can still see the
+	// pre-commit state.
 	for pageIdx, info := range writeInfos {
+		if minSnap < newSeq && info.OriginalPage != nil {
+			tm.appendPageVersionLocked(pageIdx, newSeq-1, info.OriginalPage)
+		}
 		tm.saver.SavePage(ctx, pageIdx, info.Page)
+		tm.pageLastCommittedSeq[pageIdx] = newSeq
 		tm.globalPageVersions[pageIdx] += 1
 		pagesToFlush = append(pagesToFlush, pageIdx)
 	}
@@ -321,6 +504,7 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 		}
 		tx.Commit()
 		delete(tm.transactions, tx.ID)
+		tm.trimPageVersionHistoryLocked()
 		tm.mu.Unlock()
 		tm.logger.Debug("commit read-only transaction (WAL)", zap.Uint64("tx_id", uint64(tx.ID)))
 		return nil
@@ -381,8 +565,16 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 		tm.saver.SaveHeader(ctx, *header)
 		tm.globalDBHeaderVersion++
 	}
+	// Advance commit sequence and save old page versions for snapshot readers.
+	tm.commitSeq++
+	newSeq := tm.commitSeq
+	minSnap := tm.minActiveSnapshotSeqLocked()
 	for pageIdx, info := range writeInfos {
+		if minSnap < newSeq && info.OriginalPage != nil {
+			tm.appendPageVersionLocked(pageIdx, newSeq-1, info.OriginalPage)
+		}
 		tm.saver.SavePage(ctx, pageIdx, info.Page)
+		tm.pageLastCommittedSeq[pageIdx] = newSeq
 		tm.globalPageVersions[pageIdx] += 1
 	}
 	if tx.DDLChanges.HasChanges() {
@@ -506,8 +698,10 @@ func (tm *TransactionManager) serializePage0ForWAL(ctx context.Context, page0 *P
 
 // runAutoCheckpoint triggers a WAL checkpoint when the frame count exceeds the
 // configured threshold.  The checkpoint is performed via checkpointFn (set by
-// SetCheckpointFunc).  If no function is registered the call is a no-op.
-// Failures are logged but do not propagate — the commit already succeeded.
+// SetCheckpointFunc).  If no function is registered, or if snapshot readers
+// are active, the call is a no-op (the checkpoint will be attempted on the
+// next commit once the readers have finished).  Failures are logged but do not
+// propagate — the commit already succeeded.
 func (tm *TransactionManager) runAutoCheckpoint(_ context.Context) {
 	if tm.checkpointThreshold <= 0 || tm.wal == nil || tm.checkpointFn == nil {
 		return
@@ -515,11 +709,22 @@ func (tm *TransactionManager) runAutoCheckpoint(_ context.Context) {
 	if tm.wal.FrameCount() < int64(tm.checkpointThreshold) {
 		return
 	}
+	// Skip if snapshot readers are active; they will be unblocked by the next
+	// commit that reduces minActiveSnapshotSeq.
+	tm.mu.RLock()
+	blocked := tm.hasActiveSnapshotReadersLocked()
+	tm.mu.RUnlock()
+	if blocked {
+		tm.logger.Debug("auto-checkpoint deferred: active snapshot readers")
+		return
+	}
 	if err := tm.checkpointFn(); err != nil {
-		tm.logger.Warn("WAL auto-checkpoint failed",
-			zap.Int64("frame_count", tm.wal.FrameCount()),
-			zap.Int("threshold", tm.checkpointThreshold),
-			zap.Error(err))
+		if !errors.Is(err, ErrCheckpointBlockedByReaders) {
+			tm.logger.Warn("WAL auto-checkpoint failed",
+				zap.Int64("frame_count", tm.wal.FrameCount()),
+				zap.Int("threshold", tm.checkpointThreshold),
+				zap.Error(err))
+		}
 	}
 }
 
@@ -527,9 +732,10 @@ func (tm *TransactionManager) runAutoCheckpoint(_ context.Context) {
 func (tm *TransactionManager) RollbackTransaction(ctx context.Context, tx *Transaction) {
 	tx.Abort()
 
-	// Clean up transaction
+	// Clean up transaction and GC any version history that is no longer needed.
 	tm.mu.Lock()
 	delete(tm.transactions, tx.ID)
+	tm.trimPageVersionHistoryLocked()
 	tm.mu.Unlock()
 
 	tm.logger.Debug("rollback transaction", zap.Uint64("tx_id", uint64(tx.ID)))

--- a/internal/minisql/transaction_manager_test.go
+++ b/internal/minisql/transaction_manager_test.go
@@ -73,6 +73,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 			&Page{Index: PageIndex(4)},
 			"users",
 			"pk_users",
+			nil,
 		}
 
 		// Setup expectations
@@ -127,6 +128,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 			&Page{Index: PageIndex(3), LeafNode: NewLeafNode()},
 			"orders",
 			"pk_orders",
+			nil,
 		}
 
 		// Setup expectations
@@ -184,6 +186,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 			&Page{Index: PageIndex(4)},
 			"orders",
 			"pk_orders",
+			nil,
 		}
 
 		// Second tx will modify the same page to cause conflict
@@ -192,6 +195,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 			&Page{Index: PageIndex(4)},
 			"orders",
 			"pk_orders",
+			nil,
 		}
 
 		// Setup expectations
@@ -248,6 +252,7 @@ func TestTransactionManager_Rollback(t *testing.T) {
 		&Page{Index: PageIndex(4)},
 		"users",
 		"",
+		nil,
 	}
 
 	txManager.RollbackTransaction(ctx, tx)

--- a/internal/minisql/transaction_pager.go
+++ b/internal/minisql/transaction_pager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // TransactionalPager wraps a base Pager and routes reads and writes through the current transaction.
@@ -24,6 +26,18 @@ func NewTransactionalPager(basePager Pager, txManager *TransactionManager, table
 }
 
 // ReadPage returns the page at pageIdx, returning the in-progress write copy if it exists.
+//
+// For read-only (snapshot) transactions the method enforces snapshot isolation:
+//   - If the page was last committed at or before tx.SnapshotSeq, the shared
+//     page cache is safe to use — no concurrent write has touched it since the
+//     snapshot started.
+//   - Otherwise the method retrieves the historical version from the
+//     TransactionManager's page-version history (saved at commit time by the
+//     writer that superseded the page).
+//   - If no historical version is found (the page was newly allocated after
+//     the snapshot), the cached version is returned as a safe fallback; this
+//     should not occur during normal B+ tree traversal because pre-snapshot
+//     pointer chains never reference post-snapshot pages.
 func (tp *TransactionalPager) ReadPage(ctx context.Context, pageIdx PageIndex) (*Page, error) {
 	tx := TxFromContext(ctx)
 	if tx == nil {
@@ -31,10 +45,22 @@ func (tp *TransactionalPager) ReadPage(ctx context.Context, pageIdx PageIndex) (
 		return tp.GetPage(ctx, pageIdx)
 	}
 
-	// Check if we have a modified version in our write set
-	modifiedPage, exists := tx.GetModifiedPage(pageIdx)
-	if exists {
+	// Check if we have a modified version in our write set (always empty for read-only txns)
+	if modifiedPage, exists := tx.GetModifiedPage(pageIdx); exists {
 		return modifiedPage, nil
+	}
+
+	// For write transactions the page version must be captured BEFORE reading
+	// the page content from the LRU cache to avoid a TOCTOU race: if a commit
+	// lands between GetPage (pager mutex) and GlobalPageVersion (txManager
+	// mutex), we would record a version that is newer than the page content we
+	// actually read.  By snapshotting the version first, any interleaved commit
+	// causes readVersion < the post-commit version seen at ModifyPage time,
+	// which the OCC check will catch.  Read-only transactions skip this to
+	// avoid the mutex acquisition (the version is never used for them).
+	var readVersion uint64
+	if !tx.ReadOnly {
+		readVersion = tp.txManager.GlobalPageVersion(ctx, pageIdx)
 	}
 
 	page, err := tp.GetPage(ctx, pageIdx)
@@ -42,13 +68,34 @@ func (tp *TransactionalPager) ReadPage(ctx context.Context, pageIdx PageIndex) (
 		return nil, err
 	}
 
-	// TrackRead is a no-op for read-only transactions, so skip the GlobalPageVersion
-	// mutex acquisition entirely — it would compute a value that is immediately discarded.
 	if !tx.ReadOnly {
-		currentVersion := tp.txManager.GlobalPageVersion(ctx, pageIdx)
-		tx.TrackRead(pageIdx, currentVersion)
+		tx.TrackRead(pageIdx, readVersion)
+		return page, nil
 	}
 
+	// Read-only snapshot path: check whether the cached version is safe for
+	// this snapshot.
+	lastCommitted := tp.txManager.PageLastCommittedSeq(pageIdx)
+	if lastCommitted <= tx.SnapshotSeq {
+		// The cache was last updated at or before our snapshot — safe to use.
+		return page, nil
+	}
+
+	// The cache is newer than our snapshot.  Retrieve the historical version.
+	if historical, ok := tp.txManager.PageVersionAtSnapshot(pageIdx, tx.SnapshotSeq); ok {
+		return historical, nil
+	}
+
+	// No historical version found.  This can only happen for pages that were
+	// newly allocated (by a split, overflow, or free-list add) after our snapshot
+	// started.  Under correct snapshot pointer-following the caller should never
+	// reach a post-snapshot page, but if it does we return the cache version as a
+	// best-effort fallback and log a warning so it can be investigated.
+	tp.txManager.logger.Warn("snapshot gap: no historical version for page, using cache",
+		zap.Uint64("page_idx", uint64(pageIdx)),
+		zap.Uint64("snapshot_seq", tx.SnapshotSeq),
+		zap.Uint64("last_committed_seq", lastCommitted),
+	)
 	return page, nil
 }
 
@@ -71,9 +118,24 @@ func (tp *TransactionalPager) ModifyPage(ctx context.Context, pageIdx PageIndex)
 		return nil, err
 	}
 
-	// Create a deep copy for modification
+	// Early conflict detection: if this page was already read by this transaction
+	// and the page has since been updated by a concurrent commit, fail fast with
+	// ErrTxConflict rather than letting the stale cursor position produce a
+	// confusing "duplicate key" error later.
+	if !tx.ReadOnly {
+		if readVersion, ok := tx.GetReadVersion(pageIdx); ok {
+			currentVersion := tp.txManager.GlobalPageVersion(ctx, pageIdx)
+			if currentVersion != readVersion {
+				return nil, ErrTxConflict
+			}
+		}
+	}
+
+	// Create a deep copy for modification.  Keep a reference to originalPage so
+	// the transaction manager can store it in the version history at commit time
+	// for any concurrent snapshot readers.
 	modifiedPage = originalPage.Clone()
-	tx.TrackWrite(pageIdx, modifiedPage, tp.table, tp.index)
+	tx.TrackWrite(pageIdx, modifiedPage, originalPage, tp.table, tp.index)
 
 	return modifiedPage, nil
 }


### PR DESCRIPTION
Implement proper Snapshot Isolation (MVCC) for read only transactions. Write transactions use OCC (optimistic concurrency control).

**Write transactions — Optimistic Concurrency Control (OCC)**
- `txPager.ReadPage()` captures the global page version *before* reading the LRU cache (important: version is read first to avoid a TOCTOU race with concurrent commits), then records it in the read-set.
- `txPager.ModifyPage()` clones the page into the write-set.  It also performs early conflict detection: if the page was previously read and the global version has advanced since then, it returns `ErrTxConflict` immediately rather than waiting for commit-time validation.
- At commit time, each read-set version is checked against the current global page version; any mismatch returns `ErrTxConflict`.
- All Table methods run inside a write transaction context supplied by `TransactionManager.ExecuteInTransaction`.

**Read-only transactions — Snapshot Isolation (MVCC)**
- `BeginReadOnlyTransaction` captures `tm.commitSeq` as the transaction's `SnapshotSeq` (under `tm.mu` to prevent races with concurrent commits).
- `ReadPage` for read-only transactions checks `pageLastCommittedSeq[pageIdx]` against `tx.SnapshotSeq`. If the cached page was committed after the snapshot, it retrieves the historical version from `pageVersionHistory` instead.
- At write commit time, the pre-modification page (`WriteInfo.OriginalPage`) is saved in `pageVersionHistory` with `validUntilSeq = commitSeq - 1` if any snapshot readers need it.
- `trimPageVersionHistoryLocked` GC's historical versions no longer needed by any active reader (called on each commit/rollback).
- Checkpoint (WAL truncation) is blocked while snapshot readers are active (`ErrCheckpointBlockedByReaders`).
- Use `ExecuteReadOnlyTransaction` for the read-only wrapper; `BeginReadOnlyTransaction` + `CommitTransaction` manually if you need the snapshot seq.