### PR TITLE
feat: implement EXPLAIN ANALYZE for SELECT queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Important behavior and current non-goals:
 | `ON CONFLICT` | Both `DO NOTHING` and `DO UPDATE` supported (with `EXCLUDED` pseudo table syntax for updating) |
 | `SELECT` | All fields with `*`, specific fields, or row count with `COUNT(*)`, |
 | `SELECT DISTINCT` | |
+| `EXPLAIN`, `EXPLAIN ANALYZE` | Query plan inspection for `SELECT` statements. `EXPLAIN ANALYZE` also executes the query and returns actual row counts and timing |
 | `JOIN` | `INNER`, `LEFT` and `RIGHT` joins supported |
 | `UPDATE` | |
 | `DELETE` | |
@@ -522,6 +523,47 @@ You can also count rows in a table:
 ```go
 var count int
 if err := db.QueryRow(`select count(*) from users;`).Scan(&count); err != nil {
+	return err
+}
+```
+
+You can inspect the query plan for a `SELECT` with `EXPLAIN`. The result columns are `step`, `operation`, `detail`, `rows_estimated`, `rows_actual`, and `duration_us`. For plain `EXPLAIN`, actual rows and duration are `NULL`; `EXPLAIN ANALYZE` executes the query and fills those fields.
+
+```go
+type explainStep struct {
+	Step          int64
+	Operation     string
+	Detail        string
+	RowsEstimated sql.NullInt64
+	RowsActual    sql.NullInt64
+	DurationUS    sql.NullInt64
+}
+
+rows, err := db.QueryContext(context.Background(), `
+	EXPLAIN ANALYZE
+	SELECT * FROM users WHERE age >= 30 ORDER BY created DESC;
+`)
+if err != nil {
+	return err
+}
+defer rows.Close()
+
+var plan []explainStep
+for rows.Next() {
+	var step explainStep
+	if err := rows.Scan(
+		&step.Step,
+		&step.Operation,
+		&step.Detail,
+		&step.RowsEstimated,
+		&step.RowsActual,
+		&step.DurationUS,
+	); err != nil {
+		return err
+	}
+	plan = append(plan, step)
+}
+if err := rows.Err(); err != nil {
 	return err
 }
 ```

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,82 @@
+package minisql
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriverPreparedStatementsAndTransactions(t *testing.T) {
+	t.Parallel()
+
+	tempFile, err := os.CreateTemp("", "minisql-driver-test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Remove(tempFile.Name())
+		_ = os.Remove(tempFile.Name() + "-wal")
+	})
+
+	db, err := sql.Open("minisql", tempFile.Name())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	_, err = db.ExecContext(context.Background(), `create table "users" (
+		id int8 primary key autoincrement,
+		name text
+	);`)
+	require.NoError(t, err)
+
+	insertStmt, err := db.PrepareContext(context.Background(), `insert into users("name") values(?);`)
+	require.NoError(t, err)
+	defer insertStmt.Close()
+
+	result, err := insertStmt.ExecContext(context.Background(), "Alice")
+	require.NoError(t, err)
+	rowsAffected, err := result.RowsAffected()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rowsAffected)
+
+	selectStmt, err := db.PrepareContext(context.Background(), `select id, name from users where name = ?;`)
+	require.NoError(t, err)
+	defer selectStmt.Close()
+
+	rows, err := selectStmt.QueryContext(context.Background(), "Alice")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	require.True(t, rows.Next())
+	var (
+		id   int64
+		name string
+	)
+	require.NoError(t, rows.Scan(&id, &name))
+	assert.Equal(t, int64(1), id)
+	assert.Equal(t, "Alice", name)
+	assert.False(t, rows.Next())
+	require.NoError(t, rows.Err())
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), `insert into users("name") values('Bob');`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Rollback())
+
+	var count int
+	require.NoError(t, db.QueryRowContext(context.Background(), `select count(*) from users;`).Scan(&count))
+	assert.Equal(t, 1, count)
+
+	tx, err = db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), `insert into users("name") values('Cara');`)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	require.NoError(t, db.QueryRowContext(context.Background(), `select count(*) from users;`).Scan(&count))
+	assert.Equal(t, 2, count)
+}

