### PR TITLE
feat: implement RETURNING clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,11 +346,12 @@ Important behavior and current non-goals:
 | `CREATE INDEX`, `DROP INDEX` | Secondary non-unique indexes only; primary and unique indexes are declared as part of `CREATE TABLE` |
 | `INSERT` | Single row or multiple rows via a tuple of values separated by commas |
 | `ON CONFLICT` | Both `DO NOTHING` and `DO UPDATE` supported (with `EXCLUDED` pseudo table syntax for updating) |
-| `SELECT` | All fields with `*`, specific fields, or row count with `COUNT(*)` |
+| `SELECT` | All fields with `*`, specific fields, or row count with `COUNT(*)`, |
 | `SELECT DISTINCT` | |
 | `JOIN` | `INNER`, `LEFT` and `RIGHT` joins supported |
 | `UPDATE` | |
 | `DELETE` | |
+| `RETURNING` | Can be used to return columns from `INSERT` or `DELETE` queries, common use case is to return auto incremented primary key |
 | `WHERE` | Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `IN`, `NOT IN`, `LIKE`, `NOT LIKE`, `BETWEEN` |
 | `LIKE`, `NOT LIKE` | `%` matches any sequence of zero or more characters; `_` matches any single character |
 | `LIMIT` and `OFFSET` | Basic pagination |

