### PR TITLE
refactor: maintain free space cache avoiding the O(n) TakenSpace()

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,54 @@
-### 2026-04-26 (binary search within index nodes — latest)
+### 2026-04-26 (O(1) free-space cache in IndexNode — latest)
+
+Added a `freeBytes uint64` field to `IndexNode[T]` (in-memory only, not serialized). Maintained on every mutating operation so `AvailableSpace()` / `HasSpaceForKey()` / `AtLeastHalfFull()` / `SplitInHalves()` all return in O(1) instead of O(n):
+- **`AvailableSpace()`** now returns `n.freeBytes` directly (was: `MaxSpace() - TakenSpace()`, an O(n) cell-size sum).
+- **`SplitInHalves()`** uses `(n.MaxSpace() - n.freeBytes)` instead of `TakenSpace()` for non-unique midpoint search.
+- `freeBytes` is initialized in `NewIndexNode` (= `MaxSpace()`) and recomputed in `Unmarshal` (accumulates bytes consumed per cell, which equals `cell.Size()`).
+- `Clone()` copies `freeBytes`; all mutating node methods (`AppendCells`, `PrependCell`, `RemoveLastCell`, `RemoveFirstCell`, `DeleteKeyAndRightChild`) maintain it incrementally.
+- `borrowFromLeft` / `borrowFromRight` apply an O(1) size delta to the parent (instead of a full O(n) recompute) to handle variable-width key types (varchar, CompositeKey) correctly.
+- **Insert_Batch: 407.3 µs → 349.3 µs (1.17× faster, ratio vs SQLite 1.8× → 1.55×)** — `hasSpaceForKey` is called on every internal node and the leaf; O(1) free-space check directly reduces per-insert overhead.
+- **Insert_PreparedBatch: 405.9 µs → 347.6 µs (1.17× faster, ratio 1.8× → 1.54×)**
+- **Insert_MultiValues: 317.9 µs → 260.4 µs (1.22× faster, ratio 1.9× → 1.50×)**
+- Insert_SingleRow: unchanged (17.9 µs) — single-row-per-transaction workload benefits less as OCC/WAL overhead dominates.
+- Delete_ByPK: 22.2 µs → 26.4 µs (slight regression; allocs 103 → 116) — cause not fully identified; delete is still 2.7× faster than SQLite.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| **Delete_ByPK** | **26.4 µs/op** | **70.2 µs/op** | **0.37×** |
+| **Insert_SingleRow** | **17.9 µs/op** | **41.9 µs/op** | **0.43×** |
+| **Insert_Batch** | **349.3 µs/op** | **225.2 µs/op** | **1.55×** |
+| **Insert_PreparedBatch** | **347.6 µs/op** | **225.9 µs/op** | **1.54×** |
+| **Insert_MultiValues** | **260.4 µs/op** | **173.3 µs/op** | **1.50×** |
+| Select_PointScan | 4.31 µs/op | 3.43 µs/op | 1.3× |
+| **Select_Limit** | **7.59 µs/op** | **7.70 µs/op** | **0.99×** |
+| **Select_FullScan** | **4.80 ms/op** | **5.08 ms/op** | **0.94×** |
+| Select_CountStar | 17.0 µs/op | 9.86 µs/op | 1.7× |
+| **Select_IndexRangeScan** | **703.5 µs/op** | **770.8 µs/op** | **0.91×** |
+| Select_RangeScan | 1.77 ms/op | 0.86 ms/op | 2.1× |
+| **Update_ByPK** | **10.7 µs/op** | **36.4 µs/op** | **0.29×** |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 30.2 KiB | 447 B |
+| Insert_SingleRow | 21.5 KiB | 311 B |
+| Insert_Batch | 356.1 KiB | 31.0 KiB |
+| Insert_PreparedBatch | 355.7 KiB | 31.0 KiB |
+| Insert_MultiValues | 322.0 KiB | 25.2 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.1 KiB | 1.7 KiB |
+| Select_FullScan | 5.3 MiB | 1.3 MiB |
+| Select_CountStar | 6.0 KiB | 400 B |
+| Select_IndexRangeScan | 739.3 KiB | 85.9 KiB |
+| Select_RangeScan | 1.6 MiB | 85.9 KiB |
+| Update_ByPK | 9.1 KiB | 263 B |
+
+---
+
+### 2026-04-26 (binary search within index nodes)
 
 Replaced all linear scans over `IndexNode.Cells` with `sort.Search` (binary search) in `index.go` and `index_cursor.go`:
 - **`insertNotFull` — non-unique duplicate key check**: forward linear scan → binary search lower-bound + equality check.

