### PR TITLE
refactor: move unmarshalling of timestamps further out

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,49 @@
-### 2026-04-26 (biased leaf splits for sequential inserts — latest)
+### 2026-04-29 (TimestampMicros named-type refactor — latest)
+
+`type TimestampMicros int64` replaces `Time` (13-byte struct) as the in-memory representation for all TIMESTAMP column values:
+- A 13-byte `Time` struct boxed into `any` always requires a separate heap allocation (the struct exceeds the 8-byte inline data word). `TimestampMicros` is a named `int64` — 8 bytes, stores inline in the `any` data word with zero extra allocation.
+- The named type is distinct from bare `int64` in type switches, so timestamp arithmetic in `expr.go` (`DATE_TRUNC`, `EXTRACT`, interval math) can still dispatch correctly.
+- All internal paths (`row.go` marshal/unmarshal, `condition.go` comparisons, `stmt.go` parsing, `table_primary_key.go` index key casting) operate on `int64` directly; conversion to `Time` happens only at output boundaries (`rows.go` driver → `time.Time`, DDL string rendering).
+- The benchmark table (`bench_rows`) has no TIMESTAMP columns, so the allocation saving is not reflected in these numbers. Impact is measurable in workloads with TIMESTAMP columns — one fewer heap allocation per TIMESTAMP value per row scanned.
+- Timing differences vs the previous entry are within machine run-to-run variance (the M1 Max exhibits thermal variance of ±15% on short write-path benchmarks across separate runs). Delete_ByPK shows higher variance than usual; no code path touched by this refactor affects the delete benchmark.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| **Delete_ByPK** | **38.7 µs/op** | **72.2 µs/op** | **0.54×** |
+| **Insert_SingleRow** | **19.9 µs/op** | **43.0 µs/op** | **0.46×** |
+| **Insert_Batch** | **334.5 µs/op** | **247.7 µs/op** | **1.35×** |
+| **Insert_PreparedBatch** | **344.9 µs/op** | **254.8 µs/op** | **1.35×** |
+| **Insert_MultiValues** | **238.6 µs/op** | **198.6 µs/op** | **1.20×** |
+| Select_PointScan | 4.39 µs/op | 3.34 µs/op | 1.31× |
+| **Select_Limit** | **7.36 µs/op** | **8.00 µs/op** | **0.92×** |
+| **Select_FullScan** | **4.75 ms/op** | **5.05 ms/op** | **0.94×** |
+| Select_CountStar | 17.4 µs/op | 9.67 µs/op | 1.80× |
+| **Select_IndexRangeScan** | **715.6 µs/op** | **752.7 µs/op** | **0.95×** |
+| Select_RangeScan | 1.68 ms/op | 885.7 µs/op | 1.90× |
+| **Update_ByPK** | **11.8 µs/op** | **38.8 µs/op** | **0.30×** |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Delete_ByPK | 32.7 KiB | 447 B |
+| Insert_SingleRow | 18.6 KiB | 311 B |
+| Insert_Batch | 301.6 KiB | 31.0 KiB |
+| Insert_PreparedBatch | 301.2 KiB | 31.0 KiB |
+| Insert_MultiValues | 268.2 KiB | 25.2 KiB |
+| Select_PointScan | 4.6 KiB | 679 B |
+| Select_Limit | 6.1 KiB | 1.7 KiB |
+| Select_FullScan | 5.3 MiB | 1.3 MiB |
+| Select_CountStar | 6.0 KiB | 400 B |
+| Select_IndexRangeScan | 738.5 KiB | 85.9 KiB |
+| Select_RangeScan | 1.6 MiB | 85.9 KiB |
+| Update_ByPK | 8.4 KiB | 263 B |
+
+---
+
+### 2026-04-26 (biased leaf splits for sequential inserts — previous)
 
 Three changes in this entry:
 

--- a/internal/minisql/analyze_test.go
+++ b/internal/minisql/analyze_test.go
@@ -78,7 +78,7 @@ func TestDatabase_Analyze(t *testing.T) {
 		if i > 0 && i%10 == 0 {
 			now = now.Add(time.Minute)
 		}
-		row.Values[5].Value = MustParseTimestamp(now.Format(timestampFormat))
+		row.Values[5].Value = MustParseTimestampMicros(now.Format(timestampFormat))
 		insertStmt.Inserts = append(insertStmt.Inserts, row.Values)
 	}
 