--- a/e2e_tests/returning_test.go
+++ b/e2e_tests/returning_test.go
@@ -1,0 +1,201 @@
+package e2etests
+
+import "time"
+
+func (s *TestSuite) TestReturning() {
+	_, err := s.db.Exec(`create table "users" (
+		id         int8 primary key autoincrement,
+		name       varchar(100) not null,
+		email      varchar(200) not null,
+		score      int8,
+		created_at timestamp
+	);`)
+	s.Require().NoError(err)
+
+	s.Run("INSERT_RETURNING_id", func() {
+		rows, err := s.db.Query(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"Alice", "alice@example.com", int64(10), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var id int64
+		s.Require().NoError(rows.Scan(&id))
+		s.Greater(id, int64(0))
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("INSERT_RETURNING_multiple_columns", func() {
+		rows, err := s.db.Query(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id, name, score`,
+			"Bob", "bob@example.com", int64(20), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var id, score int64
+		var name string
+		s.Require().NoError(rows.Scan(&id, &name, &score))
+		s.Greater(id, int64(0))
+		s.Equal("Bob", name)
+		s.Equal(int64(20), score)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("INSERT_multi_row_RETURNING", func() {
+		rows, err := s.db.Query(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?), (?, ?, ?, ?) returning id, name`,
+			"Carol", "carol@example.com", int64(30), time.Now(),
+			"Dave", "dave@example.com", int64(40), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var results []struct {
+			id   int64
+			name string
+		}
+		for rows.Next() {
+			var id int64
+			var name string
+			s.Require().NoError(rows.Scan(&id, &name))
+			results = append(results, struct {
+				id   int64
+				name string
+			}{id, name})
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(results, 2)
+		s.Equal("Carol", results[0].name)
+		s.Equal("Dave", results[1].name)
+		s.Greater(results[1].id, results[0].id)
+	})
+
+	s.Run("UPDATE_RETURNING_single_column", func() {
+		// First insert a known row
+		var id int64
+		row := s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"Eve", "eve@example.com", int64(50), time.Now(),
+		)
+		s.Require().NoError(row.Scan(&id))
+
+		rows, err := s.db.Query(
+			`update users set score = ? where id = ? returning score`,
+			int64(99), id,
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var score int64
+		s.Require().NoError(rows.Scan(&score))
+		s.Equal(int64(99), score)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("UPDATE_RETURNING_multiple_columns", func() {
+		var id int64
+		row := s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"Frank", "frank@example.com", int64(5), time.Now(),
+		)
+		s.Require().NoError(row.Scan(&id))
+
+		rows, err := s.db.Query(
+			`update users set name = ?, score = ? where id = ? returning id, name, score`,
+			"Franklin", int64(55), id,
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotID, gotScore int64
+		var gotName string
+		s.Require().NoError(rows.Scan(&gotID, &gotName, &gotScore))
+		s.Equal(id, gotID)
+		s.Equal("Franklin", gotName)
+		s.Equal(int64(55), gotScore)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("DELETE_RETURNING_id", func() {
+		var id int64
+		row := s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"Grace", "grace@example.com", int64(1), time.Now(),
+		)
+		s.Require().NoError(row.Scan(&id))
+
+		rows, err := s.db.Query(
+			`delete from users where id = ? returning id, name`,
+			id,
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotID int64
+		var gotName string
+		s.Require().NoError(rows.Scan(&gotID, &gotName))
+		s.Equal(id, gotID)
+		s.Equal("Grace", gotName)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+
+		// Confirm row is actually gone
+		var count int64
+		s.Require().NoError(s.db.QueryRow(`select count(*) from users where id = ?`, id).Scan(&count))
+		s.Equal(int64(0), count)
+	})
+
+	s.Run("DELETE_RETURNING_multiple_rows", func() {
+		// Insert several rows, delete a subset, return them
+		for i := range 3 {
+			_, err := s.db.Exec(
+				`insert into users (name, email, score, created_at) values (?, ?, ?, ?)`,
+				"TempUser", "temp@example.com", int64(i+100), time.Now(),
+			)
+			s.Require().NoError(err)
+		}
+
+		rows, err := s.db.Query(`delete from users where name = ? returning score`, "TempUser")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var scores []int64
+		for rows.Next() {
+			var score int64
+			s.Require().NoError(rows.Scan(&score))
+			scores = append(scores, score)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(scores, 3)
+	})
+
+	s.Run("INSERT_ON_CONFLICT_DO_NOTHING_no_rows_returned", func() {
+		// Insert a row first
+		var id int64
+		s.Require().NoError(s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"Unique", "unique@example.com", int64(1), time.Now(),
+		).Scan(&id))
+
+		// DO NOTHING conflict — nothing inserted, no rows returned
+		rows, err := s.db.Query(
+			`insert into users (id, name, email, score, created_at) values (?, ?, ?, ?, ?) on conflict do nothing returning id`,
+			id, "Unique", "unique@example.com", int64(1), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+		s.Require().False(rows.Next(), "DO NOTHING should return no rows")
+		s.Require().NoError(rows.Err())
+	})
+}

--- a/internal/minisql/delete.go
+++ b/internal/minisql/delete.go
@@ -76,5 +76,18 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
+	if len(stmt.ReturningFields) > 0 {
+		returningRows := make([]Row, 0, len(rows))
+		for _, row := range rows {
+			projected, err := projectReturning(row, stmt.ReturningFields)
+			if err != nil {
+				return result, err
+			}
+			returningRows = append(returningRows, projected)
+		}
+		result.Columns = returningColumns(stmt.ReturningFields, t.Columns)
+		result.Rows = NewSliceIterator(returningRows)
+	}
+
 	return result, nil
 }

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -30,6 +30,7 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 	// newRowsInserted counts only actual new rows added to the table (not DO UPDATE
 	// hits, which update existing rows without changing the total count).
 	newRowsInserted := 0
+	var returningRows []Row
 	for insertIdx, values := range stmt.Inserts {
 		switch stmt.ConflictAction {
 		case ConflictActionDoNothing:
@@ -129,6 +130,16 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 		row := NewRowWithValues(t.Columns, rowValues)
 
+		// Collect the row for RETURNING before it is inserted (values are already
+		// final at this point, including any autoincrement PK that was resolved above).
+		if len(stmt.ReturningFields) > 0 {
+			projected, err := projectReturning(row, stmt.ReturningFields)
+			if err != nil {
+				return StatementResult{}, err
+			}
+			returningRows = append(returningRows, projected)
+		}
+
 		page, err := t.pager.ModifyPage(ctx, cursor.PageIdx)
 		if err != nil {
 			return StatementResult{}, fmt.Errorf("insert: %w", err)
@@ -195,8 +206,12 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
-	// TODO - set LastInsertId
-	return StatementResult{RowsAffected: rowsInserted}, nil
+	result := StatementResult{RowsAffected: rowsInserted}
+	if len(stmt.ReturningFields) > 0 {
+		result.Columns = returningColumns(stmt.ReturningFields, t.Columns)
+		result.Rows = NewSliceIterator(returningRows)
+	}
+	return result, nil
 }
 
 // hasInsertConflict returns true if inserting the row at insertIdx would violate

--- a/internal/minisql/returning.go
+++ b/internal/minisql/returning.go
@@ -1,0 +1,51 @@
+package minisql
+
+// returningColumns resolves the output Column slice for a RETURNING clause.
+// Fields containing "*" expand to all table columns.
+func returningColumns(fields []Field, tableColumns []Column) []Column {
+	out := make([]Column, 0, len(fields))
+	for _, f := range fields {
+		if f.Name == "*" {
+			out = append(out, tableColumns...)
+			continue
+		}
+		for _, col := range tableColumns {
+			if col.Name == f.Name {
+				out = append(out, col)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// projectReturning projects a row down to the columns requested by a RETURNING
+// clause. The returned Row has one Value per field (in field order).
+func projectReturning(row Row, fields []Field) (Row, error) {
+	cols := make([]Column, 0, len(fields))
+	vals := make([]OptionalValue, 0, len(fields))
+	for _, f := range fields {
+		if f.Name == "*" {
+			cols = append(cols, row.Columns...)
+			vals = append(vals, row.Values...)
+			continue
+		}
+		val, ok := row.GetValue(f.Name)
+		if !ok {
+			// Column not in row — return NULL rather than an error so that callers
+			// composing rows from partial fetches still work.
+			val = OptionalValue{}
+		}
+		// Find the Column definition for type metadata.
+		var col Column
+		for _, c := range row.Columns {
+			if c.Name == f.Name {
+				col = c
+				break
+			}
+		}
+		cols = append(cols, col)
+		vals = append(vals, val)
+	}
+	return NewRowWithValues(cols, vals), nil
+}

--- a/internal/minisql/returning_test.go
+++ b/internal/minisql/returning_test.go
@@ -1,0 +1,117 @@
+package minisql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReturningColumns(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "name", Kind: Varchar, Size: 100},
+		{Name: "score", Kind: Int4, Size: 4},
+		{Name: "email", Kind: Varchar, Size: 200},
+	}
+
+	t.Run("specific fields in order", func(t *testing.T) {
+		t.Parallel()
+		got := returningColumns([]Field{{Name: "id"}, {Name: "score"}}, cols)
+		require.Len(t, got, 2)
+		assert.Equal(t, "id", got[0].Name)
+		assert.Equal(t, "score", got[1].Name)
+	})
+
+	t.Run("star expands to all columns", func(t *testing.T) {
+		t.Parallel()
+		got := returningColumns([]Field{{Name: "*"}}, cols)
+		assert.Equal(t, cols, got)
+	})
+
+	t.Run("unknown field returns empty slice entry", func(t *testing.T) {
+		t.Parallel()
+		got := returningColumns([]Field{{Name: "nonexistent"}}, cols)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty fields returns empty slice", func(t *testing.T) {
+		t.Parallel()
+		got := returningColumns(nil, cols)
+		assert.Empty(t, got)
+	})
+
+	t.Run("mix of specific and star", func(t *testing.T) {
+		t.Parallel()
+		got := returningColumns([]Field{{Name: "id"}, {Name: "*"}}, cols)
+		require.Len(t, got, 5) // "id" + all 4 columns from "*"
+		assert.Equal(t, "id", got[0].Name)
+		assert.Equal(t, "id", got[1].Name)
+	})
+}
+
+func TestProjectReturning(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "name", Kind: Varchar, Size: 100},
+		{Name: "score", Kind: Int4, Size: 4},
+	}
+	vals := []OptionalValue{
+		{Value: int64(42), Valid: true},
+		{Value: NewTextPointer([]byte("Alice")), Valid: true},
+		{Value: int32(99), Valid: true},
+	}
+	row := NewRowWithValues(cols, vals)
+
+	t.Run("project single field", func(t *testing.T) {
+		t.Parallel()
+		got, err := projectReturning(row, []Field{{Name: "id"}})
+		require.NoError(t, err)
+		require.Len(t, got.Values, 1)
+		assert.Equal(t, int64(42), got.Values[0].Value)
+		assert.True(t, got.Values[0].Valid)
+	})
+
+	t.Run("project multiple fields", func(t *testing.T) {
+		t.Parallel()
+		got, err := projectReturning(row, []Field{{Name: "id"}, {Name: "score"}})
+		require.NoError(t, err)
+		require.Len(t, got.Values, 2)
+		assert.Equal(t, int64(42), got.Values[0].Value)
+		assert.Equal(t, int32(99), got.Values[1].Value)
+	})
+
+	t.Run("star returns all values", func(t *testing.T) {
+		t.Parallel()
+		got, err := projectReturning(row, []Field{{Name: "*"}})
+		require.NoError(t, err)
+		assert.Equal(t, row.Values, got.Values)
+		assert.Equal(t, row.Columns, got.Columns)
+	})
+
+	t.Run("unknown field returns null value", func(t *testing.T) {
+		t.Parallel()
+		got, err := projectReturning(row, []Field{{Name: "nonexistent"}})
+		require.NoError(t, err)
+		require.Len(t, got.Values, 1)
+		assert.False(t, got.Values[0].Valid)
+	})
+
+	t.Run("null value in row is preserved", func(t *testing.T) {
+		t.Parallel()
+		nullVals := []OptionalValue{
+			{Value: int64(7), Valid: true},
+			{Valid: false}, // name is NULL
+			{Value: int32(0), Valid: true},
+		}
+		nullRow := NewRowWithValues(cols, nullVals)
+		got, err := projectReturning(nullRow, []Field{{Name: "name"}})
+		require.NoError(t, err)
+		require.Len(t, got.Values, 1)
+		assert.False(t, got.Values[0].Valid)
+	})
+}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -331,10 +331,11 @@ type Statement struct {
 	UniqueIndexes  []UniqueIndex
 	Columns        []Column
 	Conditions     OneOrMore
-	Kind           StatementKind
-	ConflictAction ConflictAction
-	IfNotExists    bool
-	Distinct       bool
+	ReturningFields []Field
+	Kind            StatementKind
+	ConflictAction  ConflictAction
+	IfNotExists     bool
+	Distinct        bool
 }
 
 // NumPlaceholders returns the number of placeholder parameters (?) in the statement.
@@ -401,24 +402,30 @@ func (s Statement) Clone() Statement {
 	}
 
 	stmt := Statement{
-		Kind:           s.Kind,
-		IfNotExists:    s.IfNotExists,
-		TableName:      s.TableName,
-		IndexName:      s.IndexName,
-		PragmaName:     s.PragmaName,
-		PragmaValue:    s.PragmaValue,
-		ConflictAction: s.ConflictAction,
-		Columns:        s.Columns,
-		Distinct:       s.Distinct,
-		Fields:         fields,
-		Aggregates:     s.Aggregates, // slice of value types, safe to share
-		Aliases:        s.Aliases,
-		Inserts:        make([][]OptionalValue, len(s.Inserts)),
-		Functions:      s.Functions,
-		Conditions:     make(OneOrMore, len(s.Conditions)),
-		OrderBy:        s.OrderBy,
-		Limit:          s.Limit,
-		Offset:         s.Offset,
+		Kind:            s.Kind,
+		IfNotExists:     s.IfNotExists,
+		TableName:       s.TableName,
+		TableAlias:      s.TableAlias,
+		IndexName:       s.IndexName,
+		Target:          s.Target,
+		PragmaName:      s.PragmaName,
+		PragmaValue:     s.PragmaValue,
+		ConflictAction:  s.ConflictAction,
+		Columns:         s.Columns,
+		Distinct:        s.Distinct,
+		Fields:          fields,
+		Aggregates:      s.Aggregates, // slice of value types, safe to share
+		Aliases:         s.Aliases,
+		Inserts:         make([][]OptionalValue, len(s.Inserts)),
+		Functions:       s.Functions,
+		Conditions:      make(OneOrMore, len(s.Conditions)),
+		GroupBy:         s.GroupBy,
+		Having:          s.Having,
+		Joins:           s.Joins,
+		OrderBy:         s.OrderBy,
+		Limit:           s.Limit,
+		Offset:          s.Offset,
+		ReturningFields: s.ReturningFields,
 	}
 	for i := range s.Inserts {
 		stmt.Inserts[i] = make([]OptionalValue, len(s.Inserts[i]))

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -34,7 +34,10 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 	// affects indexed columns. If not, and the row size does not increase, we update
 	// rows in-place as we encounter them. Otherwise we collect all rows first and
 	// update them afterwards to avoid conflicts with B-tree structural changes.
-	var cantUpdateInPlace []Row
+	var (
+		cantUpdateInPlace []Row
+		updatedKeys       []RowID // tracked only when RETURNING is requested
+	)
 
 	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
 		size := row.Size()
@@ -88,6 +91,9 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 			}
 			if changed {
 				result.RowsAffected += 1
+				if len(stmt.ReturningFields) > 0 {
+					updatedKeys = append(updatedKeys, row.Key)
+				}
 			}
 			return nil
 		}
@@ -113,9 +119,35 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 
 		if changed {
 			result.RowsAffected += 1
+			if len(stmt.ReturningFields) > 0 {
+				updatedKeys = append(updatedKeys, row.Key)
+			}
 		}
 	}
 
 	t.logger.Debug("updated rows", zap.Int("count", result.RowsAffected))
+
+	if len(stmt.ReturningFields) > 0 {
+		allFields := fieldsFromColumns(t.Columns...)
+		returningRows := make([]Row, 0, len(updatedKeys))
+		for _, key := range updatedKeys {
+			cursor, err := t.Seek(ctx, key)
+			if err != nil {
+				return result, err
+			}
+			row, err := cursor.fetchRow(ctx, false, allFields...)
+			if err != nil {
+				return result, err
+			}
+			projected, err := projectReturning(row, stmt.ReturningFields)
+			if err != nil {
+				return result, err
+			}
+			returningRows = append(returningRows, projected)
+		}
+		result.Columns = returningColumns(stmt.ReturningFields, t.Columns)
+		result.Rows = NewSliceIterator(returningRows)
+	}
+
 	return result, nil
 }

--- a/internal/parser/insert.go
+++ b/internal/parser/insert.go
@@ -115,8 +115,13 @@ func (p *parserItem) doParseInsert() error {
 		p.step = stepInsertValuesCommaBeforeOpeningParens
 	case stepInsertValuesCommaBeforeOpeningParens:
 		commaOrEnd := p.peek()
-		if commaOrEnd == ";" {
+		if commaOrEnd == ";" || commaOrEnd == "" {
 			p.step = stepStatementEnd
+			return nil
+		}
+		if strings.ToUpper(commaOrEnd) == "RETURNING" {
+			p.pop()
+			p.step = stepReturningField
 			return nil
 		}
 		if strings.ToUpper(commaOrEnd) == "ON CONFLICT" {
@@ -210,6 +215,11 @@ func (p *parserItem) doParseInsert() error {
 		commaOrEnd := p.peek()
 		if commaOrEnd == ";" || commaOrEnd == "" {
 			p.step = stepStatementEnd
+			return nil
+		}
+		if strings.ToUpper(commaOrEnd) == "RETURNING" {
+			p.pop()
+			p.step = stepReturningField
 			return nil
 		}
 		if commaOrEnd != "," {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -49,6 +49,7 @@ var reservedWords = []string{
 	"DO UPDATE", "DO NOTHING",
 	"DISTINCT",
 	"UNION ALL", "UNION",
+	"RETURNING",
 	";",
 }
 
@@ -125,6 +126,8 @@ const (
 	stepWhere
 	stepAnalyze
 	stepPragma
+	stepReturningField
+	stepReturningComma
 	stepStatementEnd
 )
 
@@ -342,6 +345,13 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 			if err := p.doParsePragma(); err != nil {
 				return statements, err
 			}
+		// -----------------
+		// RETURNING
+		//------------------
+		case stepReturningField, stepReturningComma:
+			if err := p.doParseReturning(); err != nil {
+				return statements, err
+			}
 		case stepStatementEnd:
 			// For SELECT statements, intercept UNION / UNION ALL before requiring a semicolon.
 			if p.Kind == minisql.Select {
@@ -373,6 +383,14 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 					statements = append(statements, p.Statement)
 					// rest consumed all remaining SQL (including any trailing semicolons).
 					return statements, nil
+				}
+			}
+			// RETURNING can follow any DML statement (INSERT, UPDATE, DELETE).
+			if p.Kind == minisql.Insert || p.Kind == minisql.Update || p.Kind == minisql.Delete {
+				if strings.ToUpper(p.peek()) == "RETURNING" {
+					p.pop()
+					p.step = stepReturningField
+					continue
 				}
 			}
 			semicolon := p.peek()

--- a/internal/parser/returning.go
+++ b/internal/parser/returning.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+// doParseReturning handles stepReturningField and stepReturningComma.
+// The "RETURNING" keyword itself is consumed at each transition site before
+// setting stepReturningField, so this function only sees field names.
+func (p *parserItem) doParseReturning() error {
+	switch p.step {
+	case stepReturningField:
+		identifier := p.peek()
+		if !isIdentifier(identifier) && identifier != "*" {
+			return p.errorf("at RETURNING: expected column name or *")
+		}
+		p.ReturningFields = append(p.ReturningFields, minisql.Field{Name: identifier})
+		p.pop()
+		p.step = stepReturningComma
+	case stepReturningComma:
+		if p.peek() == "," {
+			p.pop()
+			p.step = stepReturningField
+		} else {
+			p.step = stepStatementEnd
+		}
+	}
+	return nil
+}

--- a/internal/parser/returning_test.go
+++ b/internal/parser/returning_test.go
@@ -1,0 +1,184 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_Returning(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCase{
+		{
+			"INSERT RETURNING single column",
+			"INSERT INTO 'users' (id, name) VALUES (1, 'Alice') RETURNING id",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "users",
+					Fields:    []minisql.Field{{Name: "id"}, {Name: "name"}},
+					Inserts: [][]minisql.OptionalValue{
+						{
+							{Value: int64(1), Valid: true},
+							{Value: minisql.NewTextPointer([]byte("Alice")), Valid: true},
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT RETURNING multiple columns",
+			"INSERT INTO 'users' (name, score) VALUES ('Bob', 10) RETURNING id, name, score",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "users",
+					Fields:    []minisql.Field{{Name: "name"}, {Name: "score"}},
+					Inserts: [][]minisql.OptionalValue{
+						{
+							{Value: minisql.NewTextPointer([]byte("Bob")), Valid: true},
+							{Value: int64(10), Valid: true},
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}, {Name: "name"}, {Name: "score"}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT RETURNING star",
+			"INSERT INTO 'users' (name) VALUES ('Carol') RETURNING *",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "users",
+					Fields:    []minisql.Field{{Name: "name"}},
+					Inserts: [][]minisql.OptionalValue{
+						{
+							{Value: minisql.NewTextPointer([]byte("Carol")), Valid: true},
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "*"}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT ON CONFLICT DO NOTHING RETURNING id",
+			"INSERT INTO 'users' (id, name) VALUES (1, 'Dave') ON CONFLICT DO NOTHING RETURNING id",
+			[]minisql.Statement{
+				{
+					Kind:           minisql.Insert,
+					TableName:      "users",
+					ConflictAction: minisql.ConflictActionDoNothing,
+					Fields:         []minisql.Field{{Name: "id"}, {Name: "name"}},
+					Inserts: [][]minisql.OptionalValue{
+						{
+							{Value: int64(1), Valid: true},
+							{Value: minisql.NewTextPointer([]byte("Dave")), Valid: true},
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}},
+				},
+			},
+			nil,
+		},
+		{
+			"UPDATE RETURNING single column",
+			"UPDATE 'users' SET score = 99 WHERE id = '1' RETURNING score",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Update,
+					TableName: "users",
+					Updates: map[string]minisql.OptionalValue{
+						"score": {Value: int64(99), Valid: true},
+					},
+					Fields: []minisql.Field{{Name: "score"}},
+					Conditions: minisql.OneOrMore{
+						{
+							minisql.FieldIsEqual(minisql.Field{Name: "id"}, minisql.OperandQuotedString, minisql.NewTextPointer([]byte("1"))),
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "score"}},
+				},
+			},
+			nil,
+		},
+		{
+			"UPDATE RETURNING multiple columns",
+			"UPDATE 'users' SET score = 99 WHERE id = '1' RETURNING id, score",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Update,
+					TableName: "users",
+					Updates: map[string]minisql.OptionalValue{
+						"score": {Value: int64(99), Valid: true},
+					},
+					Fields: []minisql.Field{{Name: "score"}},
+					Conditions: minisql.OneOrMore{
+						{
+							minisql.FieldIsEqual(minisql.Field{Name: "id"}, minisql.OperandQuotedString, minisql.NewTextPointer([]byte("1"))),
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}, {Name: "score"}},
+				},
+			},
+			nil,
+		},
+		{
+			"DELETE RETURNING columns",
+			"DELETE FROM 'sessions' WHERE id = '42' RETURNING id, name",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Delete,
+					TableName: "sessions",
+					Conditions: minisql.OneOrMore{
+						{
+							minisql.FieldIsEqual(minisql.Field{Name: "id"}, minisql.OperandQuotedString, minisql.NewTextPointer([]byte("42"))),
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}, {Name: "name"}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT RETURNING with semicolon terminator",
+			"INSERT INTO 'users' (id) VALUES (1) RETURNING id;",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "users",
+					Fields:    []minisql.Field{{Name: "id"}},
+					Inserts: [][]minisql.OptionalValue{
+						{
+							{Value: int64(1), Valid: true},
+						},
+					},
+					ReturningFields: []minisql.Field{{Name: "id"}},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, aTestCase := range testCases {
+		t.Run(aTestCase.Name, func(t *testing.T) {
+			aStatement, err := New().Parse(context.Background(), aTestCase.SQL)
+			if aTestCase.Err != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, aTestCase.Err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, aTestCase.Expected, aStatement)
+		})
+	}
+}

--- a/internal/parser/update.go
+++ b/internal/parser/update.go
@@ -109,8 +109,13 @@ func (p *parserItem) doParseUpdate() error {
 		p.step = stepUpdateComma
 	case stepUpdateComma:
 		commaOrEnd := p.peek()
-		if commaOrEnd == ";" {
+		if commaOrEnd == ";" || commaOrEnd == "" {
 			p.step = stepStatementEnd
+			return nil
+		}
+		if strings.ToUpper(commaOrEnd) == "RETURNING" {
+			p.pop()
+			p.step = stepReturningField
 			return nil
 		}
 		if commaOrEnd != "," {

--- a/internal/parser/where.go
+++ b/internal/parser/where.go
@@ -23,14 +23,15 @@ func (p *parserItem) doParseWhere() error {
 	whereOrEnd := p.peek()
 
 	// No WHERE clause — move on.
-	if whereOrEnd == ";" {
+	if whereOrEnd == ";" || whereOrEnd == "" {
 		p.step = stepStatementEnd
 		return nil
 	}
 
 	whereRWord := strings.ToUpper(whereOrEnd)
 
-	// GROUP BY / HAVING / ORDER BY / LIMIT / OFFSET / UNION appearing before WHERE means no WHERE clause.
+	// GROUP BY / HAVING / ORDER BY / LIMIT / OFFSET / UNION / RETURNING appearing
+	// before WHERE means no WHERE clause.
 	switch whereRWord {
 	case "GROUP BY":
 		p.step = stepSelectGroupBy
@@ -43,6 +44,10 @@ func (p *parserItem) doParseWhere() error {
 		return nil
 	case "UNION ALL", "UNION":
 		p.step = stepStatementEnd
+		return nil
+	case "RETURNING":
+		p.pop()
+		p.step = stepReturningField
 		return nil
 	}
 
@@ -76,6 +81,9 @@ func (p *parserItem) doParseWhere() error {
 		p.step = stepSelectHaving
 	case "ORDER BY", "LIMIT", "OFFSET":
 		p.step = stepSelectOrderBy
+	case "RETURNING":
+		p.pop()
+		p.step = stepReturningField
 	default:
 		p.step = stepStatementEnd
 	}

--- a/minisql.go
+++ b/minisql.go
@@ -203,10 +203,6 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 
 // ExecContext executes a query that doesn't return rows.
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	if len(args) > 0 {
-		return nil, fmt.Errorf("query arguments not yet supported")
-	}
-
 	statements, err := c.parser.Parse(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
@@ -216,9 +212,20 @@ func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 		return nil, fmt.Errorf("no statements in query")
 	}
 
+	internalArgs, err := toInternalArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
 	var totalRowsAffected int64
 
 	for _, stmt := range statements {
+		if len(internalArgs) > 0 {
+			stmt, err = stmt.BindArguments(internalArgs...)
+			if err != nil {
+				return nil, err
+			}
+		}
 		result, err := c.executeStatement(ctx, stmt)
 		if err != nil {
 			return nil, err
@@ -231,10 +238,6 @@ func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 
 // QueryContext executes a query that may return rows.
 func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	if len(args) > 0 {
-		return nil, fmt.Errorf("query arguments not yet supported")
-	}
-
 	statements, err := c.parser.Parse(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
@@ -248,7 +251,19 @@ func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		return nil, fmt.Errorf("multiple statements not supported")
 	}
 
+	internalArgs, err := toInternalArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
 	stmt := statements[0]
+	if len(internalArgs) > 0 {
+		stmt, err = stmt.BindArguments(internalArgs...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	result, err := c.executeStatement(ctx, stmt)
 	if err != nil {
 		return nil, err

--- a/stmt.go
+++ b/stmt.go
@@ -111,7 +111,7 @@ func toInternalArgs(args []driver.NamedValue) ([]any, error) {
 		case string:
 			internalArgs = append(internalArgs, minisql.NewTextPointer([]byte(v)))
 		case time.Time:
-			internalArgs = append(internalArgs, minisql.Time{
+			t := minisql.Time{
 				Year:         int32(v.Year()),
 				Month:        int8(v.Month()),
 				Day:          int8(v.Day()),
@@ -119,7 +119,8 @@ func toInternalArgs(args []driver.NamedValue) ([]any, error) {
 				Minutes:      int8(v.Minute()),
 				Seconds:      int8(v.Second()),
 				Microseconds: int32(v.Nanosecond() / 1000),
-			})
+			}
+			internalArgs = append(internalArgs, minisql.TimestampMicros(t.TotalMicroseconds()))
 		default:
 			return nil, fmt.Errorf("unsupported argument type: %T", arg)
 		}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -74,7 +74,7 @@ func TestToInternalArgs(t *testing.T) {
 		assert.Equal(t, "hello", tp.String())
 	})
 
-	t.Run("time.Time is converted to internal Time struct", func(t *testing.T) {
+	t.Run("time.Time is converted to TimestampMicros", func(t *testing.T) {
 		t.Parallel()
 
 		ts := time.Date(2024, 6, 15, 12, 34, 56, 123000, time.UTC)
@@ -82,10 +82,8 @@ func TestToInternalArgs(t *testing.T) {
 		got, err := toInternalArgs(args)
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		// We can't import internal/minisql.Time directly from the root package test,
-		// so we just verify a non-nil value was produced with the correct concrete type name.
 		assert.NotNil(t, got[0])
-		assert.Equal(t, "minisql.Time", fmt.Sprintf("%T", got[0]))
+		assert.Equal(t, "minisql.TimestampMicros", fmt.Sprintf("%T", got[0]))
 	})
 
 	t.Run("multiple args of different types", func(t *testing.T) {


### PR DESCRIPTION
Implement `RETURNING` clause, also fixed three bugs:                                                         
                                                                                                                                                                                                                                                                                       
  1. toInternalArgs converted time.Time to minisql.Time struct (root cause of the original timestamp field expects TextPointer value error) — changed to convert directly to TimestampMicros instead, which is what parseTimeValue accepts.                                            
  2. Statement.Clone() omitted ReturningFields — this caused BindArguments (called from Conn.QueryContext) to silently strip the RETURNING clause, so Insert() never saw it and returned an empty iterator. Also added TableAlias, Target, GroupBy, Having, and Joins to the clone     
  since those were missing too.                                                                                                                                                                                                                                                        
  3. stepStatementEnd didn't intercept RETURNING for DML — so INSERT ... ON CONFLICT DO NOTHING RETURNING ... failed with "expected semicolon". Added a check in stepStatementEnd to transition to stepReturningField when RETURNING follows an INSERT/UPDATE/DELETE.