--- a/internal/minisql/index.go
+++ b/internal/minisql/index.go
@@ -118,6 +118,7 @@ func (ui *Index[T]) Insert(ctx context.Context, keyAny any, rowID RowID) error {
 		rootNode.Header.IsRoot = true
 		rootNode.Header.IsLeaf = true
 		rootNode.Header.Keys += 1
+		rootNode.freeBytes -= rootNode.Cells[0].Size()
 		// Seed the cache: the root leaf is the rightmost (and only) leaf.
 		ui.rightmostLeaf.Store(int64(ui.GetRootPageIdx()))
 		return nil
@@ -269,6 +270,7 @@ func (ui *Index[T]) tryInsertIntoRightmostLeaf(ctx context.Context, leafIdx Page
 		leafNode.Cells[i].RowIDs = []RowID{rowID}
 	}
 	leafNode.Header.Keys++
+	leafNode.freeBytes -= leafNode.Cells[i].Size()
 	return true, nil
 }
 
@@ -349,6 +351,7 @@ func (ui *Index[T]) insertNotFull(ctx context.Context, pageIdx PageIndex, key T,
 			node.Cells[pos].RowIDs = []RowID{rowID}
 		}
 		node.Header.Keys += 1
+		node.freeBytes -= node.Cells[pos].Size()
 		// The leaf itself is trivially "rightmost at leaf level"; whether it is the
 		// global rightmost depends on the path taken above (callers check their own
 		// level's direction and AND it with this return value).
@@ -456,6 +459,7 @@ func (ui *Index[T]) splitChild(ctx context.Context, parentPage, splitPage *Page,
 		parentNode.Cells[j+1].Overflow = parentNode.Cells[j].Overflow
 	}
 	parentNode.Header.Keys += 1
+	parentNode.freeBytes -= cellToMoveToParent.Size()
 	if len(parentNode.Cells) < int(indexInParent) {
 		parentNode.Cells = append(parentNode.Cells, NewIndexCell[T](ui.unique))
 	}
@@ -846,11 +850,22 @@ func (ui *Index[T]) borrowFromLeft(ctx context.Context, parent, page, left *Page
 		childPage.IndexNode.(*IndexNode[T]).setParent(page.Index)
 	}
 
-	parentNode.Cells[idx-1].Key = leftNode.LastCell().Key
-	parentNode.Cells[idx-1].InlineRowIDs = leftNode.LastCell().InlineRowIDs
-	parentNode.Cells[idx-1].RowIDs = leftNode.LastCell().RowIDs
-	parentNode.Cells[idx-1].UniqueRowID = leftNode.LastCell().UniqueRowID
-	parentNode.Cells[idx-1].Overflow = leftNode.LastCell().Overflow
+	// Capture size before the in-place key replacement; then delta-adjust
+	// freeBytes. For fixed-width types (int64 etc.) old == new, so this is
+	// effectively a no-op arithmetic-wise, but avoids the O(n) recompute.
+	oldCellSize := parentNode.Cells[idx-1].Size()
+	last := leftNode.LastCell()
+	parentNode.Cells[idx-1].Key = last.Key
+	parentNode.Cells[idx-1].InlineRowIDs = last.InlineRowIDs
+	parentNode.Cells[idx-1].RowIDs = last.RowIDs
+	parentNode.Cells[idx-1].UniqueRowID = last.UniqueRowID
+	parentNode.Cells[idx-1].Overflow = last.Overflow
+	newCellSize := parentNode.Cells[idx-1].Size()
+	if newCellSize > oldCellSize {
+		parentNode.freeBytes -= newCellSize - oldCellSize
+	} else {
+		parentNode.freeBytes += oldCellSize - newCellSize
+	}
 
 	leftNode.RemoveLastCell()
 
@@ -884,11 +899,20 @@ func (ui *Index[T]) borrowFromRight(ctx context.Context, parent, page, right *Pa
 		childPage.IndexNode.(*IndexNode[T]).setParent(page.Index)
 	}
 
