### PR TITLE
feat: add in memory row count for fast select count start

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,46 @@
+### 2026-04-25 (latest)
+
+O(1) COUNT(*) via in-memory row-count cache:
+- Added `rowCounts map[string]int64` to `Database`, one entry per user table. Initialised at startup from a single leaf-page walk per table; kept up to date on every committed INSERT/DELETE via a `rowCountApplier` callback on `TransactionManager`.
+- `Transaction` accumulates `rowCountDeltas` during execution; applied atomically at commit time, discarded on rollback. DO UPDATE upserts (which replace an existing row) are correctly excluded from the delta.
+- `countAllLeafWalk` in `select.go` now returns the cached count in O(1) when the getter is set; falls back to the original leaf walk for system tables and any table without an initialised counter.
+- **Select_CountStar: 36.9 µs → 20.0 µs (1.84× faster)** — ratio vs SQLite drops from 3.14× to 1.87×. The remaining gap is the Go query framework overhead (transaction begin/end, SQL parsing, result marshalling) — not the counting itself.
+- Note: this benchmark run exhibited higher machine variance than usual (one Insert_SingleRow/sqlite outlier at 111 µs, one Delete_ByPK/minisql outlier at 160 µs); write-path numbers should be compared with the previous entry's cleaner run rather than taken at face value here.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 76.6 µs/op | 62.5 µs/op | 1.23× |
+| Insert_SingleRow | 94.1 µs/op | 56.0 µs/op | 1.68× |
+| Insert_Batch | 787.7 µs/op | 309.7 µs/op | 2.54× |
+| Select_PointScan | 6.0 µs/op | 4.0 µs/op | 1.49× |
+| Select_Limit | 9.9 µs/op | 10.4 µs/op | **0.95×** |
+| Select_FullScan | 6.94 ms/op | 6.36 ms/op | 1.09× |
+| **Select_CountStar** | **20.0 µs/op** | **10.7 µs/op** | **1.87×** |
+| Select_IndexRangeScan | 948.9 µs/op | 863.4 µs/op | 1.10× |
+| Select_RangeScan | 3.58 ms/op | 1.04 ms/op | 3.44× |
+| Txn_NInserts | 438.9 µs/op | 182.8 µs/op | 2.40× |
+| Update_ByPK | 73.7 µs/op | 53.2 µs/op | 1.39× |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 27.6 KiB | 447 B |
+| Insert_SingleRow | 22.9 KiB | 312 B |
+| Insert_Batch | 360.7 KiB | 31.1 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.5 KiB | 1.7 KiB |
+| Select_FullScan | 5.7 MiB | 1.3 MiB |
+| Select_CountStar | 5.9 KiB | 400 B |
+| Select_IndexRangeScan | 771.4 KiB | 85.9 KiB |
+| Select_RangeScan | 2.0 MiB | 85.9 KiB |
+| Txn_NInserts | 204.4 KiB | 15.9 KiB |
+| Update_ByPK | 9.0 KiB | 263 B |
+
+---
+
 ### 2026-04-24 (latest)
 
 Checkpoint write coalescing in `wal.go` — `WAL.Checkpoint` now sorts page indices and coalesces consecutive runs into a single `WriteAt` call:

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -44,6 +44,10 @@ type Database struct {
 	clock          clock
 	logger         *zap.Logger
 	lockedProvider TableProvider
+	// rowCounts stores the total row count for each user table, kept up to date
+	// by insert/delete operations so that COUNT(*) can be served in O(1).
+	rowCounts   map[string]int64
+	rowCountsMu sync.RWMutex
 }
 
 type clock func() Time
@@ -58,6 +62,7 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 		factory:    factory,
 		saver:      saver,
 		tables:     make(map[string]*Table),
+		rowCounts:  make(map[string]int64),
 		dbLock:     new(sync.RWMutex),
 		stmtCache:  lrucache.New[string](defaultMaxCachedStatements),
 		logger:     logger,