--- a/e2e_tests/explain_test.go
+++ b/e2e_tests/explain_test.go
@@ -1,0 +1,84 @@
+package e2etests
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+)
+
+type explainResult struct {
+	RowsEstimated sql.NullInt64
+	RowsActual    sql.NullInt64
+	DurationUS    sql.NullInt64
+	Operation     string
+	Detail        string
+	Step          int64
+}
+
+func (s *TestSuite) TestExplainSelect() {
+	s.execQuery(createUsersTableSQL, 0)
+	s.execQuery(`insert into users("email", "name") values
+('alice@example.com', 'Alice'),
+('bob@example.com', 'Bob');`, 2)
+
+	rows := s.collectExplain(`EXPLAIN SELECT * FROM users WHERE id = 1;`)
+	s.Require().NotEmpty(rows)
+	s.Equal(int64(1), rows[0].Step)
+	s.Equal("index_point", rows[0].Operation)
+	s.Contains(rows[0].Detail, "table=users")
+	s.Contains(rows[0].Detail, "index=pkey__users")
+	s.True(rows[0].RowsEstimated.Valid)
+	s.False(rows[0].RowsActual.Valid)
+	s.False(rows[0].DurationUS.Valid)
+}
+
+func (s *TestSuite) TestExplainAnalyzeSelect() {
+	s.execQuery(createUsersTableSQL, 0)
+	s.execQuery(`insert into users("email", "name") values
+('alice@example.com', 'Alice'),
+('bob@example.com', 'Bob');`, 2)
+
+	rows := s.collectExplain(`EXPLAIN ANALYZE SELECT * FROM users WHERE id > 0 ORDER BY name;`)
+	s.Require().Len(rows, 2)
+	s.Equal("index_range", rows[0].Operation)
+	s.True(rows[0].RowsActual.Valid)
+	s.Equal(int64(2), rows[0].RowsActual.Int64)
+	s.True(rows[0].DurationUS.Valid)
+	s.Equal("sort", rows[1].Operation)
+	s.True(rows[1].RowsActual.Valid)
+	s.Equal(int64(2), rows[1].RowsActual.Int64)
+	s.True(rows[1].DurationUS.Valid)
+}
+
+func (s *TestSuite) TestExplainUnsupportedStatement() {
+	s.execQuery(createUsersTableSQL, 0)
+
+	rows, err := s.db.QueryContext(context.Background(), `EXPLAIN INSERT INTO users("email", "name") VALUES ('x@example.com', 'X');`)
+	s.Require().Error(err)
+	s.Nil(rows)
+	s.True(strings.Contains(err.Error(), "EXPLAIN currently supports SELECT statements only"))
+	s.True(strings.Contains(err.Error(), "got INSERT"))
+}
+
+func (s *TestSuite) collectExplain(query string) []explainResult {
+	rows, err := s.db.QueryContext(context.Background(), query)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	var results []explainResult
+	for rows.Next() {
+		var result explainResult
+		err := rows.Scan(
+			&result.Step,
+			&result.Operation,
+			&result.Detail,
+			&result.RowsEstimated,
+			&result.RowsActual,
+			&result.DurationUS,
+		)
+		s.Require().NoError(err)
+		results = append(results, result)
+	}
+	s.Require().NoError(rows.Err())
+	return results
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -436,6 +436,8 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 		return StatementResult{}, d.Vacuum(ctx)
 	case Pragma:
 		return d.executePragmaStatement(ctx, stmt)
+	case Explain:
+		return d.executeExplain(ctx, stmt)
 	case CreateTable, DropTable, CreateIndex, DropIndex:
 		return d.executeDDLStatement(ctx, stmt)
 	case Insert, Select, Update, Delete:

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -1,0 +1,375 @@
+package minisql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var errExplainUnsupportedStatement = errors.New("EXPLAIN currently supports SELECT statements only")
+
+type explainRow struct {
+	operation string
+	detail    string
+	estimated OptionalValue
+	actual    OptionalValue
+	duration  OptionalValue
+}
+
+type explainMetric struct {
+	rows       int64
+	durationUS int64
+}
+
+var explainColumns = []Column{
+	{Name: "step", Kind: Int8},
+	{Name: "operation", Kind: Text},
+	{Name: "detail", Kind: Text},
+	{Name: "rows_estimated", Kind: Int8},
+	{Name: "rows_actual", Kind: Int8},
+	{Name: "duration_us", Kind: Int8},
+}
+
+func (d *Database) executeExplain(ctx context.Context, stmt Statement) (StatementResult, error) {
+	if stmt.ExplainStatement == nil {
+		return StatementResult{}, errors.New("EXPLAIN requires a statement")
+	}
+
+	inner := stmt.ExplainStatement.Clone()
+	if inner.Kind != Select {
+		return StatementResult{}, fmt.Errorf("%w: got %s", errExplainUnsupportedStatement, inner.Kind)
+	}
+
+	table, ok := d.GetTable(ctx, inner.TableName)
+	if !ok {
+		return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, inner.TableName)
+	}
+
+	inner.TableName = table.Name
+	inner.Columns = table.Columns
+
+	var err error
+	inner, err = inner.Prepare(d.clock())
+	if err != nil {
+		return StatementResult{}, err
+	}
+	if err := inner.Validate(table); err != nil {
+		return StatementResult{}, err
+	}
+
+	plan, err := table.PlanQuery(ctx, inner)
+	if err != nil {
+		return StatementResult{}, err
+	}
+
+	var metrics map[int]explainMetric
+	if stmt.ExplainAnalyze {
+		metrics, err = table.analyzePlan(ctx, inner, plan)
+		if err != nil {
+			return StatementResult{}, err
+		}
+	}
+
+	return buildExplainResult(plan, table, metrics), nil
+}
+
+func buildExplainResult(plan QueryPlan, table *Table, metrics map[int]explainMetric) StatementResult {
+	rows := plan.explainRows(table)
+	resultRows := make([]Row, 0, len(rows))
+	for idx, row := range rows {
+		step := idx + 1
+		if metric, ok := metrics[step]; ok {
+			row.actual = OptionalValue{Valid: true, Value: metric.rows}
+			row.duration = OptionalValue{Valid: true, Value: metric.durationUS}
+		}
+		resultRows = append(resultRows, NewRowWithValues(explainColumns, []OptionalValue{
+			{Valid: true, Value: int64(step)},
+			{Valid: true, Value: NewTextPointer([]byte(row.operation))},
+			{Valid: true, Value: NewTextPointer([]byte(row.detail))},
+			row.estimated,
+			row.actual,
+			row.duration,
+		}))
+	}
+	return StatementResult{
+		Columns: explainColumns,
+		Rows:    NewSliceIterator(resultRows),
+	}
+}
+
+func (p QueryPlan) explainRows(table *Table) []explainRow {
+	rows := make([]explainRow, 0, len(p.Scans)+len(p.Joins)+1)
+	for _, scan := range p.Scans {
+		rows = append(rows, explainRow{
+			operation: scanOperation(scan),
+			detail:    scanDetail(scan),
+			estimated: estimateScanRows(table, scan),
+		})
+	}
+	for _, join := range p.Joins {
+		rows = append(rows, explainRow{
+			operation: "join",
+			detail:    joinDetail(p, join),
+		})
+	}
+	if p.SortInMemory {
+		rows = append(rows, explainRow{
+			operation: "sort",
+			detail:    orderByDetail(p.OrderBy),
+		})
+	}
+	return rows
+}
+
+func (t *Table) analyzePlan(ctx context.Context, stmt Statement, plan QueryPlan) (map[int]explainMetric, error) {
+	selectedFields := explainSelectedFields(t, stmt)
+	metrics := make(map[int]explainMetric)
+
+	if len(plan.Joins) > 0 {
+		step := len(plan.Scans) + 1
+		start := time.Now()
+		var count int64
+		if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+			count += 1
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		metrics[step] = explainMetric{
+			rows:       count,
+			durationUS: time.Since(start).Microseconds(),
+		}
+		return metrics, nil
+	}
+
+	var rows []Row
+	for idx, scan := range plan.Scans {
+		step := idx + 1
+		start := time.Now()
+		var count int64
+		if err := t.executeExplainScan(ctx, plan, scan, selectedFields, func(row Row) error {
+			count += 1
+			if plan.SortInMemory {
+				rows = append(rows, row)
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		metrics[step] = explainMetric{
+			rows:       count,
+			durationUS: time.Since(start).Microseconds(),
+		}
+	}
+
+	if plan.SortInMemory {
+		step := len(plan.Scans) + 1
+		start := time.Now()
+		if err := t.sortRows(rows, plan.OrderBy); err != nil {
+			return nil, err
+		}
+		metrics[step] = explainMetric{
+			rows:       int64(len(rows)),
+			durationUS: time.Since(start).Microseconds(),
+		}
+	}
+
+	return metrics, nil
+}
+
+func (t *Table) executeExplainScan(ctx context.Context, plan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
+	switch scan.Type {
+	case ScanTypeIndexAll:
+		return t.indexScanAll(ctx, plan, scan, selectedFields, out)
+	case ScanTypeIndexRange:
+		return t.indexRangeScan(ctx, plan, scan, selectedFields, out)
+	case ScanTypeIndexPoint:
+		return t.indexPointScan(ctx, scan, selectedFields, out)
+	case ScanTypeIndexFirst:
+		return t.indexEndpointScan(ctx, scan, selectedFields, out, false)
+	case ScanTypeIndexLast:
+		return t.indexEndpointScan(ctx, scan, selectedFields, out, true)
+	case ScanTypeSequential:
+		return t.sequentialScan(ctx, scan, selectedFields, out)
+	default:
+		return fmt.Errorf("unhandled scan type in EXPLAIN ANALYZE: %d", scan.Type)
+	}
+}
+
+func explainSelectedFields(t *Table, stmt Statement) []Field {
+	switch {
+	case stmt.IsSelectAll():
+		return fieldsFromColumns(t.Columns...)
+	case stmt.IsSelectAggregate():
+		colSet := make(map[string]struct{})
+		for _, field := range stmt.GroupBy {
+			colSet[field.Name] = struct{}{}
+		}
+		for _, aggregate := range stmt.Aggregates {
+			if aggregate.Column != "" {
+				colSet[aggregate.Column] = struct{}{}
+			}
+		}
+		fields := make([]Field, 0, len(colSet))
+		for colName := range colSet {
+			fields = append(fields, Field{Name: colName})
+		}
+		return appendConditionFields(fields, stmt.Conditions)
+	default:
+		selectedFields := make([]Field, 0, len(stmt.Fields))
+		if !stmt.IsSelectCountAll() {
+			selectedFields = exprSourceFields(stmt.Fields)
+		}
+		return appendConditionFields(selectedFields, stmt.Conditions)
+	}
+}
+
+func appendConditionFields(fields []Field, conditions OneOrMore) []Field {
+	for _, group := range conditions {
+		for _, cond := range group {
+			if cond.Operand1.Type == OperandField {
+				fields = append(fields, cond.Operand1.Value.(Field))
+			}
+			if cond.Operand2.Type == OperandField {
+				fields = append(fields, cond.Operand2.Value.(Field))
+			}
+		}
+	}
+	return fields
+}
+
+func scanOperation(scan Scan) string {
+	if scan.CoveringIndex && scan.Type != ScanTypeSequential {
+		return "covering_" + scan.Type.String()
+	}
+	return scan.Type.String()
+}
+
+func scanDetail(scan Scan) string {
+	parts := []string{"table=" + scan.TableName}
+	if scan.TableAlias != "" && scan.TableAlias != scan.TableName {
+		parts = append(parts, "alias="+scan.TableAlias)
+	}
+	if scan.IndexName != "" {
+		parts = append(parts, "index="+scan.IndexName)
+	}
+	if len(scan.IndexColumns) > 0 {
+		parts = append(parts, "columns="+columnNames(scan.IndexColumns))
+	}
+	if len(scan.IndexKeys) > 0 {
+		parts = append(parts, fmt.Sprintf("keys=%v", scan.IndexKeys))
+	}
+	if scan.RangeCondition.Lower != nil || scan.RangeCondition.Upper != nil {
+		parts = append(parts, "range="+rangeDetail(scan.RangeCondition))
+	}
+	if len(scan.Filters) > 0 {
+		parts = append(parts, fmt.Sprintf("filters=%d", conditionCount(scan.Filters)))
+	}
+	if scan.CoveringIndex {
+		parts = append(parts, "covering=true")
+	}
+	return strings.Join(parts, " ")
+}
+
+func joinDetail(plan QueryPlan, join JoinPlan) string {
+	parts := []string{"type=" + joinTypeString(join.Type)}
+	if join.LeftScanIndex >= 0 && join.LeftScanIndex < len(plan.Scans) {
+		parts = append(parts, "left="+plan.Scans[join.LeftScanIndex].TableAlias)
+	}
+	if join.RightScanIndex >= 0 && join.RightScanIndex < len(plan.Scans) {
+		parts = append(parts, "right="+plan.Scans[join.RightScanIndex].TableAlias)
+	}
+	if len(join.JoinColumnPairs) > 0 {
+		pairs := make([]string, 0, len(join.JoinColumnPairs))
+		for _, pair := range join.JoinColumnPairs {
+			pairs = append(pairs, pair.BaseTableColumn.String()+"="+pair.JoinTableColumn.String())
+		}
+		parts = append(parts, "on="+strings.Join(pairs, ","))
+	} else if join.OuterJoinColumn != "" || join.InnerJoinColumn != "" {
+		parts = append(parts, "on="+join.OuterJoinColumn+"="+join.InnerJoinColumn)
+	}
+	return strings.Join(parts, " ")
+}
+
+func joinTypeString(joinType JoinType) string {
+	switch joinType {
+	case Inner:
+		return "inner"
+	case Left:
+		return "left"
+	case Right:
+		return "right"
+	default:
+		return "unknown"
+	}
+}
+
+func orderByDetail(orderBy []OrderBy) string {
+	parts := make([]string, 0, len(orderBy))
+	for _, order := range orderBy {
+		direction := "ASC"
+		if order.Direction == Desc {
+			direction = "DESC"
+		}
+		parts = append(parts, order.Field.String()+" "+direction)
+	}
+	return "order_by=" + strings.Join(parts, ",")
+}
+
+func rangeDetail(condition RangeCondition) string {
+	parts := make([]string, 0, 2)
+	if condition.Lower != nil {
+		op := ">"
+		if condition.Lower.Inclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s %v", op, condition.Lower.Value))
+	}
+	if condition.Upper != nil {
+		op := "<"
+		if condition.Upper.Inclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s %v", op, condition.Upper.Value))
+	}
+	return strings.Join(parts, " and ")
+}
+
+func conditionCount(conditions OneOrMore) int {
+	count := 0
+	for _, group := range conditions {
+		count += len(group)
+	}
+	return count
+}
+
+func estimateScanRows(table *Table, scan Scan) OptionalValue {
+	switch scan.Type {
+	case ScanTypeSequential, ScanTypeIndexAll:
+		if table.getRowCount != nil {
+			return OptionalValue{Valid: true, Value: table.getRowCount()}
+		}
+	case ScanTypeIndexFirst, ScanTypeIndexLast:
+		return OptionalValue{Valid: true, Value: int64(1)}
+	case ScanTypeIndexPoint:
+		if stats, ok := table.indexStats[scan.IndexName]; ok {
+			estimated := estimateFilteredRows(&stats, nil)
+			if estimated >= 0 {
+				return OptionalValue{Valid: true, Value: estimated * int64(max(1, len(scan.IndexKeys)))}
+			}
+		}
+		if len(scan.IndexKeys) > 0 {
+			return OptionalValue{Valid: true, Value: int64(len(scan.IndexKeys))}
+		}
+	case ScanTypeIndexRange:
+		if stats, ok := table.indexStats[scan.IndexName]; ok {
+			estimated := estimateFilteredRows(&stats, &scan.RangeCondition)
+			if estimated >= 0 {
+				return OptionalValue{Valid: true, Value: estimated}
+			}
+		}
+	}
+	return OptionalValue{}
+}

--- a/internal/minisql/explain_test.go
+++ b/internal/minisql/explain_test.go
@@ -1,0 +1,114 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatement_ExplainReadOnlyCloneAndBind(t *testing.T) {
+	t.Parallel()
+
+	stmt := Statement{
+		Kind:           Explain,
+		ExplainAnalyze: true,
+		ExplainStatement: &Statement{
+			Kind:      Select,
+			TableName: testTableName,
+			Fields:    []Field{{Name: "*"}},
+			Conditions: OneOrMore{
+				{
+					FieldIsEqual(Field{Name: "id"}, OperandPlaceholder, Placeholder{}),
+				},
+			},
+		},
+	}
+
+	assert.True(t, stmt.ReadOnly())
+	assert.Equal(t, 1, stmt.NumPlaceholders())
+
+	clone := stmt.Clone()
+	require.NotNil(t, clone.ExplainStatement)
+	clone.ExplainStatement.TableName = "other"
+	assert.Equal(t, testTableName, stmt.ExplainStatement.TableName)
+
+	bound, err := stmt.BindArguments(int64(42))
+	require.NoError(t, err)
+	require.NotNil(t, bound.ExplainStatement)
+	assert.Equal(t, OperandInteger, bound.ExplainStatement.Conditions[0][0].Operand2.Type)
+	assert.Equal(t, int64(42), bound.ExplainStatement.Conditions[0][0].Operand2.Value)
+}
+
+func TestBuildExplainResult_PlainPlan(t *testing.T) {
+	t.Parallel()
+
+	table := NewTable(testLogger, nil, nil, testTableName, testColumns[0:2], 0, nil,
+		WithPrimaryKey(NewPrimaryKey(PrimaryKeyName(testTableName), testColumns[0:1], true)),
+		WithRowCountGetter(func() int64 { return 10 }),
+	)
+	plan := QueryPlan{
+		Scans: []Scan{
+			{
+				TableName:    testTableName,
+				Type:         ScanTypeIndexPoint,
+				IndexName:    PrimaryKeyName(testTableName),
+				IndexColumns: testColumns[0:1],
+				IndexKeys:    []any{int64(1)},
+			},
+		},
+	}
+
+	result := buildExplainResult(plan, table, nil)
+	require.Equal(t, explainColumns, result.Columns)
+	require.True(t, result.Rows.Next(context.Background()))
+
+	row := result.Rows.Row()
+	require.Len(t, row.Values, len(explainColumns))
+	assert.Equal(t, int64(1), row.Values[0].Value)
+	assert.Equal(t, "index_point", row.Values[1].Value.(TextPointer).String())
+	assert.Contains(t, row.Values[2].Value.(TextPointer).String(), "index=pkey__test_table")
+	assert.Equal(t, int64(1), row.Values[3].Value)
+	assert.False(t, row.Values[4].Valid)
+	assert.False(t, row.Values[5].Valid)
+}
+
+func TestTable_AnalyzePlanSequentialScan(t *testing.T) {
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+	insertStmt := Statement{
+		Kind:    Insert,
+		Columns: table.Columns,
+		Fields:  fieldsFromColumns(table.Columns...),
+		Inserts: [][]OptionalValue{
+			{
+				{Valid: true, Value: int64(1)},
+				{Valid: true, Value: NewTextPointer([]byte("a@example.com"))},
+			},
+			{
+				{Valid: true, Value: int64(2)},
+				{Valid: true, Value: NewTextPointer([]byte("b@example.com"))},
+			},
+		},
+	}
+	mustInsert(ctx, t, table, txManager, insertStmt)
+
+	selectStmt := Statement{
+		Kind:   Select,
+		Fields: fieldsFromColumns(table.Columns...),
+	}
+	var metrics map[int]explainMetric
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		plan, err := table.PlanQuery(ctx, selectStmt)
+		if err != nil {
+			return err
+		}
+		metrics, err = table.analyzePlan(ctx, selectStmt, plan)
+		return err
+	})
+	require.NoError(t, err)
+	require.Contains(t, metrics, 1)
+	assert.Equal(t, int64(2), metrics[1].rows)
+	assert.GreaterOrEqual(t, metrics[1].durationUS, int64(0))
+}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -40,6 +40,7 @@ const (
 	Analyze
 	Vacuum
 	Pragma
+	Explain
 )
 
 func (s StatementKind) String() string {
@@ -72,6 +73,8 @@ func (s StatementKind) String() string {
 		return "VACUUM"
 	case Pragma:
 		return "PRAGMA"
+	case Explain:
+		return "EXPLAIN"
 	default:
 		return "UNKNOWN"
 	}
@@ -310,38 +313,44 @@ type UnionClause struct {
 
 // Statement ...
 type Statement struct {
-	PrimaryKey     PrimaryKey
-	Aliases        map[string]string
-	Functions      map[string]Function
-	Updates        map[string]OptionalValue
-	Offset         OptionalValue
-	Limit          OptionalValue
-	TableName      string
-	TableAlias     string
-	IndexName      string
-	Target         string
-	PragmaName     string
-	PragmaValue    string
-	Fields         []Field
-	Inserts        [][]OptionalValue
-	Aggregates     []AggregateExpr
-	GroupBy        []Field
-	Having         OneOrMore
-	Unions         []UnionClause
-	Joins          []Join
-	OrderBy        []OrderBy
-	UniqueIndexes  []UniqueIndex
-	Columns        []Column
-	Conditions     OneOrMore
-	ReturningFields []Field
-	Kind            StatementKind
-	ConflictAction  ConflictAction
-	IfNotExists     bool
-	Distinct        bool
+	PrimaryKey       PrimaryKey
+	Aliases          map[string]string
+	Functions        map[string]Function
+	Updates          map[string]OptionalValue
+	Offset           OptionalValue
+	Limit            OptionalValue
+	TableName        string
+	TableAlias       string
+	IndexName        string
+	Target           string
+	PragmaName       string
+	PragmaValue      string
+	Fields           []Field
+	Inserts          [][]OptionalValue
+	Aggregates       []AggregateExpr
+	GroupBy          []Field
+	Having           OneOrMore
+	Unions           []UnionClause
+	Joins            []Join
+	OrderBy          []OrderBy
+	UniqueIndexes    []UniqueIndex
+	Columns          []Column
+	Conditions       OneOrMore
+	ReturningFields  []Field
+	ExplainStatement *Statement
+	Kind             StatementKind
+	ConflictAction   ConflictAction
+	IfNotExists      bool
+	ExplainAnalyze   bool
+	Distinct         bool
 }
 
 // NumPlaceholders returns the number of placeholder parameters (?) in the statement.
 func (s Statement) NumPlaceholders() int {
+	if s.Kind == Explain && s.ExplainStatement != nil {
+		return s.ExplainStatement.NumPlaceholders()
+	}
+
 	count := 0
 
 	if s.Kind == Insert {
@@ -428,6 +437,7 @@ func (s Statement) Clone() Statement {
 		Limit:           s.Limit,
 		Offset:          s.Offset,
 		ReturningFields: s.ReturningFields,
+		ExplainAnalyze:  s.ExplainAnalyze,
 	}
 	for i := range s.Inserts {
 		stmt.Inserts[i] = make([]OptionalValue, len(s.Inserts[i]))
@@ -448,6 +458,10 @@ func (s Statement) Clone() Statement {
 			stmt.Unions[i] = UnionClause{All: u.All, Stmt: u.Stmt.Clone()}
 		}
 	}
+	if s.ExplainStatement != nil {
+		inner := s.ExplainStatement.Clone()
+		stmt.ExplainStatement = &inner
+	}
 	return stmt
 }
 
@@ -456,6 +470,15 @@ func (s Statement) BindArguments(args ...any) (Statement, error) {
 	// Clone statement so we can keep using the preparement statement
 	// with different arguments without modifying it
 	stmt := s.Clone()
+
+	if s.Kind == Explain && stmt.ExplainStatement != nil {
+		inner, err := stmt.ExplainStatement.BindArguments(args...)
+		if err != nil {
+			return Statement{}, err
+		}
+		stmt.ExplainStatement = &inner
+		return stmt, nil
+	}
 
 	if s.Kind == Insert {
 		for i, anInsert := range stmt.Inserts {
@@ -581,7 +604,7 @@ func (s Statement) HasField(name string) bool {
 
 // ReadOnly ...
 func (s Statement) ReadOnly() bool {
-	return s.Kind == Select || s.Kind == Pragma
+	return s.Kind == Select || s.Kind == Pragma || s.Kind == Explain
 }
 
 // IsDDL ...

--- a/internal/parser/explain.go
+++ b/internal/parser/explain.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func (p *parserItem) parseExplain(analyze bool) error {
+	p.Kind = minisql.Explain
+	p.ExplainAnalyze = analyze
+	p.pop()
+
+	rest := &parserItem{
+		sql:  p.sql[p.i:],
+		step: stepBeginning,
+	}
+	statements, err := rest.doParse()
+	if err != nil {
+		return fmt.Errorf("EXPLAIN: %w", err)
+	}
+	if len(statements) != 1 {
+		return p.errorf("at EXPLAIN: expected exactly one statement")
+	}
+
+	p.i += rest.i
+	p.ExplainStatement = &statements[0]
+	p.step = stepStatementEnd
+	return nil
+}

--- a/internal/parser/explain_test.go
+++ b/internal/parser/explain_test.go
@@ -1,0 +1,90 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_Explain(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCase{
+		{
+			"EXPLAIN SELECT",
+			"EXPLAIN SELECT * FROM users WHERE id = 1;",
+			[]minisql.Statement{
+				{
+					Kind: minisql.Explain,
+					ExplainStatement: &minisql.Statement{
+						Kind:      minisql.Select,
+						TableName: "users",
+						Fields:    []minisql.Field{{Name: "*"}},
+						Conditions: minisql.OneOrMore{
+							{
+								minisql.FieldIsEqual(
+									minisql.Field{Name: "id"},
+									minisql.OperandInteger,
+									int64(1),
+								),
+							},
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"EXPLAIN ANALYZE SELECT",
+			"EXPLAIN ANALYZE SELECT id FROM users;",
+			[]minisql.Statement{
+				{
+					Kind:           minisql.Explain,
+					ExplainAnalyze: true,
+					ExplainStatement: &minisql.Statement{
+						Kind:      minisql.Select,
+						TableName: "users",
+						Fields:    []minisql.Field{{Name: "id"}},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"EXPLAIN unsupported statement still parses",
+			"EXPLAIN INSERT INTO users (id) VALUES (1);",
+			[]minisql.Statement{
+				{
+					Kind: minisql.Explain,
+					ExplainStatement: &minisql.Statement{
+						Kind:      minisql.Insert,
+						TableName: "users",
+						Fields:    []minisql.Field{{Name: "id"}},
+						Inserts: [][]minisql.OptionalValue{
+							{{Valid: true, Value: int64(1)}},
+						},
+					},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			statements, err := New().Parse(context.Background(), tc.SQL)
+			if tc.Err != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.Err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, statements)
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -36,6 +36,7 @@ var reservedWords = []string{
 	// column types
 	"BOOLEAN", "INT4", "INT8", "REAL", "DOUBLE", "TEXT", "VARCHAR(", "TIMESTAMP",
 	// statement types
+	"EXPLAIN ANALYZE", "EXPLAIN",
 	"CREATE TABLE", "DROP TABLE", "CREATE INDEX", "DROP INDEX",
 	"SELECT", "INSERT INTO", "VALUES", "UPDATE", "DELETE FROM",
 	// statement other
@@ -212,6 +213,14 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 				p.Kind = minisql.Pragma
 				p.pop()
 				p.step = stepPragma
+			case "EXPLAIN ANALYZE":
+				if err := p.parseExplain(true); err != nil {
+					return statements, err
+				}
+			case "EXPLAIN":
+				if err := p.parseExplain(false); err != nil {
+					return statements, err
+				}
 			default:
 				return statements, p.wrapErr(errInvalidStatementKind)
 			}
@@ -605,7 +614,11 @@ func (p *parserItem) validate(stmt minisql.Statement) error {
 		if stmt.Kind == minisql.CreateIndex && len(stmt.Columns) == 0 {
 			return errCreateIndexNoColumns
 		}
-	} else if stmt.TableName == "" && stmt.Kind != minisql.Analyze && stmt.Kind != minisql.Vacuum && stmt.Kind != minisql.Pragma {
+	} else if stmt.TableName == "" &&
+		stmt.Kind != minisql.Analyze &&
+		stmt.Kind != minisql.Vacuum &&
+		stmt.Kind != minisql.Pragma &&
+		stmt.Kind != minisql.Explain {
 		return errEmptyTableName
 	}
 	if stmt.Kind == minisql.CreateTable {

--- a/minisql.go
+++ b/minisql.go
@@ -316,7 +316,7 @@ func (c *Conn) executeStatement(ctx context.Context, stmt minisql.Statement) (mi
 		return err
 	}
 	var err error
-	if stmt.Kind == minisql.Select {
+	if stmt.Kind == minisql.Select || stmt.Kind == minisql.Explain {
 		err = c.db.GetTransactionManager().ExecuteReadOnlyTransaction(ctx, txFn)
 	} else {
 		err = c.db.GetTransactionManager().ExecuteInTransaction(ctx, txFn)

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,84 @@
+package minisql
+
+import (
+	"context"
+	"database/sql/driver"
+	"io"
+	"testing"
+	"time"
+
+	internalminisql "github.com/RichardKnop/minisql/internal/minisql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowsColumnsCloseAndNext(t *testing.T) {
+	t.Parallel()
+
+	columns := []internalminisql.Column{
+		{Name: "id", Kind: internalminisql.Int8},
+		{Name: "name", Kind: internalminisql.Text},
+		{Name: "created", Kind: internalminisql.Timestamp},
+		{Name: "nullable", Kind: internalminisql.Text},
+	}
+	ts := internalminisql.MustParseTimestampMicros("2024-06-15 12:34:56.123456")
+	rows := Rows{
+		columns: columns,
+		iter: internalminisql.NewSliceIterator([]internalminisql.Row{
+			internalminisql.NewRowWithValues(columns, []internalminisql.OptionalValue{
+				{Valid: true, Value: int64(1)},
+				{Valid: true, Value: internalminisql.NewTextPointer([]byte("alice"))},
+				{Valid: true, Value: internalminisql.TimestampMicros(ts)},
+				{},
+			}),
+		}),
+		ctx: context.Background(),
+	}
+
+	assert.Equal(t, []string{"id", "name", "created", "nullable"}, rows.Columns())
+
+	dest := make([]driver.Value, len(columns))
+	require.NoError(t, rows.Next(dest))
+	assert.Equal(t, int64(1), dest[0])
+	assert.Equal(t, "alice", dest[1])
+	assert.Equal(t, time.Date(2024, 6, 15, 12, 34, 56, 123456000, time.UTC), dest[2])
+	assert.Nil(t, dest[3])
+
+	assert.ErrorIs(t, rows.Next(dest), io.EOF)
+	require.NoError(t, rows.Close())
+}
+
+func TestRowsNextReturnsIteratorError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := assert.AnError
+	rows := Rows{
+		columns: []internalminisql.Column{{Name: "id", Kind: internalminisql.Int8}},
+		iter: internalminisql.NewIterator(func(context.Context) (internalminisql.Row, error) {
+			return internalminisql.Row{}, wantErr
+		}),
+		ctx: context.Background(),
+	}
+
+	err := rows.Next(make([]driver.Value, 1))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestRowsNextValidatesDestinationWidth(t *testing.T) {
+	t.Parallel()
+
+	columns := []internalminisql.Column{{Name: "id", Kind: internalminisql.Int8}}
+	rows := Rows{
+		columns: columns,
+		iter: internalminisql.NewSliceIterator([]internalminisql.Row{
+			internalminisql.NewRowWithValues(columns, []internalminisql.OptionalValue{
+				{Valid: true, Value: int64(1)},
+			}),
+		}),
+		ctx: context.Background(),
+	}
+
+	err := rows.Next(make([]driver.Value, 2))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 2 values, got 1")
+}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	internalminisql "github.com/RichardKnop/minisql/internal/minisql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -132,4 +133,38 @@ func TestResultRowsAffected(t *testing.T) {
 	n, err := r.RowsAffected()
 	require.NoError(t, err)
 	assert.Equal(t, int64(7), n)
+}
+
+func TestStmtCloseNumInputAndUnsupportedLegacyMethods(t *testing.T) {
+	t.Parallel()
+
+	stmt := Stmt{
+		statement: internalminisql.Statement{
+			Kind:      internalminisql.Select,
+			TableName: "users",
+			Fields:    []internalminisql.Field{{Name: "*"}},
+			Conditions: internalminisql.OneOrMore{
+				{
+					internalminisql.FieldIsEqual(
+						internalminisql.Field{Name: "id"},
+						internalminisql.OperandPlaceholder,
+						internalminisql.Placeholder{},
+					),
+				},
+			},
+		},
+	}
+
+	require.NoError(t, stmt.Close())
+	assert.Equal(t, 1, stmt.NumInput())
+
+	result, err := stmt.Exec(nil)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "Exec without context is not supported")
+
+	rows, err := stmt.Query(nil)
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.Contains(t, err.Error(), "Query without context is not supported")
 }


### PR DESCRIPTION
Implemented SELECT-only EXPLAIN / EXPLAIN ANALYZE.

What changed:

- Added EXPLAIN statement parsing, including EXPLAIN ANALYZE.
- Added StatementKind / clone / placeholder binding support for wrapped statements.
- Added engine execution in internal/minisql/explain.go.
- Output columns are step, operation, detail, rows_estimated, rows_actual, duration_us.
- Unsupported wrapped statements now return a friendly error like: EXPLAIN currently supports SELECT statements only: got INSERT
- Added parser, unit, and e2e tests.