-	parentNode.Cells[idx].Key = rightNode.FirstCell().Key
-	parentNode.Cells[idx].InlineRowIDs = rightNode.FirstCell().InlineRowIDs
-	parentNode.Cells[idx].RowIDs = rightNode.FirstCell().RowIDs
-	parentNode.Cells[idx].UniqueRowID = rightNode.FirstCell().UniqueRowID
-	parentNode.Cells[idx].Overflow = rightNode.FirstCell().Overflow
+	// Capture size before the in-place key replacement; delta-adjust freeBytes.
+	oldCellSize := parentNode.Cells[idx].Size()
+	first := rightNode.FirstCell()
+	parentNode.Cells[idx].Key = first.Key
+	parentNode.Cells[idx].InlineRowIDs = first.InlineRowIDs
+	parentNode.Cells[idx].RowIDs = first.RowIDs
+	parentNode.Cells[idx].UniqueRowID = first.UniqueRowID
+	parentNode.Cells[idx].Overflow = first.Overflow
+	newCellSize := parentNode.Cells[idx].Size()
+	if newCellSize > oldCellSize {
+		parentNode.freeBytes -= newCellSize - oldCellSize
+	} else {
+		parentNode.freeBytes += oldCellSize - newCellSize
+	}
 
 	rightNode.RemoveFirstCell()
 

--- a/internal/minisql/index_node.go
+++ b/internal/minisql/index_node.go
@@ -266,8 +266,9 @@ func (c *IndexCell[T]) ReplaceRowID(id, newID RowID) int {
 
 // IndexNode is a B+ tree node used by the index, containing a header and a slice of index cells.
 type IndexNode[T IndexKey] struct {
-	Cells  []IndexCell[T]
-	Header IndexNodeHeader
+	Cells     []IndexCell[T]
+	Header    IndexNodeHeader
+	freeBytes uint64 // cached free space in bytes; maintained on every insert/delete
 }
 
 // indexCellsPrealloc is the initial Cells slice capacity for a new IndexNode.
@@ -286,10 +287,15 @@ func NewIndexNode[T IndexKey](unique bool, cells ...IndexCell[T]) *IndexNode[T] 
 	if len(cells) > 0 {
 		node.Header.Keys = uint32(len(cells)) - 1
 		node.Cells = make([]IndexCell[T], len(cells))
+		takenSpace := uint64(0)
 		for i := range cells {
 			node.Cells[i] = cells[i].Clone()
 			node.Cells[i].unique = unique
+			if uint32(i) < node.Header.Keys {
+				takenSpace += node.Cells[i].Size()
+			}
 		}
+		node.freeBytes = node.MaxSpace() - takenSpace
 		return &node
 	}
 
@@ -300,6 +306,7 @@ func NewIndexNode[T IndexKey](unique bool, cells ...IndexCell[T]) *IndexNode[T] 
 	for i := range 4 {
 		node.Cells[i] = NewIndexCell[T](unique)
 	}
+	node.freeBytes = node.MaxSpace()
 	return &node
 }
 
@@ -349,6 +356,7 @@ func (n *IndexNode[T]) Unmarshal(columns []Column, buf []byte) (uint64, error) {
 	}
 	i += hi
 
+	takenSpace := uint64(0)
 	for idx := 0; idx < int(n.Header.Keys); idx++ {
 		if len(n.Cells) == idx {
 			n.Cells = append(n.Cells, NewIndexCell[T](n.Cells[0].unique))
@@ -358,7 +366,9 @@ func (n *IndexNode[T]) Unmarshal(columns []Column, buf []byte) (uint64, error) {
 			return 0, err
 		}
 		i += ci
+		takenSpace += ci
 	}
+	n.freeBytes = n.MaxSpace() - takenSpace
 
 	return i, nil
 }
@@ -445,6 +455,8 @@ func (n *IndexNode[T]) DeleteKeyAndRightChild(idx uint32) error {
 		return fmt.Errorf("index %d out of range for keys %d", idx, n.Header.Keys)
 	}
 
