### PR TITLE
feat: implement CHECK constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Important behavior and current non-goals:
 | `PRIMARY KEY` | Single column only; no composite primary keys |
 | `AUTOINCREMENT` | Primary key must be of type `INT8` |
 | `UNIQUE` | Can be specified when creating a table |
+| `CHECK` | Constraints to test values whenever they are inserted or updated in a column |
 | Composite primary key or unique constraint | As part of `CREATE TABLE` |
 | `NULL` and `NOT NULL` | Via null bit mask included in each row/cell |
 | `DEFAULT` | Supported for all columns, including `NOW()` for `TIMESTAMP` |

--- a/e2e_tests/check_test.go
+++ b/e2e_tests/check_test.go
@@ -1,0 +1,143 @@
+package e2etests
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func (s *TestSuite) TestCheckConstraints() {
+	// Create one table for the whole test; subtests share it.
+	_, err := s.db.Exec(`create table "products" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		price int8 not null check (price > 0),
+		qty   int8 not null check (qty >= 0)
+	);`)
+	s.Require().NoError(err)
+
+	s.Run("valid_insert_passes", func() {
+		_, err := s.db.Exec(`insert into "products" (name, price, qty) values ('Widget', 10, 5)`)
+		s.Require().NoError(err)
+	})
+
+	// Use a prepared statement so that negative int64 values can be passed
+	// without relying on negative literal parsing (not supported by the parser).
+	s.Run("insert_zero_price_violates_check", func() {
+		stmt, err := s.db.Prepare(`insert into "products" (name, price, qty) values (?, ?, ?)`)
+		s.Require().NoError(err)
+		defer stmt.Close()
+
+		_, err = stmt.Exec("Bad", int64(0), int64(5))
+		s.Require().Error(err)
+		var checkErr minisql.ErrCheckConstraintViolation
+		s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation, got %T: %v", err, err)
+		s.Equal("price", checkErr.ColumnName)
+	})
+
+	s.Run("insert_negative_qty_violates_check", func() {
+		stmt, err := s.db.Prepare(`insert into "products" (name, price, qty) values (?, ?, ?)`)
+		s.Require().NoError(err)
+		defer stmt.Close()
+
+		_, err = stmt.Exec("Bad", int64(5), int64(-1))
+		s.Require().Error(err)
+		var checkErr minisql.ErrCheckConstraintViolation
+		s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation, got %T: %v", err, err)
+		s.Equal("qty", checkErr.ColumnName)
+	})
+
+	s.Run("update_valid_change_passes", func() {
+		_, err := s.db.Exec(`insert into "products" (name, price, qty) values ('Gadget', 15, 3)`)
+		s.Require().NoError(err)
+
+		_, err = s.db.Exec(`update "products" set price = 25 where name = 'Gadget'`)
+		s.Require().NoError(err)
+	})
+
+	s.Run("update_violates_check_constraint", func() {
+		_, err := s.db.Exec(`insert into "products" (name, price, qty) values ('Doomed', 10, 2)`)
+		s.Require().NoError(err)
+
+		stmt, err := s.db.Prepare(`update "products" set price = ? where name = 'Doomed'`)
+		s.Require().NoError(err)
+		defer stmt.Close()
+
+		_, err = stmt.Exec(int64(0))
+		s.Require().Error(err)
+		var checkErr minisql.ErrCheckConstraintViolation
+		s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation, got %T: %v", err, err)
+		s.Equal("price", checkErr.ColumnName)
+	})
+}
+
+func (s *TestSuite) TestCheckConstraints_DDLRoundTrip() {
+	// Use CHECK (score > 10) so that inserting 5 (a valid positive literal) triggers the violation.
+	_, err := s.db.Exec(`create table "scores" (
+		id    int8 primary key autoincrement,
+		score int8 not null check (score > 10)
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "scores" (score) values (50)`)
+	s.Require().NoError(err)
+
+	// Close and reopen: DDL must round-trip through the WAL / schema table.
+	s.Require().NoError(s.db.Close())
+	s.db, err = sql.Open("minisql", s.dbFile.Name())
+	s.Require().NoError(err)
+	s.db.SetMaxOpenConns(1)
+	s.db.SetMaxIdleConns(1)
+
+	// Valid insert still works after reopen.
+	_, err = s.db.Exec(`insert into "scores" (score) values (99)`)
+	s.Require().NoError(err)
+
+	// Violating insert still fails after reopen.
+	_, err = s.db.Exec(`insert into "scores" (score) values (5)`)
+	s.Require().Error(err)
+	var checkErr minisql.ErrCheckConstraintViolation
+	s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation after reopen, got %T: %v", err, err)
+	s.Equal("score", checkErr.ColumnName)
+}
+
+func (s *TestSuite) TestCheckConstraints_VarcharColumn() {
+	_, err := s.db.Exec(`create table "items" (
+		id   int8 primary key autoincrement,
+		code varchar(10) not null check (code != '')
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "items" (code) values ('ABC')`)
+	s.Require().NoError(err)
+
+	// Empty string violates check (code != '').
+	_, err = s.db.Exec(`insert into "items" (code) values ('')`)
+	s.Require().Error(err)
+	var checkErr minisql.ErrCheckConstraintViolation
+	s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation, got %T: %v", err, err)
+	s.Equal("code", checkErr.ColumnName)
+}
+
+func (s *TestSuite) TestCheckConstraints_DefaultAndCheck() {
+	// Ensure DEFAULT and CHECK can coexist on the same column.
+	_, err := s.db.Exec(`create table "counters" (
+		id  int8 primary key autoincrement,
+		cnt int8 not null default 1 check (cnt > 0)
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "counters" (cnt) values (5)`)
+	s.Require().NoError(err)
+
+	stmt, err := s.db.Prepare(`insert into "counters" (cnt) values (?)`)
+	s.Require().NoError(err)
+	defer stmt.Close()
+
+	_, err = stmt.Exec(int64(0))
+	s.Require().Error(err)
+	var checkErr minisql.ErrCheckConstraintViolation
+	s.True(errors.As(err, &checkErr), "expected ErrCheckConstraintViolation, got %T: %v", err, err)
+	s.Equal("cnt", checkErr.ColumnName)
+}

