### PR TITLE
feat: implement non-correlated scalar subqueries in WHERE

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Important behavior and current non-goals:
 | `UPDATE` | |
 | `DELETE` | |
 | `RETURNING` | Can be used to return columns from `INSERT` or `DELETE` queries, common use case is to return auto incremented primary key |
-| `WHERE` | Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `IN`, `NOT IN`, `LIKE`, `NOT LIKE`, `BETWEEN` |
+| `WHERE` | Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `IN`, `NOT IN`, `LIKE`, `NOT LIKE`, `BETWEEN`, support for non-correlated scalar subqueries |
 | `LIKE`, `NOT LIKE` | `%` matches any sequence of zero or more characters; `_` matches any single character |
 | `LIMIT` and `OFFSET` | Basic pagination |
 | `ORDER BY` | Single column only |

--- a/benchmarks/select_bench_test.go
+++ b/benchmarks/select_bench_test.go
@@ -100,7 +100,7 @@ func BenchmarkSelect_Limit(b *testing.B) {
 						rows.Close()
 						b.Fatalf("scan: %v", err)
 					}
-					n++
+					n += 1
 				}
 				rows.Close()
 				if err := rows.Err(); err != nil {
@@ -149,7 +149,7 @@ func BenchmarkSelect_FullScan(b *testing.B) {
 						rows.Close()
 						b.Fatalf("scan: %v", err)
 					}
-					n++
+					n += 1
 				}
 				rows.Close()
 				if err := rows.Err(); err != nil {

--- a/e2e_tests/concurrency_bench_test.go
+++ b/e2e_tests/concurrency_bench_test.go
@@ -121,7 +121,7 @@ func BenchmarkConcurrentReads(b *testing.B) {
 			err := readStmt.QueryRow(int64((i%1000)+1)).Scan(&id, &email, &name, &created)
 			require.NoError(b, err)
 
-			i++
+			i += 1
 		}
 	})
 }

