### PR TITLE
feat: add slow query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ MiniSQL supports optional connection string parameters:
 | `wal_checkpoint_threshold` | non-negative integer | `1000` | Auto-checkpoint after N WAL frames (0 = disabled) |
 | `log_level` | `debug`, `info`, `warn`, `error` | `warn` | Set logging verbosity level |
 | `max_cached_pages` | positive integer | `2000` | Maximum number of pages to keep in memory cache |
+| `slow_query_threshold` | Go duration, e.g. `50ms`, `2s` | `0` | Log queries taking at least this long at WARN level (0 = disabled) |
 | `synchronous` | `off`, `normal`, `full` | `normal` | WAL fsync mode (see [WAL durability](#wal-durability-modes) below) |
 
 **Examples:**
@@ -67,6 +68,9 @@ db, err := sql.Open("minisql", "./my.db?wal_checkpoint_threshold=0")
 
 // Maximum write durability (fsync after every commit)
 db, err := sql.Open("minisql", "./my.db?synchronous=full")
+
+// Log queries that take at least 50ms
+db, err := sql.Open("minisql", "./my.db?slow_query_threshold=50ms")
 
 // Combine multiple parameters
 db, err := sql.Open("minisql", "/path/to/db.db?log_level=info&max_cached_pages=2000")

--- a/connection_string.go
+++ b/connection_string.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
 	"go.uber.org/zap"
@@ -38,6 +39,7 @@ type ConnectionConfig struct {
 	WALWriteBufferSize     int             // WAL write-buffer size in bytes (default: 64 KiB; 0 = flush every commit)
 	LogLevel               string          // Log level: debug, info, warn, error (default: warn)
 	MaxCachedPages         int             // Maximum number of pages to cache (default: 2000, 0 = use default)
+	SlowQueryThreshold     time.Duration   // Log queries at WARN when elapsed time meets or exceeds this duration (0 = disabled)
 	Synchronous            SynchronousMode // WAL fsync mode: off, normal (default), full
 }
 
@@ -62,6 +64,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //   - wal_write_buffer_size=N           : WAL write-buffer in bytes (default: 65536; 0 = flush every commit)
 //   - log_level=debug|info|warn|error   : Set logging level (default: warn)
 //   - max_cached_pages=N                : Page cache size in pages (default: 2000)
+//   - slow_query_threshold=50ms         : Log queries taking at least this long (0 = disabled)
 //   - synchronous=off|normal|full       : WAL fsync mode (default: normal, matching SQLite WAL default)
 //
 // Examples:
@@ -127,6 +130,15 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 			return nil, fmt.Errorf("invalid max_cached_pages parameter: must be non-negative, got %d", maxPages)
 		}
 		config.MaxCachedPages = maxPages
+	}
+
+	// Parse slow_query_threshold parameter
+	if thresholdStr := queryParams.Get("slow_query_threshold"); thresholdStr != "" {
+		threshold, err := time.ParseDuration(thresholdStr)
+		if err != nil || threshold < 0 {
+			return nil, fmt.Errorf("invalid slow_query_threshold parameter: must be a non-negative duration, got %q", thresholdStr)
+		}
+		config.SlowQueryThreshold = threshold
 	}
 
 	// Parse synchronous parameter

--- a/connection_string_test.go
+++ b/connection_string_test.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"testing"
+	"time"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
 	"github.com/stretchr/testify/assert"
@@ -98,13 +99,14 @@ func TestParseConnectionString(t *testing.T) {
 		},
 		{
 			name:    "all parameters",
-			connStr: "./test.db?wal_checkpoint_threshold=200&log_level=info&max_cached_pages=4000",
+			connStr: "./test.db?wal_checkpoint_threshold=200&log_level=info&max_cached_pages=4000&slow_query_threshold=75ms",
 			wantConfig: &ConnectionConfig{
 				FilePath:               "./test.db",
 				WALCheckpointThreshold: 200,
 				WALWriteBufferSize:     DefaultWALWriteBufferSize,
 				LogLevel:               "info",
 				MaxCachedPages:         4000,
+				SlowQueryThreshold:     75 * time.Millisecond,
 				Synchronous:            SynchronousNormal,
 			},
 			wantErr: false,
@@ -202,6 +204,18 @@ func TestParseConnectionString(t *testing.T) {
 			connStr:     "./test.db?log_level=verbose",
 			wantErr:     true,
 			errContains: "invalid log_level parameter",
+		},
+		{
+			name:        "invalid slow query threshold",
+			connStr:     "./test.db?slow_query_threshold=soon",
+			wantErr:     true,
+			errContains: "invalid slow_query_threshold parameter",
+		},
+		{
+			name:        "negative slow query threshold",
+			connStr:     "./test.db?slow_query_threshold=-1ms",
+			wantErr:     true,
+			errContains: "invalid slow_query_threshold parameter",
 		},
 		{
 			name:        "invalid synchronous value",

--- a/minisql.go
+++ b/minisql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
 	"github.com/RichardKnop/minisql/internal/parser"
@@ -66,9 +67,10 @@ func (d *Driver) Open(name string) (driver.Conn, error) {
 	}
 
 	return &Conn{
-		db:     db,
-		parser: d.parser,
-		logger: d.logger,
+		db:                 db,
+		parser:             d.parser,
+		logger:             d.logger,
+		slowQueryThreshold: config.SlowQueryThreshold,
 	}, nil
 }
 
@@ -118,11 +120,12 @@ func (d *Driver) newDB(config *ConnectionConfig) (*minisql.Database, error) {
 
 // Conn implements the database/sql/driver.Conn interface.
 type Conn struct {
-	db          *minisql.Database
-	parser      minisql.Parser
-	transaction *minisql.Transaction
-	logger      *zap.Logger
-	mu          sync.RWMutex
+	db                 *minisql.Database
+	parser             minisql.Parser
+	transaction        *minisql.Transaction
+	logger             *zap.Logger
+	mu                 sync.RWMutex
+	slowQueryThreshold time.Duration
 }
 
 // Ping ...
@@ -171,6 +174,7 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 
 	return &Stmt{
 		conn:      c,
+		query:     query,
 		statement: statement,
 	}, nil
 }
@@ -202,7 +206,12 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 }
 
 // ExecContext executes a query that doesn't return rows.