--- a/internal/minisql/check.go
+++ b/internal/minisql/check.go
@@ -1,0 +1,33 @@
+package minisql
+
+import "fmt"
+
+// ErrCheckConstraintViolation is returned when an INSERT or UPDATE row fails a CHECK constraint.
+type ErrCheckConstraintViolation struct {
+	ColumnName string
+	Expr       string
+}
+
+func (e ErrCheckConstraintViolation) Error() string {
+	return fmt.Sprintf("check constraint violation on column %q: %s", e.ColumnName, e.Expr)
+}
+
+// validateCheckConstraints verifies that row satisfies every column-level CHECK
+// constraint defined in columns.  Returns ErrCheckConstraintViolation on the
+// first failure, nil if all constraints pass.
+func validateCheckConstraints(columns []Column, row Row) error {
+	for _, col := range columns {
+		if col.CheckCond == nil {
+			continue
+		}
+		dnf := col.CheckCond.ToDNF()
+		ok, err := row.CheckOneOrMore(dnf)
+		if err != nil {
+			return fmt.Errorf("check constraint on column %q: %w", col.Name, err)
+		}
+		if !ok {
+			return ErrCheckConstraintViolation{ColumnName: col.Name, Expr: col.Check}
+		}
+	}
+	return nil
+}

--- a/internal/minisql/check_test.go
+++ b/internal/minisql/check_test.go
@@ -1,0 +1,79 @@
+package minisql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCheckConstraints(t *testing.T) {
+	t.Parallel()
+
+	priceGtZero := &ConditionNode{
+		Leaf: &Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "price"}},
+			Operator: Gt,
+			Operand2: Operand{Type: OperandInteger, Value: int64(0)},
+		},
+	}
+
+	columns := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "price", Kind: Int8, Size: 8, Check: "price > 0", CheckCond: priceGtZero},
+	}
+
+	makeRow := func(id, price int64) Row {
+		return NewRowWithValues(columns, []OptionalValue{
+			{Value: id, Valid: true},
+			{Value: price, Valid: true},
+		})
+	}
+
+	t.Run("passes when all checks satisfied", func(t *testing.T) {
+		t.Parallel()
+		err := validateCheckConstraints(columns, makeRow(1, 10))
+		require.NoError(t, err)
+	})
+
+	t.Run("fails when check violated", func(t *testing.T) {
+		t.Parallel()
+		err := validateCheckConstraints(columns, makeRow(1, 0))
+		require.Error(t, err)
+		var checkErr ErrCheckConstraintViolation
+		require.True(t, errors.As(err, &checkErr))
+		assert.Equal(t, "price", checkErr.ColumnName)
+		assert.Equal(t, "price > 0", checkErr.Expr)
+	})
+
+	t.Run("no check constraints passes always", func(t *testing.T) {
+		t.Parallel()
+		bare := []Column{
+			{Name: "id", Kind: Int8, Size: 8},
+			{Name: "name", Kind: Text},
+		}
+		row := NewRowWithValues(bare, []OptionalValue{
+			{Value: int64(1), Valid: true},
+			{Value: NewTextPointer([]byte("foo")), Valid: true},
+		})
+		err := validateCheckConstraints(bare, row)
+		require.NoError(t, err)
+	})
+
+	t.Run("error message contains column name and expression", func(t *testing.T) {
+		t.Parallel()
+		err := validateCheckConstraints(columns, makeRow(1, 0))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "price")
+		assert.Contains(t, err.Error(), "price > 0")
+	})
+}
+
+func TestErrCheckConstraintViolation_Error(t *testing.T) {
+	t.Parallel()
+
+	err := ErrCheckConstraintViolation{ColumnName: "age", Expr: "age >= 18"}
+	assert.Contains(t, err.Error(), "age")
+	assert.Contains(t, err.Error(), "age >= 18")
+}

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -283,6 +283,10 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		return false, nil
 	}
 
