### PR TITLE
refactor: two-phase unmarshal / late marerialization

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,52 @@
 ### 2026-04-25 (latest)
 
+Two-phase unmarshal (late materialization) for sequential scan:
+- `sequentialScan` in `select.go` now splits decoding into two phases when a WHERE predicate references a strict subset of the selected columns.
+- Phase 1 decodes only the filter columns and evaluates the predicate. Rows that fail are discarded immediately, skipping all allocations for the remaining (often expensive) columns.
+- Phase 2 decodes the full selected-column set only for rows that pass the predicate. The page is still in the LRU cache at this point, so no extra I/O occurs.
+- Three new helpers in `select.go`: `filterOnlyMask` (builds WHERE-column mask from scan filters), `masksEqual`, `maskHasTrue`.
+- **Select_RangeScan: 3.58 ms → 2.44 ms (1.47× faster)** — ratio vs SQLite: 3.44× → 2.12×. Allocs drop from 46,392 → 21,015 per op (55% fewer); memory 2.0 MiB → 1.68 MiB (16% less).
+- Benchmarks without a WHERE predicate (FullScan, CountStar) and index-based scans (IndexRangeScan, PointScan) are unaffected; their code paths do not enter the two-phase branch.
+- Note: write-path benchmarks (Delete, Insert, Update) show elevated timings in this run due to high machine variance; they are not affected by this change and should be compared against the 2026-04-25 (previous) entry.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| Delete_ByPK | 202 µs/op | 126 µs/op | 1.60× † |
+| Insert_SingleRow | 81.0 µs/op | 50.2 µs/op | 1.61× |
+| Insert_Batch | 748.7 µs/op | 259.3 µs/op | 2.89× |
+| Select_PointScan | 5.8 µs/op | 4.0 µs/op | 1.47× |
+| Select_Limit | 10.1 µs/op | 9.4 µs/op | 1.08× |
+| Select_FullScan | 6.58 ms/op | 6.39 ms/op | 1.03× |
+| Select_CountStar | 20.2 µs/op | 11.8 µs/op | 1.71× |
+| Select_IndexRangeScan | 968.7 µs/op | 982.4 µs/op | **0.99×** |
+| **Select_RangeScan** | **2.44 ms/op** | **1.15 ms/op** | **2.12×** |
+| Txn_NInserts | 417.7 µs/op | 186.8 µs/op | 2.24× |
+| Update_ByPK | 71.1 µs/op | 46.2 µs/op | 1.54× |
+
+† Delete_ByPK and sqlite write-path outliers in first benchmark iteration indicate machine load; use 2026-04-25 (previous) for clean write-path reference.
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 52.4 KiB | 447 B |
+| Insert_SingleRow | 22.8 KiB | 312 B |
+| Insert_Batch | 360.7 KiB | 31.1 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.5 KiB | 1.7 KiB |
+| Select_FullScan | 5.7 MiB | 1.3 MiB |
+| Select_CountStar | 5.9 KiB | 400 B |
+| Select_IndexRangeScan | 774.6 KiB | 85.9 KiB |
+| **Select_RangeScan** | **1.68 MiB** | **85.9 KiB** |
+| Txn_NInserts | 205.2 KiB | 15.8 KiB |
+| Update_ByPK | 9.3 KiB | 263 B |
+
+---
+
+### 2026-04-25 (previous)
+
 O(1) COUNT(*) via in-memory row-count cache:
 - Added `rowCounts map[string]int64` to `Database`, one entry per user table. Initialised at startup from a single leaf-page walk per table; kept up to date on every committed INSERT/DELETE via a `rowCountApplier` callback on `TransactionManager`.
 - `Transaction` accumulates `rowCountDeltas` during execution; applied atomically at commit time, discarded on rollback. DO UPDATE upserts (which replace an existing row) are correctly excluded from the delta.

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1200,8 +1200,21 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	if err != nil {
 		return err
 	}
-	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+
+	fullMask := selectedColumnsMask(t.Columns, selectedFields)
 	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+
+	// Two-phase unmarshal: if the WHERE filter references only a strict subset of the
+	// selected columns, decode just the filter columns in phase 1 and check the
+	// predicate before decoding the remaining (potentially expensive) columns in phase 2.
+	// Rows that fail the predicate are discarded after the cheap phase-1 decode, avoiding
+	// TextPointer / overflow allocations for every non-matching row.
+	filterMask := fullMask
+	twoPhase := tableFilter != nil
+	if twoPhase {
+		filterMask = filterOnlyMask(t.Columns, scan.Filters)
+		twoPhase = maskHasTrue(filterMask) && !masksEqual(filterMask, fullMask)
+	}
 
 	page, err := t.pager.ReadPage(ctx, cursor.PageIdx)
 	if err != nil {
@@ -1214,20 +1227,75 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 			return err
 		}
 