-func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (result driver.Result, err error) {
+	start := time.Now()
+	defer func() {
+		c.logSlowQuery(query, time.Since(start), err)
+	}()
+
 	statements, err := c.parser.Parse(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
@@ -237,7 +246,12 @@ func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 }
 
 // QueryContext executes a query that may return rows.
-func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (rows driver.Rows, err error) {
+	start := time.Now()
+	defer func() {
+		c.logSlowQuery(query, time.Since(start), err)
+	}()
+
 	statements, err := c.parser.Parse(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse query: %w", err)
@@ -323,6 +337,22 @@ func (c *Conn) executeStatement(ctx context.Context, stmt minisql.Statement) (mi
 	}
 
 	return result, err
+}
+
+func (c *Conn) logSlowQuery(query string, elapsed time.Duration, err error) {
+	if c.slowQueryThreshold <= 0 || elapsed < c.slowQueryThreshold || c.logger == nil {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("query", query),
+		zap.Duration("duration", elapsed),
+		zap.Duration("threshold", c.slowQueryThreshold),
+	}
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+	}
+	c.logger.Warn("slow query", fields...)
 }
 
 // Ensure interfaces are implemented

--- a/slow_query_test.go
+++ b/slow_query_test.go
@@ -1,0 +1,61 @@
+package minisql
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestConnLogSlowQuery(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.WarnLevel)
+	conn := &Conn{
+		logger:             zap.New(core),
+		slowQueryThreshold: 50 * time.Millisecond,
+	}
+
+	conn.logSlowQuery("select * from users", 49*time.Millisecond, nil)
+	assert.Equal(t, 0, logs.Len())
+
+	conn.logSlowQuery("select * from users", 50*time.Millisecond, nil)
+	assert.Equal(t, 1, logs.Len())
+
+	entry := logs.All()[0]
+	assert.Equal(t, "slow query", entry.Message)
+	assert.Equal(t, "select * from users", entry.ContextMap()["query"])
+	assert.Equal(t, 50*time.Millisecond, entry.ContextMap()["duration"])
+	assert.Equal(t, 50*time.Millisecond, entry.ContextMap()["threshold"])
+}
+
+func TestConnLogSlowQueryIncludesError(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.WarnLevel)
+	conn := &Conn{
+		logger:             zap.New(core),
+		slowQueryThreshold: time.Millisecond,
+	}
+
+	err := errors.New("boom")
+	conn.logSlowQuery("select broken", 2*time.Millisecond, err)
+
+	assert.Equal(t, 1, logs.Len())
+	assert.Equal(t, "boom", logs.All()[0].ContextMap()["error"])
+}
+
+func TestConnLogSlowQueryDisabled(t *testing.T) {
+	t.Parallel()
+
+	core, logs := observer.New(zap.WarnLevel)
+	conn := &Conn{
+		logger: zap.New(core),
+	}
+
+	conn.logSlowQuery("select * from users", time.Hour, nil)
+	assert.Equal(t, 0, logs.Len())
+}

--- a/stmt.go
+++ b/stmt.go
@@ -12,6 +12,7 @@ import (
 // Stmt ...
 type Stmt struct {
 	conn      *Conn
+	query     string
 	statement minisql.Statement
 }
 
@@ -48,7 +49,12 @@ func (s Stmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 // ExecContext ...
-func (s Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+func (s Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (result driver.Result, err error) {
+	start := time.Now()
+	defer func() {
+		s.conn.logSlowQuery(s.query, time.Since(start), err)
+	}()
+
 	internalArgs, err := toInternalArgs(args)
 	if err != nil {
 		return nil, err
@@ -59,12 +65,12 @@ func (s Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver
 		return nil, err
 	}
 
-	result, err := s.conn.executeStatement(ctx, stmtWithArgs)
+	stmtResult, err := s.conn.executeStatement(ctx, stmtWithArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	return Result{rowsAffected: int64(result.RowsAffected)}, nil
+	return Result{rowsAffected: int64(stmtResult.RowsAffected)}, nil
 }
 
 // Query executes a query that may return rows, such as a
@@ -76,7 +82,12 @@ func (s Stmt) Query(args []driver.Value) (driver.Rows, error) {
 }
 
 // QueryContext ...
-func (s Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+func (s Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
+	start := time.Now()
+	defer func() {
+		s.conn.logSlowQuery(s.query, time.Since(start), err)
+	}()
+
 	internalArgs, err := toInternalArgs(args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Implemented slow query logging.

What changed:

- Added slow_query_threshold connection string parameter, parsed as a Go duration like 50ms, 2s, 1m.
- Disabled by default with 0.
- Logs at WARN when elapsed time meets/exceeds the threshold.
- Covers direct ExecContext / QueryContext and prepared statement ExecContext / QueryContext.
- Log fields include query, duration, threshold, and error when applicable.
- Updated README connection parameter docs and examples.
- Added unit tests for parsing and logging behavior.