+	if err := validateCheckConstraints(c.Table.Columns, row); err != nil {
+		return false, err
+	}
+
 	page, err := c.Table.pager.ModifyPage(ctx, c.PageIdx)
 	if err != nil {
 		return false, fmt.Errorf("update: %w", err)

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -130,6 +130,10 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 		row := NewRowWithValues(t.Columns, rowValues)
 
+		if err := validateCheckConstraints(t.Columns, row); err != nil {
+			return StatementResult{}, err
+		}
+
 		// Collect the row for RETURNING before it is inserted (values are already
 		// final at this point, including any autoincrement PK that was resolved above).
 		if len(stmt.ReturningFields) > 0 {

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -179,7 +179,9 @@ func (k ColumnKind) IsText() bool {
 // Column ...
 type Column struct {
 	DefaultValue    OptionalValue
+	CheckCond       *ConditionNode // parsed CHECK expression (nil if no CHECK constraint)
 	Name            string
+	Check           string // raw SQL text of CHECK expression, e.g. "age > 0"
 	Kind            ColumnKind
 	Size            uint32
 	Nullable        bool
@@ -1598,6 +1600,9 @@ func (s Statement) createTableDDL() string {
 				case Timestamp:
 					fmt.Fprintf(&sb, " default '%s'", FromMicroseconds(int64(col.DefaultValue.Value.(TimestampMicros))).String())
 				}
+			}
+			if col.Check != "" {
+				fmt.Fprintf(&sb, " check (%s)", col.Check)
 			}
 		}
 		if i < len(s.Columns)-1 {

--- a/internal/parser/check_test.go
+++ b/internal/parser/check_test.go
@@ -1,0 +1,183 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_CheckConstraint(t *testing.T) {
+	t.Parallel()
+
+	leaf := func(cond minisql.Condition) *minisql.ConditionNode {
+		return &minisql.ConditionNode{Leaf: &cond}
+	}
+	fieldCond := func(fieldName string, op minisql.Operator, operandType minisql.OperandType, value any) minisql.Condition {
+		return minisql.Condition{
+			Operand1: minisql.Operand{Type: minisql.OperandField, Value: minisql.Field{Name: fieldName}},
+			Operator: op,
+			Operand2: minisql.Operand{Type: operandType, Value: value},
+		}
+	}
+
+	testCases := []testCase{
+		{
+			"CHECK (price > 0) sets Check and CheckCond on column",
+			"CREATE TABLE products (price int8 not null check (price > 0));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "products",
+					Columns: []minisql.Column{
+						{
+							Name:      "price",
+							Kind:      minisql.Int8,
+							Size:      8,
+							Nullable:  false,
+							Check:     "price > 0",
+							CheckCond: leaf(fieldCond("price", minisql.Gt, minisql.OperandInteger, int64(0))),
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"CHECK (qty >= 0) parses Gte operator",
+			"CREATE TABLE stock (qty int8 check (qty >= 0));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "stock",
+					Columns: []minisql.Column{
+						{
+							Name:      "qty",
+							Kind:      minisql.Int8,
+							Size:      8,
+							Nullable:  true,
+							Check:     "qty >= 0",
+							CheckCond: leaf(fieldCond("qty", minisql.Gte, minisql.OperandInteger, int64(0))),
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"column without CHECK leaves Check empty and CheckCond nil",
+			"CREATE TABLE t (n int8 not null);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "t",
+					Columns: []minisql.Column{
+						{
+							Name:     "n",
+							Kind:     minisql.Int8,
+							Size:     8,
+							Nullable: false,
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"CHECK after DEFAULT is supported",
+			"CREATE TABLE t (n int8 not null default 1 check (n > 0));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "t",
+					Columns: []minisql.Column{
+						{
+							Name:     "n",
+							Kind:     minisql.Int8,
+							Size:     8,
+							Nullable: false,
+							DefaultValue: minisql.OptionalValue{
+								Value: int64(1),
+								Valid: true,
+							},
+							Check:     "n > 0",
+							CheckCond: leaf(fieldCond("n", minisql.Gt, minisql.OperandInteger, int64(0))),
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"multiple columns each with independent CHECK constraints",
+			"CREATE TABLE dims (w int8 check (w > 0), h int8 check (h > 0));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "dims",
+					Columns: []minisql.Column{
+						{
+							Name:      "w",
+							Kind:      minisql.Int8,
+							Size:      8,
+							Nullable:  true,
+							Check:     "w > 0",
+							CheckCond: leaf(fieldCond("w", minisql.Gt, minisql.OperandInteger, int64(0))),
+						},
+						{
+							Name:      "h",
+							Kind:      minisql.Int8,
+							Size:      8,
+							Nullable:  true,
+							Check:     "h > 0",
+							CheckCond: leaf(fieldCond("h", minisql.Gt, minisql.OperandInteger, int64(0))),
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"CHECK with AND expression",
+			"CREATE TABLE t (n int8 check (n > 0 AND n < 100));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "t",
+					Columns: []minisql.Column{
+						{
+							Name:     "n",
+							Kind:     minisql.Int8,
+							Size:     8,
+							Nullable: true,
+							Check:    "n > 0 AND n < 100",
+							CheckCond: &minisql.ConditionNode{
+								Left:  leaf(fieldCond("n", minisql.Gt, minisql.OperandInteger, int64(0))),
+								Op:    minisql.LogicOpAnd,
+								Right: leaf(fieldCond("n", minisql.Lt, minisql.OperandInteger, int64(100))),
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, aTestCase := range testCases {
+		t.Run(aTestCase.Name, func(t *testing.T) {
+			t.Parallel()
+			got, err := New().Parse(context.Background(), aTestCase.SQL)
+			if aTestCase.Err != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, aTestCase.Err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, aTestCase.Expected, got)
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -42,6 +42,7 @@ var reservedWords = []string{
 	"*", "COUNT(*)", "SUM(", "AVG(", "MIN(", "MAX(", "GROUP BY", "HAVING", "ORDER BY", "LIMIT", "OFFSET",
 	"PRIMARY KEY AUTOINCREMENT", "PRIMARY KEY", "DEFAULT", "NOT NULL", "NULL", "UNIQUE",
 	"IS NULL", "IS NOT NULL", "NOT BETWEEN", "NOT LIKE", "BETWEEN", "LIKE", "TRUE", "FALSE", "NOW()",
+	"CHECK",
 	"IF NOT EXISTS", "WHERE", "FROM", "SET", "ASC", "DESC", "AS",
 	"BEGIN", "COMMIT", "ROLLBACK", "ANALYZE", "VACUUM",
 	"PRAGMA",
@@ -67,6 +68,7 @@ const (
 	stepCreateTableColumnNullNotNull
 	stepCreateTableColumnUnique
 	stepCreateTableColumnDefaultValue
+	stepCreateTableColumnCheck
 	stepCreateTableConstraint
 	stepCreateTableConstraintPrimaryKey
 	stepCreateTableConstraintUniqueKey
@@ -226,6 +228,7 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 			stepCreateTableColumnNullNotNull,
 			stepCreateTableColumnUnique,
 			stepCreateTableColumnDefaultValue,
+			stepCreateTableColumnCheck,
 			stepCreateTableConstraint,
 			stepCreateTableConstraintPrimaryKey,
 			stepCreateTableConstraintUniqueKey,

--- a/internal/parser/table.go
+++ b/internal/parser/table.go
@@ -156,10 +156,11 @@ func (p *parserItem) doParseCreateTable() error {
 			},
 		})
 		p.pop()
-		p.step = stepCreateTableCommaOrClosingParens
+		// Allow DEFAULT and CHECK to follow UNIQUE.
+		p.step = stepCreateTableColumnDefaultValue
 	case stepCreateTableColumnDefaultValue:
 		defaultRWord := p.peek()
-		p.step = stepCreateTableCommaOrClosingParens
+		p.step = stepCreateTableColumnCheck
 		if defaultRWord != "DEFAULT" {
 			return nil
 		}
@@ -187,6 +188,29 @@ func (p *parserItem) doParseCreateTable() error {
 			Value: defaultValue,
 			Valid: true,
 		}
+	case stepCreateTableColumnCheck:
+		checkRWord := strings.ToUpper(p.peek())
+		p.step = stepCreateTableCommaOrClosingParens
+		if checkRWord != "CHECK" {
+			return nil
+		}
+		p.pop() // consume "CHECK"
+		if p.peek() != "(" {
+			return p.errorf("at CREATE TABLE: expected '(' after CHECK")
+		}
+		p.pop() // consume "("
+		startPos := p.i
+		node, err := p.parseCondExpr()
+		if err != nil {
+			return err
+		}
+		if p.peek() != ")" {
+			return p.errorf("at CREATE TABLE: expected ')' after CHECK expression")
+		}
+		rawExpr := strings.TrimSpace(p.sql[startPos:p.i])
+		p.pop() // consume ")"
+		p.Columns[len(p.Columns)-1].Check = rawExpr
+		p.Columns[len(p.Columns)-1].CheckCond = node
 	case stepCreateTableConstraint:
 		token := strings.ToUpper(p.peek())
 		switch token {


### PR DESCRIPTION
CHECK constraints are fully implemented. Here's what was added:                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                       
  Parser (internal/parser/):                                                                                                                                                                                                                                                           
  - New step stepCreateTableColumnCheck inserted after stepCreateTableColumnDefaultValue in the CREATE TABLE state machine                                                                                                                                                             
  - "CHECK" added to reservedWords                                                                                                                                                                                                                                                     
  - stepCreateTableColumnUnique when UNIQUE is found now also flows through stepCreateTableColumnDefaultValue (allowing DEFAULT+CHECK after UNIQUE)                                                                                                                                    
  - Raw expression text captured via p.sql[startPos:p.i] — stored as col.Check; parsed tree stored as col.CheckCond                                                                                                                                                                    
                                                                                                                                                                                                                                                                                       
  Data model (internal/minisql/stmt.go):                                                                                                                                                                                                                                               
  - Column gains Check string and CheckCond *ConditionNode                                                                                                                                                                                                                             
  - createTableDDL() emits check (expr) so constraints survive WAL/schema round-trips                                                                                                                                                                                                  
                                                            
  Validation (internal/minisql/check.go):                                                                                                                                                                                                                                              
  - validateCheckConstraints() iterates columns, calls row.CheckOneOrMore(col.CheckCond.ToDNF())
  - ErrCheckConstraintViolation{ColumnName, Expr} returned on first failure                                                                                                                                                                                                            
  - Called from insert.go after row assembly and cursor.update() after updates are applied