-		row, err := cursor.fetchRowWithMask(ctx, true, selectedMask)
+		if !twoPhase {
+			// ── Single-phase path (original behaviour) ────────────────────────
+			row, err := cursor.fetchRowWithMask(ctx, true, fullMask)
+			if err != nil {
+				return err
+			}
+			if tableFilter != nil {
+				ok, err := tableFilter(row)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+			}
+			if err := out(row); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// ── Two-phase path ────────────────────────────────────────────────────
+		// Re-read page when the cursor crossed a page boundary.
+		if page.Index != cursor.PageIdx {
+			page, err = t.pager.ReadPage(ctx, cursor.PageIdx)
+			if err != nil {
+				return fmt.Errorf("sequential scan: %w", err)
+			}
+		}
+
+		// Snapshot the current cell before advancing the cursor so phase 2
+		// can unmarshal from the same cell without a second ReadPage call.
+		cell := page.LeafNode.Cells[cursor.CellIdx]
+
+		// Advance cursor (mirrors fetchRowWithMask advance logic).
+		switch {
+		case cursor.CellIdx < page.LeafNode.Header.Cells-1:
+			cursor.CellIdx += 1
+		case page.LeafNode.Header.NextLeaf == 0:
+			cursor.EndOfTable = true
+		default:
+			cursor.PageIdx = page.LeafNode.Header.NextLeaf
+			cursor.CellIdx = 0
+		}
+
+		// Phase 1: decode only the columns needed to evaluate the predicate.
+		filterRow := t.newRow()
+		filterRow, err = filterRow.UnmarshalWithMask(cell, filterMask)
 		if err != nil {
 			return err
 		}
 
-		// Apply remaining filters
-		if tableFilter != nil {
-			ok, err := tableFilter(row)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				continue // Skip this row
-			}
+		ok, err := tableFilter(filterRow)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue // Non-matching row: skip the expensive phase-2 decode.
+		}
+
+		// Phase 2: decode all selected columns (cell data is still valid in cache).
+		row := t.newRow()
+		row, err = row.UnmarshalWithMask(cell, fullMask)
+		if err != nil {
+			return err
+		}
+		row, err = row.readOverflowTexts(ctx, t.pager)
+		if err != nil {
+			return fmt.Errorf("sequential scan read overflow: %w", err)
 		}
 
 		if err := out(row); err != nil {
@@ -1236,6 +1304,51 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	}
 
 	return nil
+}
+
+// filterOnlyMask returns a column-selection mask that includes only the columns
+// referenced in the given filter conditions (the WHERE predicate columns).
+func filterOnlyMask(columns []Column, filters OneOrMore) []bool {
+	filterCols := make(map[string]struct{})
+	for _, group := range filters {
+		for _, cond := range group {
+			if cond.Operand1.Type == OperandField {
+				filterCols[cond.Operand1.Value.(Field).Name] = struct{}{}
+			}
+			if cond.Operand2.Type == OperandField {
+				filterCols[cond.Operand2.Value.(Field).Name] = struct{}{}
+			}
+		}
+	}
+	mask := make([]bool, len(columns))
+	for i, col := range columns {
+		_, ok := filterCols[col.Name]
+		mask[i] = ok
+	}
+	return mask
+}
+
+// masksEqual reports whether two column-selection masks are identical.
+func masksEqual(a, b []bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// maskHasTrue reports whether any entry in the mask is true.
+func maskHasTrue(mask []bool) bool {
+	for _, b := range mask {
+		if b {
+			return true
+		}
+	}
+	return false
 }
 
 func compileScanFilter(columns []Column, filters OneOrMore) func(Row) (bool, error) {


### PR DESCRIPTION
Two-phase unmarshal (late materialization) for sequential scan:
- `sequentialScan` in `select.go` now splits decoding into two phases when a WHERE predicate references a strict subset of the selected columns.
- Phase 1 decodes only the filter columns and evaluates the predicate. Rows that fail are discarded immediately, skipping all allocations for the remaining (often expensive) columns.
- Phase 2 decodes the full selected-column set only for rows that pass the predicate. The page is still in the LRU cache at this point, so no extra I/O occurs.
- Three new helpers in `select.go`: `filterOnlyMask` (builds WHERE-column mask from scan filters), `masksEqual`, `maskHasTrue`.