@@ -77,6 +82,7 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 	db.lockedProvider = &lockedTableProvider{db: db}
 
 	db.txManager = NewTransactionManager(logger, dbFilePath, db.pagerFactory, saver, db)
+	db.txManager.SetRowCountApplier(db.applyRowCountDeltas)
 
 	if walCfg != nil {
 		db.wal = walCfg.WAL
@@ -212,6 +218,11 @@ func (d *Database) Reopen(ctx context.Context, factory PagerFactory, saver PageS
 	d.saver = saver
 	d.tables = make(map[string]*Table)
 
+	// Reset the row-count cache; init() will repopulate it via leaf walks.
+	d.rowCountsMu.Lock()
+	d.rowCounts = make(map[string]int64)
+	d.rowCountsMu.Unlock()
+
 	// Preserve WAL settings then create a fresh transaction manager for the new
 	// file.  The old manager's global page versions are no longer valid after a
 	// file swap, and its saver points to the closed old file.
@@ -220,6 +231,7 @@ func (d *Database) Reopen(ctx context.Context, factory PagerFactory, saver PageS
 		checkpointFn        = d.txManager.checkpointFn
 	)
 	d.txManager = NewTransactionManager(d.logger, d.dbFilePath, d.pagerFactory, saver, d)
+	d.txManager.SetRowCountApplier(d.applyRowCountDeltas)
 	if d.wal != nil {
 		d.txManager.wal = d.wal
 		d.txManager.walIndex = d.walIndex
@@ -277,6 +289,57 @@ func (d *Database) pagerFactory(ctx context.Context, tableName, indexName string
 	return d.factory.ForIndex(columns, unique), nil
 }
 
+// applyRowCountDeltas applies committed insert/delete row-count changes to the
+// in-memory cache.  Only entries that already exist in rowCounts (i.e. user
+// tables) are updated; system tables are not tracked and are silently ignored.
+func (d *Database) applyRowCountDeltas(deltas map[string]int64) {
+	d.rowCountsMu.Lock()
+	for name, delta := range deltas {
+		if _, tracked := d.rowCounts[name]; tracked {
+			d.rowCounts[name] += delta
+		}
+	}
+	d.rowCountsMu.Unlock()
+}
+
+// rowCountGetter returns a closure that reads the cached row count for
+// tableName from this Database's rowCounts map.
+func (d *Database) rowCountGetter(tableName string) func() int64 {
+	return func() int64 {
+		d.rowCountsMu.RLock()
+		n := d.rowCounts[tableName]
+		d.rowCountsMu.RUnlock()
+		return n
+	}
+}
+
+// initTableRowCount counts the rows in table via a B+ tree leaf walk and
+// stores the result in d.rowCounts[tableName].  It also wires up the O(1)
+// getter on the table so future COUNT(*) calls bypass the walk entirely.
+func (d *Database) initTableRowCount(ctx context.Context, tableName string, table *Table) {
+	// getRowCount is nil at this point, so countAllLeafWalk falls back to the
+	// leaf walk — exactly what we want for the initial population.
+	result, err := table.countAllLeafWalk(ctx)
+	if err != nil {
+		d.logger.Warn("failed to initialise row count; COUNT(*) will fall back to leaf walk",
+			zap.String("table", tableName), zap.Error(err))
+		return
+	}
+	var count int64
+	if result.Rows.Next(ctx) {
+		row := result.Rows.Row()
+		if len(row.Values) > 0 {
+			if n, ok := row.Values[0].Value.(int64); ok {
+				count = n
+			}
+		}
+	}
+	d.rowCountsMu.Lock()
+	d.rowCounts[tableName] = count
+	d.rowCountsMu.Unlock()
+	table.getRowCount = d.rowCountGetter(tableName)
+}
+
 // SaveDDLChanges applies committed DDL changes (table/index creates and drops) to the in-memory schema.
 func (d *Database) SaveDDLChanges(ctx context.Context, changes DDLChanges) {
 	if !changes.HasChanges() {
@@ -288,9 +351,18 @@ func (d *Database) SaveDDLChanges(ctx context.Context, changes DDLChanges) {
 
 	for _, table := range changes.CreateTables {
 		d.tables[table.Name] = table
+		// New tables start with zero rows.
+		tableName := table.Name
+		d.rowCountsMu.Lock()
+		d.rowCounts[tableName] = 0
+		d.rowCountsMu.Unlock()
+		table.getRowCount = d.rowCountGetter(tableName)
 	}
 	for _, tableName := range changes.DropTables {
 		delete(d.tables, tableName)
+		d.rowCountsMu.Lock()
+		delete(d.rowCounts, tableName)
+		d.rowCountsMu.Unlock()
 	}
 	for tableName, index := range changes.CreateIndexes {
 		d.tables[tableName].SetSecondaryIndex(index.Name, index.Columns, index.Index)
@@ -426,6 +498,10 @@ func (d *Database) init(ctx context.Context) error {
 		case SchemaTable:
 			if err := d.initTable(ctx, schema); err != nil {
 				return err
+			}
+			// Populate row-count cache so COUNT(*) can be answered in O(1).
+			if table, ok := d.tables[schema.Name]; ok {
+				d.initTableRowCount(ctx, schema.Name, table)
 			}
 		case SchemaPrimaryKey:
 			if err := d.initPrimaryKey(ctx, schema); err != nil {

--- a/internal/minisql/delete.go
+++ b/internal/minisql/delete.go
@@ -68,5 +68,13 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 	}
 
 	t.logger.Debug("deleted rows", zap.Int("count", result.RowsAffected))
+
+	// Update the in-memory row-count cache (only for user tables).
+	if t.getRowCount != nil && result.RowsAffected > 0 {
+		if tx := TxFromContext(ctx); tx != nil {
+			tx.AddRowCountDelta(t.Name, -int64(result.RowsAffected))
+		}
+	}
+
 	return result, nil
 }

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -27,6 +27,9 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 	// No map is needed — values[i] is already the value for t.Columns[i].
 
 	rowsInserted := 0
+	// newRowsInserted counts only actual new rows added to the table (not DO UPDATE
+	// hits, which update existing rows without changing the total count).
+	newRowsInserted := 0
 	for insertIdx, values := range stmt.Inserts {
 		switch stmt.ConflictAction {
 		case ConflictActionDoNothing:
@@ -59,6 +62,7 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 				}
 				if changed {
 					rowsInserted += 1
+					// Row count unchanged — DO UPDATE replaces an existing row.
 				}
 				continue
 			}
@@ -152,6 +156,7 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 
 		rowsInserted += 1
+		newRowsInserted += 1
 
 		if insertIdx == len(stmt.Inserts)-1 {
 			break
@@ -179,6 +184,14 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 			if err != nil {
 				return StatementResult{}, err
 			}
+		}
+	}
+
+	// Update the in-memory row-count cache (only for tables that have a getter,
+	// i.e. user tables managed by the Database — system tables are excluded).
+	if t.getRowCount != nil && newRowsInserted > 0 {
+		if tx := TxFromContext(ctx); tx != nil {
+			tx.AddRowCountDelta(t.Name, int64(newRowsInserted))
 		}
 	}
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -157,36 +157,44 @@ func (t *Table) selectCount(rows []Row) (StatementResult, error) {
 	}, nil
 }
 
-// countAllLeafWalk counts every row in the table by walking the B+ tree leaf
-// page chain and summing Header.Cells on each page.  No row data is read or
-// deserialised, making this O(leaf pages) instead of O(rows).
+// countAllLeafWalk counts every row in the table.
+//
+// Fast path: if a row-count getter has been registered (set by the Database
+// after loading the table), returns the cached count in O(1) without any I/O.
+//
+// Fallback: walks the B+ tree leaf page chain and sums Header.Cells on each
+// page — O(leaf pages), no row data read or deserialised.
 //
 // This is only valid for COUNT(*) with no WHERE clause and no JOIN.
 func (t *Table) countAllLeafWalk(ctx context.Context) (StatementResult, error) {
-	cursor, err := t.SeekFirst(ctx)
-	if err != nil {
-		return StatementResult{}, fmt.Errorf("count all: %w", err)
-	}
-
 	var count int64
-	pageIdx := cursor.PageIdx
-	for {
-		select {
-		case <-ctx.Done():
-			return StatementResult{}, ctx.Err()
-		default:
-		}
-
-		page, err := t.pager.ReadPage(ctx, pageIdx)
+	if t.getRowCount != nil {
+		count = t.getRowCount()
+	} else {
+		cursor, err := t.SeekFirst(ctx)
 		if err != nil {
-			return StatementResult{}, fmt.Errorf("count all: read page %d: %w", pageIdx, err)
+			return StatementResult{}, fmt.Errorf("count all: %w", err)
 		}
-		count += int64(page.LeafNode.Header.Cells)
 
-		if page.LeafNode.Header.NextLeaf == 0 {
-			break
+		pageIdx := cursor.PageIdx
+		for {
+			select {
+			case <-ctx.Done():
+				return StatementResult{}, ctx.Err()
+			default:
+			}
+
+			page, err := t.pager.ReadPage(ctx, pageIdx)
+			if err != nil {
+				return StatementResult{}, fmt.Errorf("count all: read page %d: %w", pageIdx, err)
+			}
+			count += int64(page.LeafNode.Header.Cells)
+
+			if page.LeafNode.Header.NextLeaf == 0 {
+				break
+			}
+			pageIdx = page.LeafNode.Header.NextLeaf
 		}
-		pageIdx = page.LeafNode.Header.NextLeaf
 	}
 
 	return StatementResult{

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -25,6 +25,10 @@ type Table struct {
 	txManager            *TransactionManager
 	indexStats           map[string]IndexStats
 	provider             TableProvider // Access to other tables for JOIN operations
+	// getRowCount returns the cached total row count for this table in O(1).
+	// It is nil for system tables and for tables loaded before the row-count
+	// cache has been initialised.  When nil, COUNT(*) falls back to a leaf walk.
+	getRowCount func() int64
 }
 
 // TableOption ...
@@ -48,6 +52,15 @@ func WithUniqueIndex(index UniqueIndex) TableOption {
 func WithSecondaryIndex(index SecondaryIndex) TableOption {
 	return func(t *Table) {
 		t.SecondaryIndexes[index.Name] = index
+	}
+}
+
+// WithRowCountGetter sets an O(1) row-count accessor on the table.
+// When set, COUNT(*) with no WHERE clause returns the value directly
+// instead of performing a leaf-page walk.
+func WithRowCountGetter(fn func() int64) TableOption {
+	return func(t *Table) {
+		t.getRowCount = fn
 	}
 }
 

--- a/internal/minisql/transaction.go
+++ b/internal/minisql/transaction.go
@@ -62,7 +62,11 @@ type Transaction struct {
 	// this read-only transaction was registered.  Any write committed after
 	// this point is invisible to the transaction.  Always 0 for write transactions.
 	SnapshotSeq uint64
-	mu          sync.RWMutex
+	// rowCountDeltas accumulates net row-count changes during this transaction,
+	// keyed by table name.  Applied to the Database row-count cache only on
+	// successful commit; discarded on rollback.
+	rowCountDeltas map[string]int64
+	mu             sync.RWMutex
 }
 
 // TransactionStatus represents the lifecycle state of a transaction.
@@ -88,6 +92,29 @@ func (tx *Transaction) Abort() {
 	tx.Status = TxAborted
 	tx.WriteSet = nil
 	tx.DBHeaderWrite = nil
+	tx.rowCountDeltas = nil
+}
+
+// AddRowCountDelta records a net row-count change for the named table.
+// It is a no-op for read-only transactions.
+func (tx *Transaction) AddRowCountDelta(table string, delta int64) {
+	if tx.ReadOnly || delta == 0 {
+		return
+	}
+	tx.mu.Lock()
+	if tx.rowCountDeltas == nil {
+		tx.rowCountDeltas = make(map[string]int64, 1)
+	}
+	tx.rowCountDeltas[table] += delta
+	tx.mu.Unlock()
+}
+
+// RowCountDeltas returns the accumulated row-count deltas.  The returned map
+// must not be modified by the caller.
+func (tx *Transaction) RowCountDeltas() map[string]int64 {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.rowCountDeltas
 }
 
 // TrackRead records that the given page was read at the given version.

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -65,6 +65,7 @@ type TransactionManager struct {
 	saver               PageSaver
 	ddlSaver            DDLSaver
 	commitHook          func(commitPhase)
+	rowCountApplier     func(map[string]int64) // called after each successful write commit
 }
 
 type commitPhase string
@@ -96,6 +97,14 @@ func NewTransactionManager(logger *zap.Logger, dbFilePath string, factory TxPage
 // Database.Checkpoint so the auto-checkpoint path mirrors the manual one.
 func (tm *TransactionManager) SetCheckpointFunc(fn func() error) {
 	tm.checkpointFn = fn
+}
+
+// SetRowCountApplier registers a callback that is invoked after each
+// successful write commit with the net row-count deltas for the transaction.
+// The Database uses this to keep in-memory row counts up to date so that
+// COUNT(*) queries can be answered in O(1) without a leaf-page walk.
+func (tm *TransactionManager) SetRowCountApplier(fn func(map[string]int64)) {
+	tm.rowCountApplier = fn
 }
 
 // CheckpointWAL checkpoints the WAL into dbFile, then truncates it.
@@ -451,6 +460,11 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 		tm.ddlSaver.SaveDDLChanges(ctx, tx.DDLChanges)
 	}
 
+	if tm.rowCountApplier != nil {
+		if deltas := tx.RowCountDeltas(); len(deltas) > 0 {
+			tm.rowCountApplier(deltas)
+		}
+	}
 	tx.Commit()
 	delete(tm.transactions, tx.ID)
 	tm.logger.Debug("commit transaction", zap.Uint64("tx_id", uint64(tx.ID)))
@@ -579,6 +593,11 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 	}
 	if tx.DDLChanges.HasChanges() {
 		tm.ddlSaver.SaveDDLChanges(ctx, tx.DDLChanges)
+	}
+	if tm.rowCountApplier != nil {
+		if deltas := tx.RowCountDeltas(); len(deltas) > 0 {
+			tm.rowCountApplier(deltas)
+		}
 	}
 	tx.Commit()
 	delete(tm.transactions, tx.ID)


### PR DESCRIPTION
O(1) COUNT(*) via in-memory row-count cache:
- Added `rowCounts map[string]int64` to `Database`, one entry per user table. Initialised at startup from a single leaf-page walk per table; kept up to date on every committed INSERT/DELETE via a `rowCountApplier` callback on `TransactionManager`.
- `Transaction` accumulates `rowCountDeltas` during execution; applied atomically at commit time, discarded on rollback. DO UPDATE upserts (which replace an existing row) are correctly excluded from the delta.
- `countAllLeafWalk` in `select.go` now returns the cached count in O(1) when the getter is set; falls back to the original leaf walk for system tables and any table without an initialised counter.
- **Select_CountStar: 36.9 µs → 20.0 µs (1.84× faster)** — ratio vs SQLite drops from 3.14× to 1.87×. The remaining gap is the Go query framework overhead (transaction begin/end, SQL parsing, result marshalling) — not the counting itself.