### PR TITLE
feat: WAL write-frame batching

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,56 @@
-### 2026-04-26 (rightmost-leaf cache — latest)
+### 2026-04-26 (WAL write frame batching — latest)
+
+WAL write-frame batching — frames from multiple transactions accumulated in a 64 KiB in-process buffer before a single `WriteAt` to the OS page cache:
+- **`WAL.pendingBuf`** replaces the old `writeBuf` scratch buffer. `AppendTransaction` serialises frames directly into `pendingBuf[pendingLen:]` and flushes (one `WriteAt`) only when `pendingLen >= flushThreshold` (default 64 KiB), `flushThreshold == 0` (opt-out), or `SynchronousFull`. A 64 KiB buffer holds ~16 full-page frames, so ~8–16 single-row transactions share one syscall instead of one each.
+- `Checkpoint`, `Truncate`, and `Close` all flush pending bytes before acting, so no frames are ever lost on clean shutdown. `Close` also fsyncs (unless `SynchronousOff`) so a graceful close is always durable.
+- `FrameCount()` adds `pendingLen` to the on-disk count so auto-checkpoint fires at the correct threshold even with buffered-but-unflushed frames.
+- **`wal_write_buffer_size=N`** connection-string parameter; default 65536; 0 disables batching (flush every commit). Enabled by default for all production databases opened via a connection string; raw `CreateWAL` callers (unit tests) keep `flushThreshold = 0` so existing tests are unaffected.
+- **Insert_SingleRow: 28.9 µs → 19.2 µs (1.5× faster, now 2.3× faster than SQLite, ratio 0.43×)**
+- **Update_ByPK: 18.5 µs → 11.0 µs (1.7× faster, now 3.3× faster than SQLite, ratio 0.30×)**
+- **Delete_ByPK: ~52 µs → 29.8 µs (1.7× faster, 2.7× faster than SQLite†, ratio 0.37×)**
+- Insert_Batch/PreparedBatch/MultiValues: 10–19% faster in absolute terms; ratio vs SQLite unchanged (2.1–2.2×) — batch transactions already exceed the 64 KiB threshold and flush per-transaction; the absolute improvement is machine/thermal state.
+- Read paths also faster in absolute terms; both databases improved similarly, confirming machine state rather than code change.
+- Delete_ByPK allocs/op: 131 → 117 (11% reduction) — the pending buffer grows to steady-state once and stops reallocating, eliminating the occasional `make([]byte, need)` in the hot path.
+
+† SQLite Delete run 1 was a warm-up outlier (186 µs vs 78–80 µs in runs 2–3); ratio computed from runs 2–3.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| **Delete_ByPK** | **29.8 µs/op** | **79.8 µs/op†** | **0.37×** |
+| **Insert_SingleRow** | **19.2 µs/op** | **44.4 µs/op** | **0.43×** |
+| Insert_Batch | 473.3 µs/op | 225.6 µs/op | 2.1× |
+| Insert_PreparedBatch | 482.8 µs/op | 227.5 µs/op | 2.1× |
+| Insert_MultiValues | 380.2 µs/op | 169.7 µs/op | 2.2× |
+| Select_PointScan | 4.72 µs/op | 3.37 µs/op | 1.4× |
+| **Select_Limit** | **7.37 µs/op** | **8.04 µs/op** | **0.92×** |
+| **Select_FullScan** | **4.76 ms/op** | **5.19 ms/op** | **0.92×** |
+| Select_CountStar | 17.3 µs/op | 9.73 µs/op | 1.8× |
+| **Select_IndexRangeScan** | **705.4 µs/op** | **751.8 µs/op** | **0.94×** |
+| Select_RangeScan | 1.65 ms/op | 0.87 ms/op | 1.9× |
+| **Update_ByPK** | **11.0 µs/op** | **36.4 µs/op** | **0.30×** |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 30.9 KiB | 447 B |
+| Insert_SingleRow | 21.5 KiB | 311 B |
+| Insert_Batch | 352.4 KiB | 31.0 KiB |
+| Insert_PreparedBatch | 352.0 KiB | 31.0 KiB |
+| Insert_MultiValues | 318.8 KiB | 25.2 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.1 KiB | 1.7 KiB |
+| Select_FullScan | 5.3 MiB | 1.3 MiB |
+| Select_CountStar | 6.0 KiB | 400 B |
+| Select_IndexRangeScan | 739.3 KiB | 85.9 KiB |
+| Select_RangeScan | 1.6 MiB | 85.9 KiB |
+| Update_ByPK | 9.1 KiB | 263 B |
+
+---
+
+### 2026-04-26 (rightmost-leaf cache)
 
 Rightmost-leaf cache optimization for B+ tree insertions:
 - **`Index[T]`**: added `rightmostLeaf atomic.Int64` (−1 = cold) and `lastTxID atomic.Uint64`. On each `Insert`, if `tx.ID != lastTxID` the cache is invalidated (guards against stale hints after rollback/OCC conflict). Fast path inside `hasSpaceForKey(root)` reads the cached leaf and appends directly when `key > lastKey` and the leaf has space, bypassing the O(log N) root→leaf traversal. `insertNotFull` returns `(PageIndex, bool, error)` where the bool tracks "every level chose the rightmost child" — only when the full path was rightmost is the cache updated; non-rightmost inserts unconditionally cold-start the cache.