--- a/e2e_tests/join_star_schema_test.go
+++ b/e2e_tests/join_star_schema_test.go
@@ -212,7 +212,7 @@ func (s *TestSuite) TestStarSchemaJoin() {
 			var name, email, city string
 			err := rows.Scan(&userID, &name, &email, &orderID, &amount, &city)
 			s.Require().NoError(err)
-			count++
+			count += 1
 			// All rows should be for Alice (user_id = 1)
 			s.Assert().Equal(int64(1), userID)
 			s.Assert().Equal("Alice", name)
@@ -352,7 +352,7 @@ func (s *TestSuite) TestStarSchemaLargeResult() {
 		var rating int64
 		err := rows.Scan(&name, &product, &rating)
 		s.Require().NoError(err)
-		count++
+		count += 1
 		s.Assert().Equal("Alice", name)
 	}
 

--- a/e2e_tests/join_test.go
+++ b/e2e_tests/join_test.go
@@ -126,7 +126,7 @@ func (s *TestSuite) TestInnerJoin() {
 			expected := expectedResults[i]
 			s.Equal(expected.username, username, "Row %d: user_name mismatch", i)
 			s.Equal(expected.amount, amount, "Row %d: amount mismatch", i)
-			i++
+			i += 1
 		}
 
 		s.Require().NoError(rows.Err())
@@ -170,7 +170,7 @@ func (s *TestSuite) TestInnerJoin() {
 			s.Equal(expected.userID, userID, "Row %d: user_id mismatch", i)
 			s.Equal(expected.username, username, "Row %d: user_name mismatch", i)
 			s.Equal(expected.amount, amount, "Row %d: amount mismatch", i)
-			i++
+			i += 1
 		}
 		rows.Close()
 		s.Require().NoError(rows.Err())
@@ -211,7 +211,7 @@ func (s *TestSuite) TestInnerJoin() {
 			expected := expectedByAmount[i]
 			s.Equal(expected.username, username, "Row %d: user_name mismatch", i)
 			s.Equal(expected.amount, amount, "Row %d: amount mismatch", i)
-			i++
+			i += 1
 		}
 		rows.Close()
 		s.Require().NoError(rows.Err())
@@ -252,7 +252,7 @@ func (s *TestSuite) TestInnerJoin() {
 			expected := expectedByMultiple[i]
 			s.Equal(expected.username, username, "Row %d: user_name mismatch", i)
 			s.Equal(expected.amount, amount, "Row %d: amount mismatch", i)
-			i++
+			i += 1
 		}
 		rows.Close()
 		s.Require().NoError(rows.Err())
@@ -334,7 +334,7 @@ func (s *TestSuite) TestInnerJoin_WithSecondaryIndex() {
 		s.Equal(expected.username, username, "Row %d: user_name mismatch", i)
 		s.Equal(expected.orderID, orderID, "Row %d: order_id mismatch", i)
 		s.Equal(expected.amount, amount, "Row %d: amount mismatch", i)
-		i++
+		i += 1
 	}
 
 	s.Require().NoError(rows.Err())

--- a/e2e_tests/subquery_test.go
+++ b/e2e_tests/subquery_test.go
@@ -1,0 +1,167 @@
+package e2etests
+
+func (s *TestSuite) TestSubquery() {
+	// Schema: users and orders tables.
+	_, err := s.db.Exec(`create table "users" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		score int8
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "orders" (
+		id      int8 primary key autoincrement,
+		user_id int8 not null,
+		amount  int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	// Seed users.
+	_, err = s.db.Exec(`insert into "users" (name, score) values ('Alice', 90)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "users" (name, score) values ('Bob', 70)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "users" (name, score) values ('Carol', 85)`)
+	s.Require().NoError(err)
+
+	// Seed orders referencing user IDs 1 and 2.
+	_, err = s.db.Exec(`insert into "orders" (user_id, amount) values (1, 500)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "orders" (user_id, amount) values (1, 300)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "orders" (user_id, amount) values (2, 200)`)
+	s.Require().NoError(err)
+
+	s.Run("scalar_subquery_eq", func() {
+		// Find users whose score equals Alice's score (90).
+		rows, err := s.db.Query(
+			`select name from "users" where score = (select score from "users" where name = 'Alice')`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Alice", names[0])
+	})
+
+	s.Run("scalar_subquery_gt", func() {
+		// Users with score > Bob's score (70).
+		rows, err := s.db.Query(
+			`select name from "users" where score > (select score from "users" where name = 'Bob')`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 2)
+		s.ElementsMatch([]string{"Alice", "Carol"}, names)
+	})
+
+	s.Run("scalar_subquery_lte", func() {
+		// Users with score <= Carol's score (85).
+		rows, err := s.db.Query(
+			`select name from "users" where score <= (select score from "users" where name = 'Carol')`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 2)
+		s.ElementsMatch([]string{"Bob", "Carol"}, names)
+	})
+
+	s.Run("in_subquery_finds_users_with_orders", func() {
+		// Users who have at least one order (user_ids 1 and 2).
+		rows, err := s.db.Query(
+			`select name from "users" where id IN (select user_id from "orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 2)
+		s.ElementsMatch([]string{"Alice", "Bob"}, names)
+	})
+
+	s.Run("not_in_subquery_excludes_users_with_orders", func() {
+		// Users who have NO orders (only Carol, user_id 3).
+		rows, err := s.db.Query(
+			`select name from "users" where id NOT IN (select user_id from "orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Carol", names[0])
+	})
+
+	s.Run("scalar_subquery_no_rows_returns_null_no_match", func() {
+		// Subquery returns no rows → NULL → equality always false.
+		rows, err := s.db.Query(
+			`select name from "users" where id = (select id from "orders" where amount = 9999)`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Empty(names)
+	})
+
+	s.Run("update_with_scalar_subquery_in_where", func() {
+		// Set Carol's score to match Alice's (90).
+		res, err := s.db.Exec(
+			`update "users" set score = 90 where id = (select id from "users" where name = 'Carol')`)
+		s.Require().NoError(err)
+		affected, err := res.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(1), affected)
+
+		// Verify.
+		row := s.db.QueryRow(`select score from "users" where name = 'Carol'`)
+		var score int64
+		s.Require().NoError(row.Scan(&score))
+		s.Equal(int64(90), score)
+	})
+
+	s.Run("delete_with_in_subquery", func() {
+		// Delete all orders belonging to Alice (user_id 1).
+		res, err := s.db.Exec(
+			`delete from "orders" where user_id IN (select id from "users" where name = 'Alice')`)
+		s.Require().NoError(err)
+		affected, err := res.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(2), affected)
+	})
+}

--- a/internal/minisql/condition.go
+++ b/internal/minisql/condition.go
@@ -81,6 +81,9 @@ const (
 	OperandInteger
 	OperandFloat
 	OperandList
+	// OperandSubquery holds a *Statement SELECT that is evaluated before the
+	// outer scan begins and replaced with a concrete scalar or list value.
+	OperandSubquery
 )
 
 // Operand holds a typed value on one side of a condition expression.

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -441,6 +441,15 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 	case CreateTable, DropTable, CreateIndex, DropIndex:
 		return d.executeDDLStatement(ctx, stmt)
 	case Insert, Select, Update, Delete:
+		// Pre-evaluate any non-correlated scalar subqueries in the WHERE clause.
+		if len(stmt.Conditions) > 0 {
+			resolved, err := d.resolveSubqueries(ctx, stmt.Conditions)
+			if err != nil {
+				return StatementResult{}, err
+			}
+			stmt.Conditions = resolved
+		}
+
 		// SELECT with UNION / UNION ALL branches is handled by the union executor.
 		if stmt.Kind == Select && len(stmt.Unions) > 0 {
 			return d.executeUnion(ctx, stmt)

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -741,7 +741,7 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 			return nil, fmt.Errorf("SUBSTR: start must be an integer, got %T", startVal)
 		}
 		// SQL uses 1-based indexing; clamp to valid range.
-		start-- // convert to 0-based
+		start -= 1 // convert to 0-based
 		if start < 0 {
 			start = 0
 		}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -451,6 +451,15 @@ func (s Statement) Clone() Statement {
 	for i := range s.Conditions {
 		stmt.Conditions[i] = make([]Condition, len(s.Conditions[i]))
 		copy(stmt.Conditions[i], s.Conditions[i])
+		// Deep-copy subquery operands so parallel bind calls don't race.
+		for j, cond := range stmt.Conditions[i] {
+			if cond.Operand2.Type == OperandSubquery {
+				if sub, ok := cond.Operand2.Value.(*Statement); ok {
+					cloned := sub.Clone()
+					stmt.Conditions[i][j].Operand2.Value = &cloned
+				}
+			}
+		}
 	}
 	if len(s.Unions) > 0 {
 		stmt.Unions = make([]UnionClause, len(s.Unions))

--- a/internal/minisql/subquery.go
+++ b/internal/minisql/subquery.go
@@ -1,0 +1,107 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+)
+
+// resolveSubqueries walks stmt.Conditions, finds any OperandSubquery operands,
+// executes the subquery using the same transaction already in ctx, and replaces
+// each OperandSubquery with a concrete scalar or list value so that downstream
+// condition evaluation can proceed without any knowledge of subqueries.
+//
+// For scalar operators (=, !=, <, <=, >, >=) the subquery must return exactly
+// one column and at most one row.  Zero rows resolves to NULL.
+// For IN / NOT IN the subquery must return exactly one column; all rows are
+// collected into an OperandList.
+func (d *Database) resolveSubqueries(ctx context.Context, conditions OneOrMore) (OneOrMore, error) {
+	for i, condGroup := range conditions {
+		for j, cond := range condGroup {
+			if cond.Operand2.Type != OperandSubquery {
+				continue
+			}
+			subStmt := *cond.Operand2.Value.(*Statement)
+
+			result, err := d.ExecuteStatement(ctx, subStmt)
+			if err != nil {
+				return nil, fmt.Errorf("subquery: %w", err)
+			}
+			if len(result.Columns) != 1 {
+				return nil, fmt.Errorf("subquery must return exactly one column, got %d", len(result.Columns))
+			}
+
+			switch cond.Operator {
+			case In, NotIn:
+				seen := make(map[any]struct{})
+				var values []any
+				for result.Rows.Next(ctx) {
+					row := result.Rows.Row()
+					if len(row.Values) > 0 && row.Values[0].Valid {
+						v := row.Values[0].Value
+						if _, dup := seen[v]; !dup {
+							seen[v] = struct{}{}
+							values = append(values, v)
+						}
+					}
+				}
+				if err := result.Rows.Err(); err != nil {
+					return nil, fmt.Errorf("subquery: reading rows: %w", err)
+				}
+				if values == nil {
+					values = []any{}
+				}
+				cond.Operand2 = Operand{Type: OperandList, Value: values}
+
+			default:
+				// Scalar subquery: at most one row expected.
+				if !result.Rows.Next(ctx) {
+					if err := result.Rows.Err(); err != nil {
+						return nil, fmt.Errorf("subquery: reading row: %w", err)
+					}
+					// Zero rows → NULL.
+					cond.Operand2 = Operand{Type: OperandNull}
+					conditions[i][j] = cond
+					continue
+				}
+				row := result.Rows.Row()
+				// Guard against more than one row.
+				if result.Rows.Next(ctx) {
+					return nil, fmt.Errorf("scalar subquery returned more than one row")
+				}
+				if err := result.Rows.Err(); err != nil {
+					return nil, fmt.Errorf("subquery: reading row: %w", err)
+				}
+				if len(row.Values) == 0 || !row.Values[0].Valid {
+					cond.Operand2 = Operand{Type: OperandNull}
+				} else {
+					val := row.Values[0].Value
+					cond.Operand2 = Operand{
+						Type:  scalarOperandType(val),
+						Value: val,
+					}
+				}
+			}
+			conditions[i][j] = cond
+		}
+	}
+	return conditions, nil
+}
+
+// scalarOperandType returns the OperandType for a concrete Go value that came
+// from a subquery result row.  TimestampMicros is mapped to OperandQuotedString
+// because the condition evaluator already handles TextPointer/TimestampMicros
+// comparisons at the column-type level.
+func scalarOperandType(v any) OperandType {
+	switch v.(type) {
+	case int64, int32:
+		return OperandInteger
+	case float64, float32:
+		return OperandFloat
+	case bool:
+		return OperandBoolean
+	case TimestampMicros:
+		return OperandQuotedString
+	default:
+		return OperandQuotedString
+	}
+}

--- a/internal/minisql/timestamp.go
+++ b/internal/minisql/timestamp.go
@@ -417,7 +417,7 @@ func dateFromEpochDaysBackward(days int64) (int32, int, int) {
 			break
 		}
 		remainingDays -= yearDays
-		year--
+		year -= 1
 	}
 
 	month := 12
@@ -427,7 +427,7 @@ func dateFromEpochDaysBackward(days int64) (int32, int, int) {
 			break
 		}
 		remainingDays -= monthDays
-		month--
+		month -= 1
 	}
 
 	day := daysInMonth(isLeapYear(int(year)), month) - int(remainingDays) + 1

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -453,7 +453,7 @@ func (p *parserItem) pop() string {
 
 func (p *parserItem) popWhitespace() {
 	for p.i < len(p.sql) && p.sql[p.i] == ' ' {
-		p.i++
+		p.i += 1
 	}
 }
 

--- a/internal/parser/subquery_test.go
+++ b/internal/parser/subquery_test.go
@@ -1,0 +1,175 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_ScalarSubquery(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		sql  string
+		// We only assert on the subquery operand to keep tests focused.
+		wantOperandType minisql.OperandType
+		wantSubKind     minisql.StatementKind
+		wantSubTable    string
+		wantErr         bool
+	}{
+		{
+			name:            "WHERE id = (SELECT id FROM orders)",
+			sql:             "SELECT * FROM users WHERE id = (SELECT id FROM orders)",
+			wantOperandType: minisql.OperandSubquery,
+			wantSubKind:     minisql.Select,
+			wantSubTable:    "orders",
+		},
+		{
+			name:            "WHERE id != (SELECT id FROM orders)",
+			sql:             "SELECT * FROM users WHERE id != (SELECT id FROM orders)",
+			wantOperandType: minisql.OperandSubquery,
+			wantSubKind:     minisql.Select,
+			wantSubTable:    "orders",
+		},
+		{
+			name:            "WHERE score > (SELECT score FROM baseline)",
+			sql:             "SELECT * FROM users WHERE score > (SELECT score FROM baseline)",
+			wantOperandType: minisql.OperandSubquery,
+			wantSubKind:     minisql.Select,
+			wantSubTable:    "baseline",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stmts, err := New().Parse(context.Background(), tc.sql)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+			stmt := stmts[0]
+			require.NotEmpty(t, stmt.Conditions)
+			cond := stmt.Conditions[0][0]
+			assert.Equal(t, tc.wantOperandType, cond.Operand2.Type)
+			subStmt, ok := cond.Operand2.Value.(*minisql.Statement)
+			require.True(t, ok, "expected *minisql.Statement, got %T", cond.Operand2.Value)
+			assert.Equal(t, tc.wantSubKind, subStmt.Kind)
+			assert.Equal(t, tc.wantSubTable, subStmt.TableName)
+		})
+	}
+}
+
+func TestParse_InSubquery(t *testing.T) {
+	t.Parallel()
+
+	stmts, err := New().Parse(context.Background(),
+		"SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt := stmts[0]
+	require.NotEmpty(t, stmt.Conditions)
+	cond := stmt.Conditions[0][0]
+	assert.Equal(t, minisql.In, cond.Operator)
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+	subStmt, ok := cond.Operand2.Value.(*minisql.Statement)
+	require.True(t, ok)
+	assert.Equal(t, minisql.Select, subStmt.Kind)
+	assert.Equal(t, "orders", subStmt.TableName)
+}
+
+func TestParse_NotInSubquery(t *testing.T) {
+	t.Parallel()
+
+	stmts, err := New().Parse(context.Background(),
+		"SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM banned)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	cond := stmts[0].Conditions[0][0]
+	assert.Equal(t, minisql.NotIn, cond.Operator)
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+	sub := cond.Operand2.Value.(*minisql.Statement)
+	assert.Equal(t, "banned", sub.TableName)
+}
+
+func TestParse_SubqueryWithNestedParens(t *testing.T) {
+	t.Parallel()
+
+	// Subquery contains COUNT(*) which has parens inside it.
+	stmts, err := New().Parse(context.Background(),
+		"SELECT * FROM users WHERE total = (SELECT COUNT(*) FROM orders)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	cond := stmts[0].Conditions[0][0]
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+	sub := cond.Operand2.Value.(*minisql.Statement)
+	assert.Equal(t, "orders", sub.TableName)
+}
+
+func TestParse_SubqueryWithWhere(t *testing.T) {
+	t.Parallel()
+
+	// Subquery has its own WHERE clause.
+	stmts, err := New().Parse(context.Background(),
+		"SELECT * FROM users WHERE id = (SELECT id FROM orders WHERE status = 'active')")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	cond := stmts[0].Conditions[0][0]
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+	sub := cond.Operand2.Value.(*minisql.Statement)
+	assert.Equal(t, "orders", sub.TableName)
+	assert.NotEmpty(t, sub.Conditions)
+}
+
+func TestParse_SubqueryAndLiteralInSameWhere(t *testing.T) {
+	t.Parallel()
+
+	// One condition is a subquery, another is a plain literal.
+	stmts, err := New().Parse(context.Background(),
+		"SELECT * FROM users WHERE name = 'Alice' AND id = (SELECT id FROM orders)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	// DNF: one group with two conditions.
+	require.Len(t, stmts[0].Conditions, 1)
+	require.Len(t, stmts[0].Conditions[0], 2)
+
+	literalCond := stmts[0].Conditions[0][0]
+	assert.Equal(t, minisql.OperandQuotedString, literalCond.Operand2.Type)
+
+	subqueryCond := stmts[0].Conditions[0][1]
+	assert.Equal(t, minisql.OperandSubquery, subqueryCond.Operand2.Type)
+}
+
+func TestParse_UpdateWithSubquery(t *testing.T) {
+	t.Parallel()
+
+	stmts, err := New().Parse(context.Background(),
+		"UPDATE users SET name = 'Bob' WHERE id = (SELECT id FROM orders)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Update, stmt.Kind)
+	require.NotEmpty(t, stmt.Conditions)
+	cond := stmt.Conditions[0][0]
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+}
+
+func TestParse_DeleteWithSubquery(t *testing.T) {
+	t.Parallel()
+
+	stmts, err := New().Parse(context.Background(),
+		"DELETE FROM users WHERE id = (SELECT id FROM banned)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Delete, stmt.Kind)
+	cond := stmt.Conditions[0][0]
+	assert.Equal(t, minisql.OperandSubquery, cond.Operand2.Type)
+}

--- a/internal/parser/where.go
+++ b/internal/parser/where.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -287,8 +288,8 @@ func (p *parserItem) parseLeafCondition() (*minisql.ConditionNode, error) {
 	return &minisql.ConditionNode{Leaf: &cond}, nil
 }
 
-// parseCondScalarValue parses a scalar value (literal, placeholder, or field identifier)
-// and assigns it to cond.Operand2.
+// parseCondScalarValue parses a scalar value (literal, placeholder, field
+// identifier, or scalar subquery) and assigns it to cond.Operand2.
 func (p *parserItem) parseCondScalarValue(cond *minisql.Condition) error {
 	value, ln := p.peekValue()
 	if ln != 0 {
@@ -314,6 +315,19 @@ func (p *parserItem) parseCondScalarValue(cond *minisql.Condition) error {
 		p.pop()
 		return nil
 	}
+	// Scalar subquery: col = (SELECT ...)
+	if p.peek() == "(" {
+		p.pop() // consume "("
+		if strings.ToUpper(p.peek()) != "SELECT" {
+			return p.errorf("at WHERE: expected SELECT after '(' for scalar subquery")
+		}
+		subStmt, err := p.parseSubquery()
+		if err != nil {
+			return err
+		}
+		cond.Operand2 = minisql.Operand{Type: minisql.OperandSubquery, Value: subStmt}
+		return nil
+	}
 	if identifier := p.peek(); isIdentifier(identifier) {
 		cond.Operand2 = minisql.Operand{
 			Type:  minisql.OperandField,
@@ -325,9 +339,65 @@ func (p *parserItem) parseCondScalarValue(cond *minisql.Condition) error {
 	return p.wrapErr(errWhereExpectedIdentifierPlaceholderOrValue)
 }
 
+// parseSubquery extracts the SQL from p.i to the matching closing paren,
+// parses it as a SELECT statement, and returns the parsed *Statement.
+// p.i must be positioned at the start of the SELECT keyword when called.
+// The closing ")" is consumed before returning.
+func (p *parserItem) parseSubquery() (*minisql.Statement, error) {
+	// Find the matching ")" by scanning character-by-character, respecting
+	// single-quoted strings and nested parentheses.
+	var (
+		depth   = 1
+		scanI   = p.i
+		inQuote = false
+	)
+	for scanI < len(p.sql) {
+		ch := p.sql[scanI]
+		if ch == '\'' {
+			inQuote = !inQuote
+		} else if !inQuote {
+			if ch == '(' {
+				depth += 1
+			} else if ch == ')' {
+				depth -= 1
+				if depth == 0 {
+					break
+				}
+			}
+		}
+		scanI += 1
+	}
+	if depth != 0 {
+		return nil, p.errorf("at WHERE: unclosed parenthesis in subquery")
+	}
+	subSQL := strings.TrimSpace(p.sql[p.i:scanI])
+	p.i = scanI + 1 // skip ")"
+	p.popWhitespace()
+
+	stmts, err := New().Parse(context.Background(), subSQL)
+	if err != nil {
+		return nil, p.errorf("at WHERE: subquery parse error: %v", err)
+	}
+	if len(stmts) != 1 || stmts[0].Kind != minisql.Select {
+		return nil, p.errorf("at WHERE: subquery must be a single SELECT statement")
+	}
+	return &stmts[0], nil
+}
+
 // parseCondListValues parses the comma-separated values inside IN (...).
 // The opening "(" is already consumed as part of the "IN (" token.
+// If the first token is SELECT, the entire list is treated as a subquery.
 func (p *parserItem) parseCondListValues(cond *minisql.Condition) error {
+	// IN (SELECT ...) — list subquery
+	if strings.ToUpper(p.peek()) == "SELECT" {
+		subStmt, err := p.parseSubquery()
+		if err != nil {
+			return err
+		}
+		cond.Operand2 = minisql.Operand{Type: minisql.OperandSubquery, Value: subStmt}
+		return nil
+	}
+
 	for {
 		value, ln := p.peekValue()
 		switch {

--- a/pkg/lrucache/lru_cache.go
+++ b/pkg/lrucache/lru_cache.go
@@ -128,7 +128,7 @@ func (c *cacheImpl[T]) EvictIfNeeded() (T, bool) {
 		// Reset its access count and check the next one
 		atomic.StoreUint32(&victim.accessCount, 0)
 		victim = victim.prev
-		attempts++
+		attempts += 1
 	}
 
 	// If all checked entries were accessed, just evict the tail anyway


### PR DESCRIPTION
```sql
SELECT * FROM orders WHERE user_id = (SELECT id FROM users WHERE email = ?)
SELECT * FROM orders WHERE status IN (SELECT code FROM valid_statuses)
SELECT * FROM orders WHERE total > (SELECT AVG(total) FROM orders)
```

Extend `Operand` to carry optional `*Statement` subquery. Add `doParseSubquery()` recursive-descent (called when `(SELECT` seen). Execute non-correlated subqueries once before outer query; cache result. Keep state machine as top-level dispatcher.