+	removedSize := n.Cells[idx].Size()
+
 	if idx == n.Header.Keys-1 {
 		n.Header.RightChild = n.Cells[idx].Child
 	} else {
@@ -455,6 +467,7 @@ func (n *IndexNode[T]) DeleteKeyAndRightChild(idx uint32) error {
 	}
 
 	n.Cells[int(n.Header.Keys)-1] = NewIndexCell[T](n.Cells[int(n.Header.Keys)-1].unique)
+	n.freeBytes += removedSize
 	n.Header.Keys -= 1
 
 	return nil
@@ -481,10 +494,12 @@ func (n *IndexNode[T]) LastCell() IndexCell[T] {
 
 // RemoveFirstCell ...
 func (n *IndexNode[T]) RemoveFirstCell() {
+	removedSize := n.Cells[0].Size()
 	for i := 0; i < int(n.Header.Keys)-1; i++ {
 		n.Cells[i] = n.Cells[i+1]
 	}
 	n.Cells[n.Header.Keys-1] = NewIndexCell[T](n.Cells[n.Header.Keys-1].unique)
+	n.freeBytes += removedSize
 	n.Header.Keys -= 1
 }
 
@@ -493,6 +508,7 @@ func (n *IndexNode[T]) RemoveLastCell() IndexCell[T] {
 	idx := n.Header.Keys - 1
 	n.Header.RightChild = n.Cells[idx].Child
 	cellToRemove := n.Cells[idx]
+	n.freeBytes += cellToRemove.Size()
 	n.Cells[idx] = NewIndexCell[T](cellToRemove.unique)
 	n.Header.Keys -= 1
 	return cellToRemove
@@ -507,6 +523,7 @@ func (n *IndexNode[T]) PrependCell(cell IndexCell[T]) {
 		n.Cells[i+1] = n.Cells[i]
 	}
 	n.Cells[0] = cell
+	n.freeBytes -= cell.Size()
 	n.Header.Keys += 1
 }
 
@@ -524,6 +541,7 @@ func (n *IndexNode[T]) AppendCells(cells ...IndexCell[T]) {
 		}
 	}
 	for _, cell := range cells {
+		n.freeBytes -= cell.Size()
 		n.Cells[n.Header.Keys] = cell
 		n.Header.Keys += 1
 	}
@@ -557,7 +575,8 @@ func marshalIndexNode(anyNode any, buf []byte) error {
 // Clone ...
 func (n *IndexNode[T]) Clone() *IndexNode[T] {
 	nodeCopy := &IndexNode[T]{
-		Header: n.Header,
+		Header:    n.Header,
+		freeBytes: n.freeBytes,
 	}
 	if n.Header.Keys == 0 {
 		return nodeCopy
@@ -627,10 +646,11 @@ func (n *IndexNode[T]) TakenSpace() uint64 {
 	return takenPageSize
 }
 
-// AvailableSpace ...
+// AvailableSpace returns the number of free bytes in this node (O(1) via cached freeBytes).
 func (n *IndexNode[T]) AvailableSpace() uint64 {
-	return n.MaxSpace() - n.TakenSpace()
+	return n.freeBytes
 }
+
 
 // HasSpaceForKey ...
 func (n *IndexNode[T]) HasSpaceForKey(key T) bool {
@@ -649,7 +669,7 @@ func (n *IndexNode[T]) AtLeastHalfFull() bool {
 // SplitInHalves ...
 func (n *IndexNode[T]) SplitInHalves(unique bool) (uint32, uint32) {
 	if !unique {
-		halfSpace := int(n.TakenSpace() / 2)
+		halfSpace := int((n.MaxSpace() - n.freeBytes) / 2)
 		for i := uint32(0); i < n.Header.Keys; i++ {
 			halfSpace -= int(n.Cells[i].Size())
 			if halfSpace < 0 {

--- a/internal/minisql/index_node_test.go
+++ b/internal/minisql/index_node_test.go
@@ -28,6 +28,7 @@ func TestIndexNode_Int8_Unique_Marshal(t *testing.T) {
 	node.Cells[1].Key = int64(126)
 	node.Cells[1].UniqueRowID = 126
 	node.Cells[1].Child = 8
+	node.freeBytes = node.MaxSpace() - node.TakenSpace()
 
 	buf := make([]byte, node.Size())
 	err := node.Marshal(buf)
@@ -67,6 +68,7 @@ func TestIndexNode_Int8_Marshal(t *testing.T) {
 	node.Cells[1].RowIDs = []RowID{127, 128, 129}
 	node.Cells[1].InlineRowIDs = 3
 	node.Cells[1].Child = 8
+	node.freeBytes = node.MaxSpace() - node.TakenSpace()
 
 	buf := make([]byte, node.Size())
 	err := node.Marshal(buf)
@@ -104,6 +106,7 @@ func TestIndexNode_Varchar_Unique_Marshal(t *testing.T) {
 	node.Cells[1].Key = "bar qux"
 	node.Cells[1].UniqueRowID = 126
 	node.Cells[1].Child = 8
+	node.freeBytes = node.MaxSpace() - node.TakenSpace()
 
 	buf := make([]byte, node.Size())
 	err := node.Marshal(buf)
@@ -148,6 +151,7 @@ func TestIndexNode_Varchar_Marshal(t *testing.T) {
 	node.Cells[1].RowIDs = []RowID{126, 127}
 	node.Cells[1].InlineRowIDs = 2
 	node.Cells[1].Child = 8
+	node.freeBytes = node.MaxSpace() - node.TakenSpace()
 
 	buf := make([]byte, node.Size())
 	err := node.Marshal(buf)

--- a/internal/minisql/index_overflow.go
+++ b/internal/minisql/index_overflow.go
@@ -99,9 +99,10 @@ func (h *IndexOverflowPage) RemoveLastRowID() RowID {
 func appendRowID[T IndexKey](ctx context.Context, pager TxPager, node *IndexNode[T], cellIdx uint32, rowID RowID) error {
 	cell := node.Cells[cellIdx]
 	if cell.Overflow == 0 && len(cell.RowIDs) < MaxInlineRowIDs {
-		// Just append to inline row IDs
+		// Just append to inline row IDs; each inline RowID is 8 bytes.
 		node.Cells[cellIdx].RowIDs = append(node.Cells[cellIdx].RowIDs, rowID)
 		node.Cells[cellIdx].InlineRowIDs += 1
+		node.freeBytes -= 8
 		return nil
 	}
 	if cell.Overflow == 0 && len(cell.RowIDs) == MaxInlineRowIDs {
@@ -165,10 +166,11 @@ func removeRowID[T IndexKey](ctx context.Context, pager TxPager, node *IndexNode
 		return fmt.Errorf("row ID %d not found for key %v", rowID, key)
 	}
 	if node.Cells[cellIdx].Overflow == 0 {
-		// No overflow page, just remove inline row ID
+		// No overflow page, just remove inline row ID; each inline RowID is 8 bytes.
 		if node.Cells[cellIdx].RemoveRowID(rowID) < 0 {
 			return fmt.Errorf("row ID %d not found for key %v", rowID, key)
 		}
+		node.freeBytes += 8
 		return nil
 	}
 	// Otherwise, we need to find the row in overflow pages, remove it,


### PR DESCRIPTION
Added a `freeBytes uint64` field to `IndexNode[T]` (in-memory only, not serialized). Maintained on every mutating operation so `AvailableSpace()` / `HasSpaceForKey()` / `AtLeastHalfFull()` / `SplitInHalves()` all return in O(1) instead of O(n):
- **`AvailableSpace()`** now returns `n.freeBytes` directly (was: `MaxSpace() - TakenSpace()`, an O(n) cell-size sum).
- **`SplitInHalves()`** uses `(n.MaxSpace() - n.freeBytes)` instead of `TakenSpace()` for non-unique midpoint search.
- `freeBytes` is initialized in `NewIndexNode` (= `MaxSpace()`) and recomputed in `Unmarshal` (accumulates bytes consumed per cell, which equals `cell.Size()`).
- `Clone()` copies `freeBytes`; all mutating node methods (`AppendCells`, `PrependCell`, `RemoveLastCell`, `RemoveFirstCell`, `DeleteKeyAndRightChild`) maintain it incrementally.
- `borrowFromLeft` / `borrowFromRight` apply an O(1) size delta to the parent (instead of a full O(n) recompute) to handle variable-width key types (varchar, CompositeKey) correctly.
- **Insert_Batch: 407.3 µs → 349.3 µs (1.17× faster, ratio vs SQLite 1.8× → 1.55×)** — `hasSpaceForKey` is called on every internal node and the leaf; O(1) free-space check directly reduces per-insert overhead.
- **Insert_PreparedBatch: 405.9 µs → 347.6 µs (1.17× faster, ratio 1.8× → 1.54×)**
- **Insert_MultiValues: 317.9 µs → 260.4 µs (1.22× faster, ratio 1.9× → 1.50×)**
- Insert_SingleRow: unchanged (17.9 µs) — single-row-per-transaction workload benefits less as OCC/WAL overhead dominates.
- Delete_ByPK: 22.2 µs → 26.4 µs (slight regression; allocs 103 → 116) — cause not fully identified; delete is still 2.7× faster than SQLite.