### PR TITLE
refactor: replace linear scans with binary search

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,57 @@
-### 2026-04-26 (IndexNode cell pre-sizing — latest)
+### 2026-04-26 (binary search within index nodes — latest)
+
+Replaced all linear scans over `IndexNode.Cells` with `sort.Search` (binary search) in `index.go` and `index_cursor.go`:
+- **`insertNotFull` — non-unique duplicate key check**: forward linear scan → binary search lower-bound + equality check.
+- **`insertNotFull` — leaf insertion position**: backward linear scan + field-by-field shift → binary search + backward struct-copy shift.
+- **`insertNotFull` — internal node child selection**: backward linear scan → binary search (first index where `Cells[i].Key > key`).
+- **`remove` — key search**: forward linear scan → binary search lower-bound.
+- **`Seek` (index_cursor.go)**: forward linear scan → binary search lower-bound.
+- The table B+ tree (`InternalNode.IndexOfChild`, `leafNodeSeek`) was already using binary search; no change there.
+- **Insert_Batch: 492.2 µs → 407.3 µs (1.21× faster, ratio vs SQLite 2.2× → 1.8×)** — each of the 100 rows per transaction searches an internal or leaf node; binary search directly cuts per-insert comparison count.
+- **Insert_PreparedBatch: 490.7 µs → 405.9 µs (1.21× faster, ratio 2.2× → 1.8×)**
+- **Insert_MultiValues: 405.3 µs → 317.9 µs (1.27× faster, ratio 2.4× → 1.9×)**
+- Insert_SingleRow improved ~5% (19.0 µs → 18.0 µs) — modest benefit since single-row-per-transaction workloads don't accumulate many keys per node before the next transaction starts fresh.
+- Read, Update, Delete paths see small improvements consistent with fewer comparisons during tree traversal.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| **Delete_ByPK** | **22.2 µs/op** | **82.3 µs/op†** | **0.27×** |
+| **Insert_SingleRow** | **18.0 µs/op** | **41.0 µs/op** | **0.44×** |
+| **Insert_Batch** | **407.3 µs/op** | **223.2 µs/op** | **1.8×** |
+| **Insert_PreparedBatch** | **405.9 µs/op** | **221.4 µs/op** | **1.8×** |
+| **Insert_MultiValues** | **317.9 µs/op** | **170.3 µs/op** | **1.9×** |
+| Select_PointScan | 4.33 µs/op | 3.33 µs/op | 1.3× |
+| **Select_Limit** | **7.55 µs/op** | **7.92 µs/op** | **0.95×** |
+| **Select_FullScan** | **4.73 ms/op** | **5.08 ms/op** | **0.93×** |
+| Select_CountStar | 17.4 µs/op | 9.60 µs/op | 1.8× |
+| **Select_IndexRangeScan** | **683.8 µs/op** | **737.2 µs/op** | **0.93×** |
+| Select_RangeScan | 1.72 ms/op | 0.88 ms/op | 2.0× |
+| **Update_ByPK** | **10.5 µs/op** | **36.5 µs/op** | **0.29×** |
+
+† SQLite Delete continues to show run-to-run variance (63 / 79 / 105 µs); 3-run average used.
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 25.3 KiB | 447 B |
+| Insert_SingleRow | 21.5 KiB | 312 B |
+| Insert_Batch | 356.2 KiB | 31.1 KiB |
+| Insert_PreparedBatch | 355.6 KiB | 31.1 KiB |
+| Insert_MultiValues | 322.7 KiB | 25.3 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.1 KiB | 1.7 KiB |
+| Select_FullScan | 5.3 MiB | 1.3 MiB |
+| Select_CountStar | 5.9 KiB | 400 B |
+| Select_IndexRangeScan | 737.1 KiB | 85.9 KiB |
+| Select_RangeScan | 1.6 MiB | 85.9 KiB |
+| Update_ByPK | 9.0 KiB | 263 B |
+
+---
+
+### 2026-04-26 (IndexNode cell pre-sizing)
 
 IndexNode `Cells` slice capacity increased from 4 to 32, eliminating most slice reallocations during sequential insert / rebalance workloads:
 - **`NewIndexNode`**: changed `make([]IndexCell[T], 4, 4)` to `make([]IndexCell[T], 4, 32)`. With `cap==len==4`, the very first `append` (insert) triggered an immediate reallocation to cap=8 and then up to cap=256 across 6 steps to fill a full int64 leaf. With cap=32, no reallocation occurs for the first 28 insertions; a full leaf needs 3 reallocs (32→64→128→256) instead of 6.