--- a/internal/minisql/compare.go
+++ b/internal/minisql/compare.go
@@ -111,14 +111,11 @@ func compareAny(a, b any) int {
 		bVal := b.(TextPointer)
 		return strings.Compare(val.String(), bVal.String())
 
-	case Time:
-		var (
-			aMicroseconds = a.(Time).TotalMicroseconds()
-			bMicroseconds = b.(Time).TotalMicroseconds()
-		)
-		if aMicroseconds < bMicroseconds {
+	case TimestampMicros:
+		bVal := b.(TimestampMicros)
+		if val < bVal {
 			return -1
-		} else if aMicroseconds > bMicroseconds {
+		} else if val > bVal {
 			return 1
 		}
 		return 0

--- a/internal/minisql/compare_test.go
+++ b/internal/minisql/compare_test.go
@@ -113,10 +113,10 @@ func TestCompareAny(t *testing.T) {
 		assert.Equal(t, 1, compareAny(world, hello1))
 	})
 
-	t.Run("Time", func(t *testing.T) {
+	t.Run("TimestampMicros", func(t *testing.T) {
 		t.Parallel()
-		t1 := MustParseTimestamp("2020-01-01 00:00:00")
-		t2 := MustParseTimestamp("2021-01-01 00:00:00")
+		t1 := MustParseTimestampMicros("2020-01-01 00:00:00")
+		t2 := MustParseTimestampMicros("2021-01-01 00:00:00")
 		assert.Equal(t, 0, compareAny(t1, t1))
 		assert.Equal(t, -1, compareAny(t1, t2))
 		assert.Equal(t, 1, compareAny(t2, t1))

--- a/internal/minisql/condition.go
+++ b/internal/minisql/condition.go
@@ -548,27 +548,27 @@ func compareText(value1, value2 any, operator Operator) (bool, error) {
 }
 
 func compareTimestamp(value1, value2 any, operator Operator) (bool, error) {
-	theValue1, ok := value1.(Time)
+	theValue1, ok := value1.(TimestampMicros)
 	if !ok {
-		return false, fmt.Errorf("value '%v' cannot be cast as Time", value1)
+		return false, fmt.Errorf("value '%v' cannot be cast as TimestampMicros", value1)
 	}
-	theValue2, ok := value2.(Time)
+	theValue2, ok := value2.(TimestampMicros)
 	if !ok {
-		return false, fmt.Errorf("operand value '%v' cannot be cast as Time", value2)
+		return false, fmt.Errorf("operand value '%v' cannot be cast as TimestampMicros", value2)
 	}
 	switch operator {
 	case Eq:
-		return theValue1.TotalMicroseconds() == theValue2.TotalMicroseconds(), nil
+		return theValue1 == theValue2, nil
 	case Ne:
-		return theValue1.TotalMicroseconds() != theValue2.TotalMicroseconds(), nil
+		return theValue1 != theValue2, nil
 	case Gt:
-		return theValue1.TotalMicroseconds() > theValue2.TotalMicroseconds(), nil
+		return theValue1 > theValue2, nil
 	case Lt:
-		return theValue1.TotalMicroseconds() < theValue2.TotalMicroseconds(), nil
+		return theValue1 < theValue2, nil
 	case Gte:
-		return theValue1.TotalMicroseconds() >= theValue2.TotalMicroseconds(), nil
+		return theValue1 >= theValue2, nil
 	case Lte:
-		return theValue1.TotalMicroseconds() <= theValue2.TotalMicroseconds(), nil
+		return theValue1 <= theValue2, nil
 	}
 	return false, fmt.Errorf("unknown operator '%s'", operator)
 }
@@ -679,9 +679,9 @@ func isInListText(value, list any) (bool, error) {
 }
 
 func isInListTimestamp(value, list any) (bool, error) {
-	_, ok := value.(Time)
+	_, ok := value.(TimestampMicros)
 	if !ok {
-		return false, fmt.Errorf("value '%v' cannot be cast as Time", value)
+		return false, fmt.Errorf("value '%v' cannot be cast as TimestampMicros", value)
 	}
 	theList, ok := list.([]any)
 	if !ok {

--- a/internal/minisql/condition_test.go
+++ b/internal/minisql/condition_test.go
@@ -1412,15 +1412,15 @@ func TestIsBetweenDouble(t *testing.T) {
 func TestIsBetweenTimestamp(t *testing.T) {
 	t.Parallel()
 
-	t1 := MustParseTimestamp("2020-01-01 00:00:00")
-	t2 := MustParseTimestamp("2021-06-15 12:00:00")
-	t3 := MustParseTimestamp("2022-12-31 23:59:59")
+	t1 := MustParseTimestampMicros("2020-01-01 00:00:00")
+	t2 := MustParseTimestampMicros("2021-06-15 12:00:00")
+	t3 := MustParseTimestampMicros("2022-12-31 23:59:59")
 
 	tests := []struct {
 		name  string
-		value Time
-		low   Time
-		high  Time
+		value TimestampMicros
+		low   TimestampMicros
+		high  TimestampMicros
 		want  bool
 	}{
 		{"value in range", t2, t1, t3, true},
@@ -1534,9 +1534,9 @@ func TestIsInListDouble(t *testing.T) {
 func TestIsInListTimestamp(t *testing.T) {
 	t.Parallel()
 
-	t1 := MustParseTimestamp("2020-01-01 00:00:00")
-	t2 := MustParseTimestamp("2021-06-15 12:00:00")
-	t3 := MustParseTimestamp("2022-12-31 23:59:59")
+	t1 := MustParseTimestampMicros("2020-01-01 00:00:00")
+	t2 := MustParseTimestampMicros("2021-06-15 12:00:00")
+	t3 := MustParseTimestampMicros("2022-12-31 23:59:59")
 
 	tests := []struct {
 		value   any
@@ -1568,9 +1568,9 @@ func TestIsInListTimestamp(t *testing.T) {
 func TestCompareTimestamp(t *testing.T) {
 	t.Parallel()
 
-	t1 := MustParseTimestamp("2020-01-01 00:00:00")
-	t2 := MustParseTimestamp("2021-06-15 12:00:00")
-	t3 := MustParseTimestamp("2021-06-15 12:00:00")
+	t1 := MustParseTimestampMicros("2020-01-01 00:00:00")
+	t2 := MustParseTimestampMicros("2021-06-15 12:00:00")
+	t3 := MustParseTimestampMicros("2021-06-15 12:00:00")
 
 	tests := []struct {
 		a        any

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -246,8 +246,8 @@ func (e *Expr) Eval(row Row) (any, error) {
 		return nil, nil
 	}
 
-	// Timestamp ± Interval → Timestamp
-	if lt, lok := leftVal.(Time); lok {
+	// Timestamp ± Interval → Timestamp (stored as TimestampMicros)
+	if lt, lok := leftVal.(TimestampMicros); lok {
 		if ri, rok := rightVal.(Interval); rok {
 			if e.Op != ArithAdd && e.Op != ArithSub {
 				return nil, fmt.Errorf("operator %s is not defined for timestamp and interval", e.Op)
@@ -256,16 +256,16 @@ func (e *Expr) Eval(row Row) (any, error) {
 			if e.Op == ArithSub {
 				sign = -1
 			}
-			return lt.AddInterval(ri, sign), nil
+			return TimestampMicros(FromMicroseconds(int64(lt)).AddInterval(ri, sign).TotalMicroseconds()), nil
 		}
 	}
 	// Interval + Timestamp → Timestamp (addition is commutative)
 	if li, lok := leftVal.(Interval); lok {
-		if rt, rok := rightVal.(Time); rok {
+		if rt, rok := rightVal.(TimestampMicros); rok {
 			if e.Op != ArithAdd {
 				return nil, fmt.Errorf("operator %s is not defined for interval and timestamp", e.Op)
 			}
-			return rt.AddInterval(li, 1), nil
+			return TimestampMicros(FromMicroseconds(int64(rt)).AddInterval(li, 1).TotalMicroseconds()), nil
 		}
 	}
 	// Interval ± Interval → Interval
@@ -285,12 +285,12 @@ func (e *Expr) Eval(row Row) (any, error) {
 		}
 	}
 	// Timestamp - Timestamp → Interval (fixed-duration difference only)
-	if lt, lok := leftVal.(Time); lok {
-		if rt, rok := rightVal.(Time); rok {
+	if lt, lok := leftVal.(TimestampMicros); lok {
+		if rt, rok := rightVal.(TimestampMicros); rok {
 			if e.Op != ArithSub {
 				return nil, fmt.Errorf("operator %s is not defined for two timestamps", e.Op)
 			}
-			return Interval{Micros: lt.TotalMicroseconds() - rt.TotalMicroseconds()}, nil
+			return Interval{Micros: int64(lt) - int64(rt)}, nil
 		}
 	}
 
@@ -488,18 +488,18 @@ func castToTextPointer(v any) (TextPointer, error) {
 	}
 }
 
-func castToTimestamp(v any) (Time, error) {
+func castToTimestamp(v any) (TimestampMicros, error) {
 	switch n := v.(type) {
-	case Time:
+	case TimestampMicros:
 		return n, nil
 	case TextPointer:
 		t, err := ParseTimestamp(string(n.Data))
 		if err != nil {
-			return Time{}, fmt.Errorf("CAST: %w", err)
+			return 0, fmt.Errorf("CAST: %w", err)
 		}
-		return t, nil
+		return TimestampMicros(t.TotalMicroseconds()), nil
 	default:
-		return Time{}, fmt.Errorf("CAST: cannot convert %T to TIMESTAMP", v)
+		return 0, fmt.Errorf("CAST: cannot convert %T to TIMESTAMP", v)
 	}
 }
 
@@ -981,7 +981,7 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 			return nil, fmt.Errorf("NOW takes no arguments")
 		}
 		now := time.Now().UTC()
-		return Time{
+		return TimestampMicros(Time{
 			Year:         int32(now.Year()),
 			Month:        int8(now.Month()),
 			Day:          int8(now.Day()),
@@ -989,7 +989,7 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 			Minutes:      int8(now.Minute()),
 			Seconds:      int8(now.Second()),
 			Microseconds: int32(now.Nanosecond() / 1000),
-		}, nil
+		}.TotalMicroseconds()), nil
 
 	case "DATE_TRUNC":
 		if len(e.Args) != 2 {
@@ -1013,23 +1013,24 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		if tsVal == nil {
 			return nil, nil
 		}
-		ts, ok := tsVal.(Time)
+		tsMicrosRaw, ok := tsVal.(TimestampMicros)
 		if !ok {
 			return nil, fmt.Errorf("DATE_TRUNC: second argument must be a timestamp, got %T", tsVal)
 		}
+		ts := FromMicroseconds(int64(tsMicrosRaw))
 		switch strings.ToLower(unit) {
 		case "year":
-			return Time{Year: ts.Year, Month: 1, Day: 1}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: 1, Day: 1}.TotalMicroseconds()), nil
 		case "month":
-			return Time{Year: ts.Year, Month: ts.Month, Day: 1}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: ts.Month, Day: 1}.TotalMicroseconds()), nil
 		case "day":
-			return Time{Year: ts.Year, Month: ts.Month, Day: ts.Day}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: ts.Month, Day: ts.Day}.TotalMicroseconds()), nil
 		case "hour":
-			return Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour}.TotalMicroseconds()), nil
 		case "minute":
-			return Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour, Minutes: ts.Minutes}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour, Minutes: ts.Minutes}.TotalMicroseconds()), nil
 		case "second":
-			return Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour, Minutes: ts.Minutes, Seconds: ts.Seconds}, nil
+			return TimestampMicros(Time{Year: ts.Year, Month: ts.Month, Day: ts.Day, Hour: ts.Hour, Minutes: ts.Minutes, Seconds: ts.Seconds}.TotalMicroseconds()), nil
 		default:
 			return nil, fmt.Errorf("DATE_TRUNC: unknown unit %q (want year/month/day/hour/minute/second)", unit)
 		}
@@ -1056,10 +1057,11 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		if tsVal == nil {
 			return nil, nil
 		}
-		ts, ok := tsVal.(Time)
+		tsMicrosRaw, ok := tsVal.(TimestampMicros)
 		if !ok {
 			return nil, fmt.Errorf("%s: second argument must be a timestamp, got %T", e.FuncName, tsVal)
 		}
+		ts := FromMicroseconds(int64(tsMicrosRaw))
 		switch strings.ToLower(field) {
 		case "year":
 			return int64(ts.Year), nil
@@ -1076,7 +1078,7 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		case "microsecond":
 			return int64(ts.Microseconds), nil
 		case "epoch":
-			return ts.TotalMicroseconds() / microsecondsInSecond, nil
+			return int64(tsMicrosRaw) / microsecondsInSecond, nil
 		default:
 			return nil, fmt.Errorf("%s: unknown field %q (want year/month/day/hour/minute/second/microsecond/epoch)", e.FuncName, field)
 		}
@@ -1100,7 +1102,7 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("TO_TIMESTAMP: %w", err)
 		}
-		return t, nil
+		return TimestampMicros(t.TotalMicroseconds()), nil
 
 	default:
 		return nil, fmt.Errorf("unknown function %q", e.FuncName)

--- a/internal/minisql/expr_test.go
+++ b/internal/minisql/expr_test.go
@@ -837,7 +837,7 @@ func TestExpr_Eval_MOD(t *testing.T) {
 }
 
 // rowWithTimestamp returns a single-column row containing a TIMESTAMP value.
-func rowWithTimestamp(name string, ts Time) Row {
+func rowWithTimestamp(name string, ts TimestampMicros) Row {
 	return NewRowWithValues(
 		[]Column{{Name: name, Kind: Timestamp}},
 		[]OptionalValue{{Value: ts, Valid: true}},
@@ -857,11 +857,11 @@ func TestExpr_Eval_NOW(t *testing.T) {
 	after := time.Now().UTC()
 
 	require.NoError(t, err)
-	ts, ok := v.(Time)
-	require.True(t, ok, "expected Time result, got %T", v)
+	ts, ok := v.(TimestampMicros)
+	require.True(t, ok, "expected TimestampMicros result, got %T", v)
 
 	// The returned timestamp should be between before and after.
-	got := ts.GoTime()
+	got := FromMicroseconds(int64(ts)).GoTime()
 	assert.False(t, got.Before(before), "NOW() returned time before call")
 	assert.False(t, got.After(after), "NOW() returned time after call")
 }
@@ -869,19 +869,19 @@ func TestExpr_Eval_NOW(t *testing.T) {
 func TestExpr_Eval_DATE_TRUNC(t *testing.T) {
 	t.Parallel()
 
-	ts := MustParseTimestamp("2024-06-15 14:32:45.123456")
+	ts := MustParseTimestampMicros("2024-06-15 14:32:45.123456")
 	row := rowWithTimestamp("ts", ts)
 
 	cases := []struct {
 		unit string
-		want Time
+		want TimestampMicros
 	}{
-		{"year", MustParseTimestamp("2024-01-01 00:00:00")},
-		{"month", MustParseTimestamp("2024-06-01 00:00:00")},
-		{"day", MustParseTimestamp("2024-06-15 00:00:00")},
-		{"hour", MustParseTimestamp("2024-06-15 14:00:00")},
-		{"minute", MustParseTimestamp("2024-06-15 14:32:00")},
-		{"second", MustParseTimestamp("2024-06-15 14:32:45")},
+		{"year", MustParseTimestampMicros("2024-01-01 00:00:00")},
+		{"month", MustParseTimestampMicros("2024-06-01 00:00:00")},
+		{"day", MustParseTimestampMicros("2024-06-15 00:00:00")},
+		{"hour", MustParseTimestampMicros("2024-06-15 14:00:00")},
+		{"minute", MustParseTimestampMicros("2024-06-15 14:32:00")},
+		{"second", MustParseTimestampMicros("2024-06-15 14:32:45")},
 	}
 	for _, tc := range cases {
 		t.Run(tc.unit, func(t *testing.T) {
@@ -916,7 +916,7 @@ func TestExpr_Eval_DATE_TRUNC(t *testing.T) {
 func TestExpr_Eval_EXTRACT(t *testing.T) {
 	t.Parallel()
 
-	ts := MustParseTimestamp("2024-06-15 14:32:45.123456")
+	ts := MustParseTimestampMicros("2024-06-15 14:32:45.123456")
 	row := rowWithTimestamp("ts", ts)
 
 	cases := []struct {
@@ -973,7 +973,7 @@ func TestExpr_Eval_TO_TIMESTAMP(t *testing.T) {
 		e := &Expr{FuncName: "TO_TIMESTAMP", Args: []*Expr{textExpr("2024-03-20 10:15:30")}}
 		v, err := e.Eval(NewRow(nil))
 		require.NoError(t, err)
-		assert.Equal(t, MustParseTimestamp("2024-03-20 10:15:30"), v)
+		assert.Equal(t, MustParseTimestampMicros("2024-03-20 10:15:30"), v)
 	})
 
 	t.Run("null propagates", func(t *testing.T) {

--- a/internal/minisql/interval_test.go
+++ b/internal/minisql/interval_test.go
@@ -203,8 +203,8 @@ func TestAddInterval_Compound(t *testing.T) {
 func TestExpr_TimestampMinusTimestamp(t *testing.T) {
 	t.Parallel()
 
-	ts1 := MustParseTimestamp("2024-01-04 00:00:00")
-	ts2 := MustParseTimestamp("2024-01-01 00:00:00")
+	ts1 := MustParseTimestampMicros("2024-01-04 00:00:00")
+	ts2 := MustParseTimestampMicros("2024-01-01 00:00:00")
 	expr := &Expr{
 		Left:  &Expr{Literal: ts1},
 		Right: &Expr{Literal: ts2},

--- a/internal/minisql/minisql_test.go
+++ b/internal/minisql/minisql_test.go
@@ -63,7 +63,7 @@ var (
 			Size:         8,
 			Name:         "created",
 			Nullable:     true,
-			DefaultValue: OptionalValue{Value: MustParseTimestamp("0001-01-01 00:00:00.000000"), Valid: true},
+			DefaultValue: OptionalValue{Value: MustParseTimestampMicros("0001-01-01 00:00:00.000000"), Valid: true},
 		},
 	}
 	testRowSize = uint64(8 + 4 + 255 + 4 + 1 + 4 + 8) // calculated size of testColumns
@@ -107,7 +107,7 @@ var (
 				Size:         8,
 				Name:         "created",
 				Nullable:     true,
-				DefaultValue: OptionalValue{Value: MustParseTimestamp("0001-01-01 00:00:00.000000"), Valid: true},
+				DefaultValue: OptionalValue{Value: MustParseTimestampMicros("0001-01-01 00:00:00.000000"), Valid: true},
 			},
 		},
 		int((PageSize-uint32(RootPageConfigSize)-
@@ -157,7 +157,7 @@ var (
 				Size:         8,
 				Name:         "created",
 				Nullable:     true,
-				DefaultValue: OptionalValue{Value: MustParseTimestamp("0001-01-01 00:00:00.000000"), Valid: true},
+				DefaultValue: OptionalValue{Value: MustParseTimestampMicros("0001-01-01 00:00:00.000000"), Valid: true},
 			},
 		},
 		int((PageSize - uint32(RootPageConfigSize) -
@@ -229,7 +229,7 @@ func (g *dataGen) Row() Row {
 		{Value: int32(g.IntRange(18, 100)), Valid: true},
 		{Value: g.Bool(), Valid: true},
 		{Value: g.Float32(), Valid: true},
-		{Value: MustParseTimestamp(g.PastDate().Format(timestampFormat)), Valid: true},
+		{Value: MustParseTimestampMicros(g.PastDate().Format(timestampFormat)), Valid: true},
 	})
 }
 
@@ -283,7 +283,7 @@ func (g *dataGen) MediumRow() Row {
 		{Value: int32(g.IntRange(18, 100)), Valid: true},
 		{Value: g.Bool(), Valid: true},
 		{Value: g.Float32(), Valid: true},
-		{Value: MustParseTimestamp(g.PastDate().Format(timestampFormat)), Valid: true},
+		{Value: MustParseTimestampMicros(g.PastDate().Format(timestampFormat)), Valid: true},
 	})
 
 	for len(row.Values) < len(testMediumColumns) {
@@ -342,7 +342,7 @@ func (g *dataGen) BigRow() Row {
 		{Value: int32(g.IntRange(18, 100)), Valid: true},
 		{Value: g.Bool(), Valid: true},
 		{Value: g.Float32(), Valid: true},
-		{Value: MustParseTimestamp(g.PastDate().Format(timestampFormat)), Valid: true},
+		{Value: MustParseTimestampMicros(g.PastDate().Format(timestampFormat)), Valid: true},
 	})
 
 	for len(row.Values) < len(testBigColumns) {
@@ -528,7 +528,7 @@ func (g *dataGen) RowWithCompositeKey() Row {
 		{Value: NewTextPointer([]byte(g.FirstName())), Valid: true},
 		{Value: NewTextPointer([]byte(g.LastName())), Valid: true},
 		{Value: NewTextPointer([]byte(g.Email())), Valid: true},
-		{Value: MustParseTimestamp(g.PastDate().Format(timestampFormat)), Valid: true},
+		{Value: MustParseTimestampMicros(g.PastDate().Format(timestampFormat)), Valid: true},
 	})
 }
 

--- a/internal/minisql/query_plan_multi_index_test.go
+++ b/internal/minisql/query_plan_multi_index_test.go
@@ -140,7 +140,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 						FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
 					},
 					{
-						FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestamp("2025-01-01 00:00:00")),
+						FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
 					},
 				},
 			},
@@ -160,7 +160,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 						IndexColumns: columns[4:5],
 						RangeCondition: RangeCondition{
 							Lower: &RangeBound{
-								Value:     MustParseTimestamp("2025-01-01 00:00:00").TotalMicroseconds(),
+								Value:     int64(MustParseTimestampMicros("2025-01-01 00:00:00")),
 								Inclusive: true,
 							},
 						},
@@ -175,7 +175,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 				Conditions: OneOrMore{
 					{
 						FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
-						FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestamp("2025-01-01 00:00:00")),
+						FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
 						FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
 					},
 				},
@@ -191,7 +191,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 						Filters: OneOrMore{
 							{
 								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
-								FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestamp("2025-01-01 00:00:00")),
+								FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
 							},
 						},
 					},
@@ -204,7 +204,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 				Kind: Select,
 				Conditions: OneOrMore{
 					{
-						FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestamp("2025-01-01 00:00:00")),
+						FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
 						FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
 					},
 				},
@@ -219,7 +219,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 						IndexKeys:    []any{"foo@example.com"},
 						Filters: OneOrMore{
 							{
-								FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestamp("2025-01-01 00:00:00")),
+								FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
 							},
 						},
 					},
@@ -232,7 +232,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 				Kind: Select,
 				Conditions: OneOrMore{
 					{
-						FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestamp("1990-01-01 00:00:00")),
+						FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestampMicros("1990-01-01 00:00:00")),
 					},
 					{
 						FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
@@ -249,7 +249,7 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 						Type:      ScanTypeSequential,
 						Filters: OneOrMore{
 							{
-								FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestamp("1990-01-01 00:00:00")),
+								FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestampMicros("1990-01-01 00:00:00")),
 							},
 							{
 								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),

--- a/internal/minisql/row.go
+++ b/internal/minisql/row.go
@@ -294,11 +294,11 @@ func (r Row) Marshal() ([]byte, error) {
 			}
 			offset += textPointer.Size()
 		case Timestamp:
-			value, ok := r.Values[i].Value.(Time)
+			value, ok := r.Values[i].Value.(TimestampMicros)
 			if !ok {
-				return nil, fmt.Errorf("could not cast value for column %s to time", col.Name)
+				return nil, fmt.Errorf("could not cast value for column %s to timestamp", col.Name)
 			}
-			marshalInt64(buf, value.TotalMicroseconds(), offset)
+			marshalInt64(buf, int64(value), offset)
 			offset += 8
 		}
 	}
@@ -378,7 +378,7 @@ func (r Row) UnmarshalWithMask(cell Cell, selectedMask []bool) (Row, error) {
 			r.Values[i] = OptionalValue{Value: textPointer, Valid: true}
 		case Timestamp:
 			value := unmarshalInt64(cell.Value, uint64(offset))
-			r.Values[i] = OptionalValue{Value: FromMicroseconds(int64(value)), Valid: true}
+			r.Values[i] = OptionalValue{Value: TimestampMicros(value), Valid: true}
 			offset += 8
 		}
 	}

--- a/internal/minisql/row_test.go
+++ b/internal/minisql/row_test.go
@@ -212,7 +212,7 @@ func TestRow_CheckOneOrMore(t *testing.T) {
 			Operator: Eq,
 			Operand2: Operand{
 				Type:  OperandQuotedString,
-				Value: row.Values[5].Value.(Time),
+				Value: row.Values[5].Value.(TimestampMicros),
 			},
 		}
 		timestampMismatch = Condition{
@@ -223,7 +223,7 @@ func TestRow_CheckOneOrMore(t *testing.T) {
 			Operator: Eq,
 			Operand2: Operand{
 				Type:  OperandQuotedString,
-				Value: MustParseTimestamp("1000-01-01 00:00:00 BC"),
+				Value: MustParseTimestampMicros("1000-01-01 00:00:00 BC"),
 			},
 		}
 	)
@@ -597,7 +597,7 @@ func TestRow_CheckOneOrMore(t *testing.T) {
 						Operator: Eq,
 						Operand2: Operand{
 							Type:  OperandQuotedString,
-							Value: MustParseTimestamp("2000-01-01 00:00:00"),
+							Value: MustParseTimestampMicros("2000-01-01 00:00:00"),
 						},
 					},
 				},

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1159,8 +1159,6 @@ func (r Row) rowDistinctKey() string {
 		switch val := v.Value.(type) {
 		case TextPointer:
 			fmt.Fprintf(&b, "t%d:%s", val.Length, val.String())
-		case Time:
-			fmt.Fprintf(&b, "ts:%d", val.Microseconds)
 		case bool:
 			fmt.Fprintf(&b, "b:%t", val)
 		case int64:

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -623,12 +623,12 @@ func (s Statement) prepareCreateTable() (Statement, error) {
 			continue
 		}
 		if col.Kind == Timestamp {
-			// If this is already a Time, accept it as is
-			_, ok := col.DefaultValue.Value.(Time)
+			// If this is already a TimestampMicros value, accept it as is
+			_, ok := col.DefaultValue.Value.(TimestampMicros)
 			if ok {
 				return s, nil
 			}
-			// Otherwise, validate and transform to Time
+			// Otherwise, validate and transform TextPointer → TimestampMicros
 			_, ok = col.DefaultValue.Value.(TextPointer)
 			if !ok {
 				return s, fmt.Errorf("default value '%s' is not a valid TextPointer", col.DefaultValue.Value)
@@ -637,7 +637,7 @@ func (s Statement) prepareCreateTable() (Statement, error) {
 			if err != nil {
 				return s, fmt.Errorf("default value '%s' is not a valid timestamp: %w", col.DefaultValue.Value, err)
 			}
-			col.DefaultValue.Value = timestamp
+			col.DefaultValue.Value = TimestampMicros(timestamp.TotalMicroseconds())
 			s.Columns[i] = col
 		}
 
@@ -708,7 +708,7 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 				if col.DefaultValue.Valid {
 					val = col.DefaultValue
 				} else if col.DefaultValueNow {
-					val = OptionalValue{Valid: true, Value: now}
+					val = OptionalValue{Valid: true, Value: TimestampMicros(now.TotalMicroseconds())}
 				}
 				newRow[i] = val
 				continue
@@ -717,7 +717,7 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 			if val.Valid {
 				if fn, ok := val.Value.(Function); ok {
 					if fn.Name == FunctionNow.Name {
-						val.Value = now
+						val.Value = TimestampMicros(now.TotalMicroseconds())
 					} else {
 						return Statement{}, fmt.Errorf("unsupported function %q in INSERT", fn.Name)
 					}
@@ -749,7 +749,7 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 				if fn.Name != FunctionNow.Name {
 					return Statement{}, fmt.Errorf("unsupported function %q in ON CONFLICT DO UPDATE", fn.Name)
 				}
-				val.Value = now
+				val.Value = TimestampMicros(now.TotalMicroseconds())
 				s.Updates[name] = val
 				continue
 			}
@@ -797,7 +797,7 @@ func (s Statement) prepareUpdate(now Time) (Statement, error) {
 
 		if fn, ok := updateValue.Value.(Function); ok {
 			if fn.Name == FunctionNow.Name {
-				updateValue.Value = now
+				updateValue.Value = TimestampMicros(now.TotalMicroseconds())
 				s.Updates[name] = updateValue
 			} else {
 				return Statement{}, fmt.Errorf("unsupported function %q in UPDATE", fn.Name)
@@ -865,20 +865,19 @@ func (s Statement) prepareWhere() (Statement, error) {
 	return s, nil
 }
 
-func parseTimeValue(value any) (Time, error) {
-	_, ok := value.(Time)
-	if ok {
-		return value.(Time), nil
+func parseTimeValue(value any) (TimestampMicros, error) {
+	if micros, ok := value.(TimestampMicros); ok {
+		return micros, nil
 	}
 	tp, ok := value.(TextPointer)
 	if !ok {
-		return Time{}, errors.New("timestamp field expects TextPointer value")
+		return 0, errors.New("timestamp field expects TextPointer value")
 	}
 	timestamp, err := ParseTimestamp(tp.String())
 	if err != nil {
-		return Time{}, fmt.Errorf("invalid timestamp format for field: %w", err)
+		return 0, fmt.Errorf("invalid timestamp format for field: %w", err)
 	}
-	return timestamp, nil
+	return TimestampMicros(timestamp.TotalMicroseconds()), nil
 }
 
 // Validate ...
@@ -1449,9 +1448,9 @@ func isValueValidForColumn(col Column, val OptionalValue) error {
 			return fmt.Errorf("expects valid UTF-8 string for %q", col.Name)
 		}
 	case Timestamp:
-		_, ok := val.Value.(Time)
+		_, ok := val.Value.(TimestampMicros)
 		if !ok {
-			return fmt.Errorf("expects time value for %q", col.Name)
+			return fmt.Errorf("expects timestamp value for %q", col.Name)
 		}
 	}
 	return nil
@@ -1585,7 +1584,7 @@ func (s Statement) createTableDDL() string {
 				case Varchar, Text:
 					fmt.Fprintf(&sb, " default '%s'", col.DefaultValue.Value.(TextPointer).String())
 				case Timestamp:
-					fmt.Fprintf(&sb, " default '%s'", col.DefaultValue.Value.(Time).String())
+					fmt.Fprintf(&sb, " default '%s'", FromMicroseconds(int64(col.DefaultValue.Value.(TimestampMicros))).String())
 				}
 			}
 		}

--- a/internal/minisql/stmt_test.go
+++ b/internal/minisql/stmt_test.go
@@ -204,7 +204,7 @@ func TestStatement_Prepare_Insert(t *testing.T) {
 		assert.Equal(t, [][]OptionalValue{
 			{
 				{
-					Value: now,
+					Value: TimestampMicros(now.TotalMicroseconds()),
 					Valid: true,
 				},
 			},
@@ -240,7 +240,7 @@ func TestStatement_Prepare_Insert(t *testing.T) {
 		assert.Equal(t, [][]OptionalValue{
 			{
 				{
-					Value: now,
+					Value: TimestampMicros(now.TotalMicroseconds()),
 					Valid: true,
 				},
 			},
@@ -283,7 +283,7 @@ func TestStatement_Prepare_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, OptionalValue{
-			Value: now,
+			Value: TimestampMicros(now.TotalMicroseconds()),
 			Valid: true,
 		}, stmt.Updates["created"])
 	})
@@ -332,7 +332,7 @@ func TestStatement_Prepare_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, OptionalValue{
-			Value: now,
+			Value: TimestampMicros(now.TotalMicroseconds()),
 			Valid: true,
 		}, stmt.Updates["created"])
 	})
@@ -362,16 +362,16 @@ func TestStatement_Prepare_CreateTable(t *testing.T) {
 		}
 	)
 
-	_, ok := stmt.Columns[1].DefaultValue.Value.(Time)
+	_, ok := stmt.Columns[1].DefaultValue.Value.(TimestampMicros)
 	assert.False(t, ok)
 
 	var err error
 	stmt, err = stmt.Prepare(Time{})
 	require.NoError(t, err)
 
-	_, ok = stmt.Columns[1].DefaultValue.Value.(Time)
-	assert.True(t, ok, "expected default value for 'created' column to be Time")
-	assert.Equal(t, MustParseTimestamp("0001-01-01 00:00:00"), stmt.Columns[1].DefaultValue.Value)
+	_, ok = stmt.Columns[1].DefaultValue.Value.(TimestampMicros)
+	assert.True(t, ok, "expected default value for 'created' column to be TimestampMicros")
+	assert.Equal(t, MustParseTimestampMicros("0001-01-01 00:00:00"), stmt.Columns[1].DefaultValue.Value)
 }
 
 func TestStatement_Validate(t *testing.T) {
@@ -1453,12 +1453,12 @@ func TestStatement_ValidateColumnValue(t *testing.T) {
 			"invalid TIMESTAMP value",
 			Column{Kind: Timestamp, Name: "foo"},
 			OptionalValue{Value: int32(25), Valid: true},
-			`expects time value for "foo"`,
+			`expects timestamp value for "foo"`,
 		},
 		{
 			"valid TIMESTAMP value",
 			Column{Kind: Timestamp, Name: "foo"},
-			OptionalValue{Value: MustParseTimestamp("2000-01-01 00:00:00"), Valid: true},
+			OptionalValue{Value: MustParseTimestampMicros("2000-01-01 00:00:00"), Valid: true},
 			"",
 		},
 	}
@@ -1897,8 +1897,8 @@ func TestStatement_PrepareWhere(t *testing.T) {
 		}
 		result, err := stmt.prepareWhere()
 		require.NoError(t, err)
-		_, ok := result.Conditions[0][0].Operand2.Value.(Time)
-		assert.True(t, ok, "expected Time value after prepareWhere")
+		_, ok := result.Conditions[0][0].Operand2.Value.(TimestampMicros)
+		assert.True(t, ok, "expected TimestampMicros value after prepareWhere")
 	})
 
 	t.Run("unknown field returns error", func(t *testing.T) {

--- a/internal/minisql/table_primary_key.go
+++ b/internal/minisql/table_primary_key.go
@@ -275,11 +275,11 @@ func castKeyValue(col Column, val any) (any, error) {
 		}
 		return tp.String(), nil
 	case Timestamp:
-		timestamp, ok := val.(Time)
+		micros, ok := val.(TimestampMicros)
 		if !ok {
-			return nil, fmt.Errorf("could not cast value for column %s to Time", col.Name)
+			return nil, fmt.Errorf("could not cast value for column %s to timestamp", col.Name)
 		}
-		return timestamp.TotalMicroseconds(), nil
+		return int64(micros), nil
 	default:
 		return val, nil
 	}

--- a/internal/minisql/timestamp.go
+++ b/internal/minisql/timestamp.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+// TimestampMicros is the in-memory representation of a TIMESTAMP column value.
+// It stores microseconds since 2000-01-01 00:00:00 UTC as a named int64 so
+// that it is distinguishable from numeric int64 values in type switches, while
+// still fitting inline in an any interface word — no heap allocation.
+type TimestampMicros int64
+
 const (
 	timestampFormat = "2006-01-02 15:04:05.999999"
 	// 2024-06-15 12:34:56
@@ -181,6 +187,11 @@ func MustParseTimestamp(timestampStr string) Time {
 		panic(err)
 	}
 	return t
+}
+
+// MustParseTimestampMicros parses a timestamp string into a TimestampMicros and panics on error.
+func MustParseTimestampMicros(timestampStr string) TimestampMicros {
+	return TimestampMicros(MustParseTimestamp(timestampStr).TotalMicroseconds())
 }
 
 // ParseTimestamp parses a PostgreSQL-style timestamp string into a Time value.

--- a/internal/minisql/update_test.go
+++ b/internal/minisql/update_test.go
@@ -75,7 +75,7 @@ func TestTable_Update(t *testing.T) {
 			Kind: Update,
 			Updates: map[string]OptionalValue{
 				"email":   {Value: NewTextPointer([]byte("updatedsingle@foo.bar")), Valid: true},
-				"created": {Value: MustParseTimestamp("2000-01-01 00:00:00"), Valid: true},
+				"created": {Value: MustParseTimestampMicros("2000-01-01 00:00:00"), Valid: true},
 			},
 			Conditions: OneOrMore{
 				{
@@ -99,7 +99,7 @@ func TestTable_Update(t *testing.T) {
 			expectedRow := row.Clone()
 			if i == 5 {
 				expectedRow, _ = expectedRow.SetValue("email", OptionalValue{Value: NewTextPointer([]byte("updatedsingle@foo.bar")), Valid: true})
-				expectedRow, _ = expectedRow.SetValue("created", OptionalValue{Value: MustParseTimestamp("2000-01-01 00:00:00"), Valid: true})
+				expectedRow, _ = expectedRow.SetValue("created", OptionalValue{Value: MustParseTimestampMicros("2000-01-01 00:00:00"), Valid: true})
 				rows[i] = expectedRow
 			}
 

--- a/rows.go
+++ b/rows.go
@@ -63,8 +63,8 @@ func (r Rows) Next(dest []driver.Value) error {
 		switch v := aRow.Values[i].Value.(type) {
 		case minisql.TextPointer:
 			dest[i] = string(v.Data)
-		case minisql.Time:
-			dest[i] = v.GoTime()
+		case minisql.TimestampMicros:
+			dest[i] = minisql.FromMicroseconds(int64(v)).GoTime()
 		default:
 			dest[i] = aRow.Values[i].Value
 		}


### PR DESCRIPTION
- `type TimestampMicros int64` replaces `Time` (13-byte struct) as the in-memory representation for all TIMESTAMP column values:
- A 13-byte `Time` struct boxed into `any` always requires a separate heap allocation (the struct exceeds the 8-byte inline data word). `TimestampMicros` is a named `int64` — 8 bytes, stores inline in the `any` data word with zero extra allocation.
- The named type is distinct from bare `int64` in type switches, so timestamp arithmetic in `expr.go` (`DATE_TRUNC`, `EXTRACT`, interval math) can still dispatch correctly.
- All internal paths (`row.go` marshal/unmarshal, `condition.go` comparisons, `stmt.go` parsing, `table_primary_key.go` index key casting) operate on `int64` directly; conversion to `Time` happens only at output boundaries (`rows.go` driver → `time.Time`, DDL string rendering).
- The benchmark table (`bench_rows`) has no TIMESTAMP columns, so the allocation saving is not reflected in these numbers. Impact is measurable in workloads with TIMESTAMP columns — one fewer heap allocation per TIMESTAMP value per row scanned.
- Timing differences vs the previous entry are within machine run-to-run variance (the M1 Max exhibits thermal variance of ±15% on short write-path benchmarks across separate runs). Delete_ByPK shows higher variance than usual; no code path touched by this refactor affects the delete benchmark.