--- a/connection_string.go
+++ b/connection_string.go
@@ -25,10 +25,17 @@ const (
 // automatic checkpoint when WAL mode is enabled.
 const DefaultWALCheckpointThreshold = 1000
 
+// DefaultWALWriteBufferSize is the default write-buffer size for WAL frame
+// batching (64 KiB ≈ 16 full-page frames).  A larger buffer reduces WriteAt
+// syscall overhead for high-frequency single-row-per-transaction workloads at
+// the cost of slightly higher data-loss exposure on unclean shutdown.
+const DefaultWALWriteBufferSize = 64 * 1024
+
 // ConnectionConfig holds parsed connection string parameters.
 type ConnectionConfig struct {
 	FilePath               string          // Database file path
 	WALCheckpointThreshold int             // Auto-checkpoint threshold in WAL frames (default: 1000)
+	WALWriteBufferSize     int             // WAL write-buffer size in bytes (default: 64 KiB; 0 = flush every commit)
 	LogLevel               string          // Log level: debug, info, warn, error (default: warn)
 	MaxCachedPages         int             // Maximum number of pages to cache (default: 2000, 0 = use default)
 	Synchronous            SynchronousMode // WAL fsync mode: off, normal (default), full
@@ -39,6 +46,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 	return &ConnectionConfig{
 		FilePath:               filePath,
 		WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+		WALWriteBufferSize:     DefaultWALWriteBufferSize,
 		LogLevel:               "warn",
 		MaxCachedPages:         minisql.PageCacheSize,
 		Synchronous:            SynchronousNormal,
@@ -51,16 +59,18 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //
 // Supported parameters:
 //   - wal_checkpoint_threshold=N        : Auto-checkpoint after N WAL frames (default: 1000; 0 = disabled)
+//   - wal_write_buffer_size=N           : WAL write-buffer in bytes (default: 65536; 0 = flush every commit)
 //   - log_level=debug|info|warn|error   : Set logging level (default: warn)
 //   - max_cached_pages=N                : Page cache size in pages (default: 2000)
 //   - synchronous=off|normal|full       : WAL fsync mode (default: normal, matching SQLite WAL default)
 //
 // Examples:
-//   - "./my.db"                                  : Default settings
-//   - "./my.db?log_level=debug"                  : Enable debug logging
-//   - "./my.db?wal_checkpoint_threshold=500"     : Auto-checkpoint every 500 frames
-//   - "./my.db?synchronous=full"                 : fsync on every commit (maximum durability)
-//   - "./my.db?log_level=info&max_cached_pages=500" : Multiple parameters
+//   - "./my.db"                                       : Default settings
+//   - "./my.db?log_level=debug"                       : Enable debug logging
+//   - "./my.db?wal_checkpoint_threshold=500"          : Auto-checkpoint every 500 frames
+//   - "./my.db?wal_write_buffer_size=0"               : Disable write batching (flush every commit)
+//   - "./my.db?synchronous=full"                      : fsync on every commit (maximum durability)
+//   - "./my.db?log_level=info&max_cached_pages=500"   : Multiple parameters
 func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 	// Split on first '?' to separate path from query params
 	parts := strings.SplitN(connStr, "?", 2)
@@ -85,6 +95,15 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 			return nil, fmt.Errorf("invalid wal_checkpoint_threshold parameter: must be a non-negative integer, got %q", threshStr)
 		}
 		config.WALCheckpointThreshold = thresh
+	}
+
+	// Parse wal_write_buffer_size parameter
+	if bufSizeStr := queryParams.Get("wal_write_buffer_size"); bufSizeStr != "" {
+		bufSize, err := strconv.Atoi(bufSizeStr)
+		if err != nil || bufSize < 0 {
+			return nil, fmt.Errorf("invalid wal_write_buffer_size parameter: must be a non-negative integer, got %q", bufSizeStr)
+		}
+		config.WALWriteBufferSize = bufSize
 	}
 
 	// Parse log_level parameter

--- a/connection_string_test.go
+++ b/connection_string_test.go
@@ -24,6 +24,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousNormal,
@@ -36,6 +37,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "debug",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousNormal,
@@ -48,6 +50,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         500,
 				Synchronous:            SynchronousNormal,
@@ -60,6 +63,33 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: 500,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
+				LogLevel:               "warn",
+				MaxCachedPages:         minisql.PageCacheSize,
+				Synchronous:            SynchronousNormal,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "custom write buffer size",
+			connStr: "./test.db?wal_write_buffer_size=131072",
+			wantConfig: &ConnectionConfig{
+				FilePath:               "./test.db",
+				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     131072,
+				LogLevel:               "warn",
+				MaxCachedPages:         minisql.PageCacheSize,
+				Synchronous:            SynchronousNormal,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "zero write buffer size disables batching",
+			connStr: "./test.db?wal_write_buffer_size=0",
+			wantConfig: &ConnectionConfig{
+				FilePath:               "./test.db",
+				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     0,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousNormal,
@@ -72,6 +102,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: 200,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "info",
 				MaxCachedPages:         4000,
 				Synchronous:            SynchronousNormal,
@@ -84,6 +115,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: 0,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousNormal,
@@ -96,6 +128,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousFull,
@@ -108,6 +141,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousNormal,
@@ -120,6 +154,7 @@ func TestParseConnectionString(t *testing.T) {
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "warn",
 				MaxCachedPages:         minisql.PageCacheSize,
 				Synchronous:            SynchronousOff,
@@ -137,6 +172,18 @@ func TestParseConnectionString(t *testing.T) {
 			connStr:     "./test.db?wal_checkpoint_threshold=abc",
 			wantErr:     true,
 			errContains: "invalid wal_checkpoint_threshold",
+		},
+		{
+			name:        "invalid wal_write_buffer_size - negative",
+			connStr:     "./test.db?wal_write_buffer_size=-1",
+			wantErr:     true,
+			errContains: "invalid wal_write_buffer_size",
+		},
+		{
+			name:        "invalid wal_write_buffer_size - not a number",
+			connStr:     "./test.db?wal_write_buffer_size=abc",
+			wantErr:     true,
+			errContains: "invalid wal_write_buffer_size",
 		},
 		{
 			name:        "invalid max_cached_pages - negative",

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -26,6 +26,7 @@ type WALConfig struct {
 	Index               *WALIndex
 	DBFile              DBFile
 	CheckpointThreshold int
+	WALWriteBufferSize  int // bytes to buffer before flushing; 0 = flush every commit
 	Synchronous         SynchronousMode
 }
 
@@ -96,6 +97,7 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 		saver.SetWALIndex(walCfg.Index)
 		if walCfg.WAL != nil {
 			walCfg.WAL.SetSynchronous(walCfg.Synchronous)
+			walCfg.WAL.SetWriteBufferSize(walCfg.WALWriteBufferSize)
 		}
 	}
 

--- a/internal/minisql/wal.go
+++ b/internal/minisql/wal.go
@@ -86,15 +86,25 @@ type WALReadFrame struct {
 //
 // Periodically, or on clean open, committed frames are copied back to the main
 // DB file via Checkpoint and the WAL is truncated.
+//
+// Write buffering: when flushThreshold > 0 frames from multiple transactions
+// are accumulated in pendingBuf and written to the file in a single WriteAt
+// once pendingLen >= flushThreshold.  This reduces syscall overhead for
+// high-frequency single-row-per-transaction workloads.  flushThreshold == 0
+// (the default) flushes after every AppendTransaction, preserving the previous
+// behaviour.  SynchronousFull always flushes immediately regardless of the
+// threshold.
 type WAL struct {
-	file         *os.File
-	filepath     string
-	writeBuf     []byte
-	nextOffset   int64
-	pageSize     uint32
-	salt1        uint32
-	salt2        uint32
-	synchronous  atomic.Int32 // SynchronousMode; default SynchronousNormal
+	file           *os.File
+	filepath       string
+	pendingBuf     []byte // write-buffer accumulating frames not yet sent to the OS
+	pendingLen     int    // valid bytes in pendingBuf
+	flushThreshold int    // flush when pendingLen >= this; 0 = flush every commit
+	nextOffset     int64
+	pageSize       uint32
+	salt1          uint32
+	salt2          uint32
+	synchronous    atomic.Int32 // SynchronousMode; default SynchronousNormal
 }
 
 // Synchronous returns the current synchronous mode.
@@ -106,6 +116,36 @@ func (w *WAL) Synchronous() SynchronousMode {
 // the next WAL commit (AppendTransaction call).
 func (w *WAL) SetSynchronous(mode SynchronousMode) {
 	w.synchronous.Store(int32(mode))
+}
+
+// SetWriteBufferSize sets the target size for write batching.  When > 0,
+// AppendTransaction accumulates serialised frames up to this many bytes before
+// issuing a WriteAt to the OS.  0 (the default) disables buffering and
+// flushes after every AppendTransaction, matching the previous behaviour.
+// SynchronousFull always flushes immediately regardless of this setting.
+func (w *WAL) SetWriteBufferSize(n int) {
+	w.flushThreshold = n
+}
+
+// Flush writes any buffered WAL frames to the OS page cache.  It is a no-op
+// when there is nothing pending.  Called automatically by Checkpoint, Truncate,
+// and Close; callers that need strict write-order guarantees can call it
+// explicitly.
+func (w *WAL) Flush() error {
+	return w.flush()
+}
+
+// flush is the unexported implementation of Flush.
+func (w *WAL) flush() error {
+	if w.pendingLen == 0 {
+		return nil
+	}
+	if _, err := w.file.WriteAt(w.pendingBuf[:w.pendingLen], w.nextOffset); err != nil {
+		return fmt.Errorf("flush WAL write buffer: %w", err)
+	}
+	w.nextOffset += int64(w.pendingLen)
+	w.pendingLen = 0
+	return nil
 }
 
 // CreateWAL creates a new WAL file (truncating any existing file at that path).
@@ -171,9 +211,12 @@ func OpenWAL(dbPath string, pageSize uint32) (*WAL, error) {
 	return w, nil
 }
 
-// AppendTransaction writes all modified pages as WAL frames and syncs the file.
-// The last frame is marked as a commit frame (CommitSize = len(pages)).
-// pages must be non-empty; each Data slice must be exactly pageSize bytes.
+// AppendTransaction serialises all modified pages as WAL frames into the write
+// buffer and, when the buffer reaches the flush threshold (or when
+// SynchronousFull mode is active), writes it to the OS page cache in a single
+// WriteAt call.  The last frame is marked as a commit frame
+// (CommitSize = len(pages)).  pages must be non-empty; each Data slice must
+// be exactly pageSize bytes.
 func (w *WAL) AppendTransaction(pages []WALPage) error {
 	if len(pages) == 0 {
 		return errors.New("cannot append empty transaction to WAL")
@@ -182,11 +225,16 @@ func (w *WAL) AppendTransaction(pages []WALPage) error {
 	commitSize := uint32(len(pages))
 	frameSize := int(WALFrameHeaderSize) + int(w.pageSize)
 	need := frameSize * len(pages)
-	if cap(w.writeBuf) < need {
-		w.writeBuf = make([]byte, need)
-	}
-	buf := w.writeBuf[:need]
 
+	// Grow the pending buffer if it cannot accommodate the new frames.
+	if w.pendingLen+need > cap(w.pendingBuf) {
+		grown := make([]byte, w.pendingLen+need)
+		copy(grown, w.pendingBuf[:w.pendingLen])
+		w.pendingBuf = grown
+	}
+
+	// Serialise frames directly into the pending buffer after any existing data.
+	buf := w.pendingBuf[w.pendingLen : w.pendingLen+need]
 	for i, page := range pages {
 		if uint32(len(page.Data)) != w.pageSize {
 			return fmt.Errorf("WAL page %d: data length %d != page size %d", page.Index, len(page.Data), w.pageSize)
@@ -201,7 +249,6 @@ func (w *WAL) AppendTransaction(pages []WALPage) error {
 			cs = commitSize
 		}
 
-		// Frame header fields
 		marshalUint32(fh, uint32(page.Index), 0)
 		marshalUint32(fh, cs, 4)
 		marshalUint32(fh, w.salt1, 8)
@@ -213,23 +260,25 @@ func (w *WAL) AppendTransaction(pages []WALPage) error {
 		crc2 := crc32.ChecksumIEEE(page.Data)
 		marshalUint32(fh, crc2, 20)
 
-		// Page data immediately follows the frame header
 		copy(buf[base+WALFrameHeaderSize:base+frameSize], page.Data)
 	}
+	w.pendingLen += need
 
-	if _, err := w.file.WriteAt(buf, w.nextOffset); err != nil {
-		return fmt.Errorf("write WAL frames: %w", err)
-	}
-
-	// fsync is only required in FULL mode.  In NORMAL mode the OS write cache
-	// is sufficient between commits; durability is recovered at checkpoint.
-	if SynchronousMode(w.synchronous.Load()) == SynchronousFull {
-		if err := syscallFsync(w.file); err != nil {
-			return fmt.Errorf("sync WAL after append: %w", err)
+	// Flush when: no buffering configured (threshold == 0), buffer reached the
+	// threshold, or the synchronous mode demands immediate durability.
+	sync := SynchronousMode(w.synchronous.Load())
+	if sync == SynchronousFull || w.flushThreshold == 0 || w.pendingLen >= w.flushThreshold {
+		if err := w.flush(); err != nil {
+			return err
+		}
+		// fsync is only required in FULL mode.  In NORMAL mode the OS write cache
+		// is sufficient between commits; durability is recovered at checkpoint.
+		if sync == SynchronousFull {
+			if err := syscallFsync(w.file); err != nil {
+				return fmt.Errorf("sync WAL after append: %w", err)
+			}
 		}
 	}
-
-	w.nextOffset += int64(len(buf))
 	return nil
 }
 
@@ -311,6 +360,11 @@ func (w *WAL) ReadAllFrames() ([]WALReadFrame, error) {
 // appears in multiple transactions) and then fsyncs the database file.
 // Callers should call Truncate after a successful checkpoint.
 func (w *WAL) Checkpoint(dbFile DBFile) error {
+	// Flush any buffered frames so the WAL file is authoritative before we read it.
+	if err := w.flush(); err != nil {
+		return fmt.Errorf("flush pending WAL frames before checkpoint: %w", err)
+	}
+
 	// Build a latest-page map directly from the WAL file without an intermediate
 	// []WALReadFrame slice.  A single shared read buffer (pageData) is reused for
 	// every frame; we only allocate a fresh 4 KB slice when we need to keep (or
@@ -429,6 +483,11 @@ func (w *WAL) Checkpoint(dbFile DBFile) error {
 // The file header is rewritten with fresh salts so that any unreachable frames
 // left behind by a partial truncation are automatically invalidated.
 func (w *WAL) Truncate() error {
+	// Safety flush: Checkpoint should have flushed already, but guard defensively.
+	if err := w.flush(); err != nil {
+		return fmt.Errorf("flush pending WAL frames before truncate: %w", err)
+	}
+
 	if err := w.file.Truncate(WALFileHeaderSize); err != nil {
 		return fmt.Errorf("truncate WAL file: %w", err)
 	}
@@ -463,18 +522,29 @@ func (w *WAL) Delete() error {
 	return nil
 }
 
-// Close closes the underlying WAL file handle without removing it.
+// Close flushes any pending frames, fsyncs (unless SynchronousOff), and closes
+// the WAL file.  On clean shutdown this guarantees all committed transactions
+// are durable before the file handle is released.
 func (w *WAL) Close() error {
+	if err := w.flush(); err != nil {
+		_ = w.file.Close()
+		return fmt.Errorf("flush pending WAL frames on close: %w", err)
+	}
+	if SynchronousMode(w.synchronous.Load()) != SynchronousOff {
+		if err := syscallFsync(w.file); err != nil {
+			_ = w.file.Close()
+			return fmt.Errorf("sync WAL on close: %w", err)
+		}
+	}
 	return w.file.Close()
 }
 
-// FrameCount returns the total number of frame slots written since the last
-// Truncate (including both committed and uncommitted frames).
+// FrameCount returns the total number of frame slots since the last Truncate,
+// including frames that are buffered but not yet flushed to the file.
 func (w *WAL) FrameCount() int64 {
-	var (
-		frameSize = int64(WALFrameHeaderSize) + int64(w.pageSize)
-		available = w.nextOffset - WALFileHeaderSize
-	)
+	frameSize := int64(WALFrameHeaderSize) + int64(w.pageSize)
+	// nextOffset counts only flushed frames; add pendingLen for buffered ones.
+	available := w.nextOffset - WALFileHeaderSize + int64(w.pendingLen)
 	if available <= 0 {
 		return 0
 	}

--- a/internal/minisql/wal_test.go
+++ b/internal/minisql/wal_test.go
@@ -548,6 +548,137 @@ func TestRecoverFromWAL(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Write-buffer batching tests
+// ---------------------------------------------------------------------------
+
+func TestWAL_WriteBuffering_AccumulatesUntilThreshold(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	defer os.Remove(tmp.Name() + "-wal")
+
+	w, err := CreateWAL(tmp.Name(), PageSize)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	frameSize := WALFrameHeaderSize + int(PageSize)
+	// Buffer exactly two frames before flushing.
+	w.flushThreshold = 2 * frameSize
+
+	// First transaction: below threshold — frames stay in the buffer.
+	require.NoError(t, w.AppendTransaction([]WALPage{{Index: 1, Data: makeTestPage(0x01)}}))
+	assert.Equal(t, frameSize, w.pendingLen, "frame should be buffered, not yet flushed")
+	assert.Equal(t, int64(WALFileHeaderSize), w.nextOffset, "no bytes written to file yet")
+
+	// FrameCount must include the pending frame.
+	assert.Equal(t, int64(1), w.FrameCount())
+
+	// ReadAllFrames reads from the file — pending frame is not there yet.
+	frames, err := w.ReadAllFrames()
+	require.NoError(t, err)
+	assert.Empty(t, frames, "frames should not be on disk until threshold is reached")
+
+	// Second transaction: crosses threshold — both frames are flushed together.
+	require.NoError(t, w.AppendTransaction([]WALPage{{Index: 2, Data: makeTestPage(0x02)}}))
+	assert.Equal(t, 0, w.pendingLen, "buffer should be empty after auto-flush")
+
+	frames, err = w.ReadAllFrames()
+	require.NoError(t, err)
+	require.Len(t, frames, 2)
+	assert.Equal(t, PageIndex(1), frames[0].PageIndex)
+	assert.Equal(t, PageIndex(2), frames[1].PageIndex)
+}
+
+func TestWAL_WriteBuffering_ExplicitFlush(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	defer os.Remove(tmp.Name() + "-wal")
+
+	w, err := CreateWAL(tmp.Name(), PageSize)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	w.flushThreshold = 1 << 20 // 1 MiB — won't auto-flush in this test
+
+	require.NoError(t, w.AppendTransaction([]WALPage{{Index: 0, Data: makeTestPage(0xAA)}}))
+	assert.Greater(t, w.pendingLen, 0, "frame should be buffered")
+
+	// Explicit flush makes the frame visible on disk.
+	require.NoError(t, w.Flush())
+	assert.Equal(t, 0, w.pendingLen)
+
+	frames, err := w.ReadAllFrames()
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	assert.Equal(t, PageIndex(0), frames[0].PageIndex)
+	assert.Equal(t, makeTestPage(0xAA), frames[0].Data)
+}
+
+func TestWAL_WriteBuffering_CheckpointFlushes(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	defer os.Remove(tmp.Name() + "-wal")
+
+	w, err := CreateWAL(tmp.Name(), PageSize)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	w.flushThreshold = 1 << 20 // large — won't auto-flush
+
+	page0 := makeTestPage(0xCC)
+	require.NoError(t, w.AppendTransaction([]WALPage{{Index: 0, Data: page0}}))
+	assert.Greater(t, w.pendingLen, 0)
+
+	dbFile, err := os.OpenFile(tmp.Name(), os.O_RDWR|os.O_CREATE, 0o644)
+	require.NoError(t, err)
+	defer dbFile.Close()
+	require.NoError(t, dbFile.Truncate(int64(PageSize)))
+
+	// Checkpoint must flush pending frames before writing to the DB file.
+	require.NoError(t, w.Checkpoint(dbFile))
+	assert.Equal(t, 0, w.pendingLen, "checkpoint must flush the write buffer")
+
+	buf := make([]byte, PageSize)
+	_, err = dbFile.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, page0, buf, "checkpoint must have written the buffered page")
+}
+
+func TestWAL_WriteBuffering_SynchronousFullBypassesBuffer(t *testing.T) {
+	t.Parallel()
+
+	tmp, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	defer os.Remove(tmp.Name() + "-wal")
+
+	w, err := CreateWAL(tmp.Name(), PageSize)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	w.flushThreshold = 1 << 20 // large — would buffer in Normal mode
+	w.SetSynchronous(SynchronousFull)
+
+	require.NoError(t, w.AppendTransaction([]WALPage{{Index: 0, Data: makeTestPage(0xDD)}}))
+
+	// SynchronousFull must flush + fsync immediately, bypassing the buffer.
+	assert.Equal(t, 0, w.pendingLen, "SynchronousFull must flush immediately")
+
+	frames, err := w.ReadAllFrames()
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	assert.Equal(t, PageIndex(0), frames[0].PageIndex)
+}
+
 func TestRecoverFromWAL_NoFile(t *testing.T) {
 	t.Parallel()
 

--- a/minisql.go
+++ b/minisql.go
@@ -110,6 +110,7 @@ func (d *Driver) newDB(config *ConnectionConfig) (*minisql.Database, error) {
 			Index:               walIndex,
 			DBFile:              dbFile,
 			CheckpointThreshold: config.WALCheckpointThreshold,
+			WALWriteBufferSize:  config.WALWriteBufferSize,
 			Synchronous:         config.Synchronous,
 		},
 	)


### PR DESCRIPTION
WAL write-frame batching — frames from multiple transactions accumulated in a 64 KiB in-process buffer before a single `WriteAt` to the OS page cache:
- **`WAL.pendingBuf`** replaces the old `writeBuf` scratch buffer. `AppendTransaction` serialises frames directly into `pendingBuf[pendingLen:]` and flushes (one `WriteAt`) only when `pendingLen >= flushThreshold` (default 64 KiB), `flushThreshold == 0` (opt-out), or `SynchronousFull`. A 64 KiB buffer holds ~16 full-page frames, so ~8–16 single-row transactions share one syscall instead of one each.
- `Checkpoint`, `Truncate`, and `Close` all flush pending bytes before acting, so no frames are ever lost on clean shutdown. `Close` also fsyncs (unless `SynchronousOff`) so a graceful close is always durable.
- `FrameCount()` adds `pendingLen` to the on-disk count so auto-checkpoint fires at the correct threshold even with buffered-but-unflushed frames.
- **`wal_write_buffer_size=N`** connection-string parameter; default 65536; 0 disables batching (flush every commit). Enabled by default for all production databases opened via a connection string; raw `CreateWAL` callers (unit tests) keep `flushThreshold = 0` so existing tests are unaffected.
- **Insert_SingleRow: 28.9 µs → 19.2 µs (1.5× faster, now 2.3× faster than SQLite, ratio 0.43×)**
- **Update_ByPK: 18.5 µs → 11.0 µs (1.7× faster, now 3.3× faster than SQLite, ratio 0.30×)**
- **Delete_ByPK: ~52 µs → 29.8 µs (1.7× faster, 2.7× faster than SQLite†, ratio 0.37×)**
- Insert_Batch/PreparedBatch/MultiValues: 10–19% faster in absolute terms; ratio vs SQLite unchanged (2.1–2.2×) — batch transactions already exceed the 64 KiB threshold and flush per-transaction; the absolute improvement is machine/thermal state.
- Read paths also faster in absolute terms; both databases improved similarly, confirming machine state rather than code change.
- Delete_ByPK allocs/op: 131 → 117 (11% reduction) — the pending buffer grows to steady-state once and stops reallocating, eliminating the occasional `make([]byte, need)` in the hot path.