--- a/internal/minisql/index.go
+++ b/internal/minisql/index.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -302,18 +303,18 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 	node := page.IndexNode.(*IndexNode[T])
 
 	if !ui.unique {
-		// For non-unique index, check for an existing key to append the row ID.
-		for cellIdx := uint32(0); cellIdx < node.Header.Keys; cellIdx++ {
-			if compare(node.Cells[cellIdx].Key, key) != 0 {
-				continue
-			}
+		// For non-unique index, binary-search for an existing key to append the row ID.
+		pos := sort.Search(int(node.Header.Keys), func(i int) bool {
+			return compare(node.Cells[i].Key, key) >= 0
+		})
+		if pos < int(node.Header.Keys) && compare(node.Cells[pos].Key, key) == 0 {
 			// Upgrade to write set before modifying.
 			page, err = ui.pager.ModifyPage(ctx, pageIdx)
 			if err != nil {
 				return 0, false, fmt.Errorf("modify page for append row ID: %w", err)
 			}
 			node = page.IndexNode.(*IndexNode[T])
-			if err := appendRowID(ctx, ui.pager, node, cellIdx, rowID); err != nil {
+			if err := appendRowID(ctx, ui.pager, node, uint32(pos), rowID); err != nil {
 				return 0, false, fmt.Errorf("error appending row ID to existing key: %w", err)
 			}
 			// Appending to an existing key — not a rightmost-leaf insert.
@@ -330,23 +331,22 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 		}
 		node = page.IndexNode.(*IndexNode[T])
 
-		// Find location to insert new key, shift keys to make space.
-		i := int(node.Header.Keys) - 1
+		// Binary search for the insertion position.
+		pos := sort.Search(int(node.Header.Keys), func(i int) bool {
+			return compare(node.Cells[i].Key, key) >= 0
+		})
+		// Extend the slice by one, then shift cells [pos, Keys-1] right to make room.
 		node.Cells = append(node.Cells, NewIndexCell[T](ui.unique))
-		for i >= 0 && compare(node.Cells[i].Key, key) > 0 {
-			node.Cells[i+1].Key = node.Cells[i].Key
-			node.Cells[i+1].InlineRowIDs = node.Cells[i].InlineRowIDs
-			node.Cells[i+1].RowIDs = node.Cells[i].RowIDs
-			node.Cells[i+1].UniqueRowID = node.Cells[i].UniqueRowID
-			node.Cells[i+1].Overflow = node.Cells[i].Overflow
-			i -= 1
+		for j := int(node.Header.Keys) - 1; j >= pos; j-- {
+			node.Cells[j+1] = node.Cells[j]
 		}
-		node.Cells[i+1].Key = key
+		node.Cells[pos] = NewIndexCell[T](ui.unique)
+		node.Cells[pos].Key = key
 		if ui.unique {
-			node.Cells[i+1].UniqueRowID = rowID
+			node.Cells[pos].UniqueRowID = rowID
 		} else {
-			node.Cells[i+1].InlineRowIDs = 1
-			node.Cells[i+1].RowIDs = []RowID{rowID}
+			node.Cells[pos].InlineRowIDs = 1
+			node.Cells[pos].RowIDs = []RowID{rowID}
 		}
 		node.Header.Keys += 1
 		// The leaf itself is trivially "rightmost at leaf level"; whether it is the
@@ -355,13 +355,13 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 		return pageIdx, true, nil
 	}
 
-	// Internal node — find the child that will receive the new key.
-	i := int(node.Header.Keys) - 1
-	for i >= 0 && compare(node.Cells[i].Key, key) > 0 {
-		i -= 1
-	}
+	// Internal node — binary search for the child that will receive the new key.
+	// pos = first index where Cells[pos].Key > key; child to descend into is pos.
+	pos := sort.Search(int(node.Header.Keys), func(i int) bool {
+		return compare(node.Cells[i].Key, key) > 0
+	})
 
-	childIdx, err := node.Child(uint32(i + 1))
+	childIdx, err := node.Child(uint32(pos))
 	if err != nil {
 		return 0, false, fmt.Errorf("get child: %w", err)
 	}
@@ -384,21 +384,21 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 		if err != nil {
 			return 0, false, fmt.Errorf("modify child page for split: %w", err)
 		}
-		if err := ui.splitChild(ctx, page, childPage, uint32(i+1)); err != nil {
+		if err := ui.splitChild(ctx, page, childPage, uint32(pos)); err != nil {
 			return 0, false, fmt.Errorf("split child: %w", err)
 		}
-		if compare(node.Cells[i+1].Key, key) < 0 {
-			i += 1
+		if compare(node.Cells[pos].Key, key) < 0 {
+			pos += 1
 		}
 		// Re-read the child index from the now-updated parent node.
-		childIdx, err = node.Child(uint32(i + 1))
+		childIdx, err = node.Child(uint32(pos))
 		if err != nil {
 			return 0, false, fmt.Errorf("get child after split: %w", err)
 		}
 	}
 
 	// isRightmostAtThisLevel: we chose node.Child(Keys) — the RightChild pointer.
-	isRightmostAtThisLevel := uint32(i+1) == node.Header.Keys
+	isRightmostAtThisLevel := uint32(pos) == node.Header.Keys
 	leafIdx, isRightmostBelow, err := ui.insertNotFull(ctx, childIdx, key, rowID)
 	return leafIdx, isRightmostAtThisLevel && isRightmostBelow, err
 }
@@ -564,11 +564,10 @@ func (ui *Index[T]) Delete(ctx context.Context, keyAny any, rowID RowID) error {
 func (ui *Index[T]) remove(ctx context.Context, page *Page, key T, rowID RowID) error {
 	node := page.IndexNode.(*IndexNode[T])
 
-	// Find index of the first key greater than or equal to key.
-	idx := 0
-	for idx < int(node.Header.Keys) && compare(node.Cells[idx].Key, key) < 0 {
-		idx += 1
-	}
+	// Binary search for the first index where Cells[idx].Key >= key.
+	idx := sort.Search(int(node.Header.Keys), func(i int) bool {
+		return compare(node.Cells[i].Key, key) >= 0
+	})
 
 	if idx < int(node.Header.Keys) && compare(node.Cells[idx].Key, key) == 0 {
 		// Key is in this node.

--- a/internal/minisql/index_cursor.go
+++ b/internal/minisql/index_cursor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 )
 
 // IndexCursor holds a position within an index, grouping page and cell index.
@@ -64,23 +65,23 @@ func (ui *Index[T]) Seek(ctx context.Context, page *Page, keyAny any) (IndexCurs
 		return IndexCursor[T]{}, false, fmt.Errorf("invalid key type: %T", keyAny)
 	}
 
-	i := uint32(0)
 	node := page.IndexNode.(*IndexNode[T])
 
-	for i < node.Header.Keys && compare(key, node.Cells[i].Key) > 0 {
-		i += 1
-	}
-	if i < node.Header.Keys && compare(key, node.Cells[i].Key) == 0 {
+	// Binary search: first position where Cells[pos].Key >= key.
+	pos := sort.Search(int(node.Header.Keys), func(i int) bool {
+		return compare(node.Cells[i].Key, key) >= 0
+	})
+	if pos < int(node.Header.Keys) && compare(node.Cells[pos].Key, key) == 0 {
 		return IndexCursor[T]{
 			Index:   ui,
 			PageIdx: page.Index,
-			CellIdx: uint32(i),
+			CellIdx: uint32(pos),
 		}, true, nil
 	}
 	if node.Header.IsLeaf {
 		return IndexCursor[T]{}, false, nil
 	}
-	childIdx, err := node.Child(uint32(i))
+	childIdx, err := node.Child(uint32(pos))
 	if err != nil {
 		return IndexCursor[T]{}, false, fmt.Errorf("get child: %w", err)
 	}


### PR DESCRIPTION
Replaced all linear scans over `IndexNode.Cells` with `sort.Search` (binary search) in `index.go` and `index_cursor.go`:
- **`insertNotFull` — non-unique duplicate key check**: forward linear scan → binary search lower-bound + equality check.
- **`insertNotFull` — leaf insertion position**: backward linear scan + field-by-field shift → binary search + backward struct-copy shift.
- **`insertNotFull` — internal node child selection**: backward linear scan → binary search (first index where `Cells[i].Key > key`).
- **`remove` — key search**: forward linear scan → binary search lower-bound.
- **`Seek` (index_cursor.go)**: forward linear scan → binary search lower-bound.
- The table B+ tree (`InternalNode.IndexOfChild`, `leafNodeSeek`) was already using binary search; no change there.
- **Insert_Batch: 492.2 µs → 407.3 µs (1.21× faster, ratio vs SQLite 2.2× → 1.8×)** — each of the 100 rows per transaction searches an internal or leaf node; binary search directly cuts per-insert comparison count.
- **Insert_PreparedBatch: 490.7 µs → 405.9 µs (1.21× faster, ratio 2.2× → 1.8×)**
- **Insert_MultiValues: 405.3 µs → 317.9 µs (1.27× faster, ratio 2.4× → 1.9×)**
- Insert_SingleRow improved ~5% (19.0 µs → 18.0 µs) — modest benefit since single-row-per-transaction workloads don't accumulate many keys per node before the next transaction starts fresh.
- Read, Update, Delete paths see small improvements consistent with fewer comparisons during tree traversal.