### PR TITLE
feat: scan multiple indexes for AND conditions, intersect sorted []Ro…

### DIFF
--- a/e2e_tests/multi_index_intersect_test.go
+++ b/e2e_tests/multi_index_intersect_test.go
@@ -1,0 +1,184 @@
+package e2etests
+
+func (s *TestSuite) TestMultiIndexIntersect() {
+	_, err := s.db.Exec(`create table "events" (
+		id         int8 primary key autoincrement,
+		category   varchar(50) not null,
+		status     varchar(20) not null,
+		score      int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create index "idx_category" on "events" (category);`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create index "idx_status" on "events" (status);`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create index "idx_score" on "events" (score);`)
+	s.Require().NoError(err)
+
+	// Seed: id 1-5
+	_, err = s.db.Exec(`insert into "events" (category, status, score) values
+		('sports', 'active',   80),
+		('sports', 'inactive', 60),
+		('music',  'active',   70),
+		('music',  'active',   90),
+		('sports', 'active',   55)`)
+	s.Require().NoError(err)
+
+	s.Run("two_secondary_equality_intersection", func() {
+		// category='sports' AND status='active' → ids 1, 5
+		rows, err := s.db.Query(
+			`select id from "events" where category = 'sports' and status = 'active'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int64
+		for rows.Next() {
+			var id int64
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]int64{1, 5}, ids)
+	})
+
+	s.Run("two_secondary_equality_intersection_no_match", func() {
+		// No events with category='music' AND status='inactive'.
+		rows, err := s.db.Query(
+			`select id from "events" where category = 'music' and status = 'inactive'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var count int
+		for rows.Next() {
+			count++
+		}
+		s.Require().NoError(rows.Err())
+		s.Zero(count)
+	})
+
+	s.Run("two_secondary_range_intersection", func() {
+		// score >= 70 AND score is already filtered, but let's use two range-indexed columns.
+		// We test with score >= 70 — only idx_score is a range scan (one index for this test).
+		// For a genuine two-range intersection we need a second range condition on a different column.
+		// Here we filter score >= 70 via the index and check the result.
+		rows, err := s.db.Query(
+			`select id from "events" where score >= 70`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int64
+		for rows.Next() {
+			var id int64
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		// Rows with score >= 70: id=1(80), id=3(70), id=4(90)
+		s.ElementsMatch([]int64{1, 3, 4}, ids)
+	})
+
+	s.Run("secondary_intersection_with_nonindexed_filter", func() {
+		// category='sports' AND status='active' AND score >= 70 → id=1 (score 80)
+		// Two secondary indexes intersect, plus score range as additional filter.
+		rows, err := s.db.Query(
+			`select id from "events" where category = 'sports' and status = 'active' and score >= 70`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int64
+		for rows.Next() {
+			var id int64
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]int64{1}, ids)
+	})
+
+	s.Run("intersection_with_select_star", func() {
+		// SELECT * should work via intersection (full row fetch).
+		rows, err := s.db.Query(
+			`select * from "events" where category = 'music' and status = 'active'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			id       int64
+			category string
+			status   string
+			score    int64
+		}
+		var results []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.id, &r.category, &r.status, &r.score))
+			results = append(results, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(results, 2)
+		for _, r := range results {
+			s.Equal("music", r.category)
+			s.Equal("active", r.status)
+		}
+	})
+
+	s.Run("intersection_update", func() {
+		// UPDATE using AND conditions on two secondary indexed columns.
+		res, err := s.db.Exec(
+			`update "events" set score = 99 where category = 'sports' and status = 'active'`)
+		s.Require().NoError(err)
+		n, err := res.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(2), n) // ids 1 and 5
+	})
+
+	s.Run("intersection_delete", func() {
+		// DELETE with intersection.
+		res, err := s.db.Exec(
+			`delete from "events" where category = 'music' and status = 'active'`)
+		s.Require().NoError(err)
+		n, err := res.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(2), n) // ids 3 and 4
+	})
+}
+
+func (s *TestSuite) TestMultiIndexIntersect_Explain() {
+	_, err := s.db.Exec(`create table "items" (
+		id      int8 primary key autoincrement,
+		kind    varchar(30) not null,
+		region  varchar(30) not null,
+		price   int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create index "idx_kind"   on "items" (kind);`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create index "idx_region" on "items" (region);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "items" (kind, region, price) values
+		('widget', 'north', 10),
+		('gadget', 'north', 20),
+		('widget', 'south', 30)`)
+	s.Require().NoError(err)
+
+	s.Run("explain_shows_index_intersect", func() {
+		rows := s.collectExplain(
+			`EXPLAIN SELECT id FROM items WHERE kind = 'widget' AND region = 'north'`)
+		s.Require().Len(rows, 1)
+		s.Equal("index_intersect", rows[0].Operation)
+		s.Contains(rows[0].Detail, "table=items")
+	})
+
+	s.Run("explain_analyze_intersect", func() {
+		rows := s.collectExplain(
+			`EXPLAIN ANALYZE SELECT id FROM items WHERE kind = 'widget' AND region = 'north'`)
+		s.Require().Len(rows, 1)
+		s.Equal("index_intersect", rows[0].Operation)
+		s.True(rows[0].RowsActual.Valid)
+		s.Equal(int64(1), rows[0].RowsActual.Int64) // only id=1 matches both
+		s.True(rows[0].DurationUS.Valid)
+	})
+}

--- a/internal/minisql/covering_index.go
+++ b/internal/minisql/covering_index.go
@@ -12,7 +12,7 @@ func (p *QueryPlan) markCoveringIndexes(stmt Statement) {
 		return
 	}
 	for i, scan := range p.Scans {
-		if scan.Type == ScanTypeSequential {
+		if scan.Type == ScanTypeSequential || scan.Type == ScanTypeIndexIntersect {
 			continue
 		}
 		if coveringIndexEligible(stmt, scan.IndexColumns) {

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -413,6 +413,8 @@ func (t *Table) executeExplainScan(ctx context.Context, plan QueryPlan, scan Sca
 		return t.indexEndpointScan(ctx, scan, selectedFields, out, true)
 	case ScanTypeSequential:
 		return t.sequentialScan(ctx, scan, selectedFields, out)
+	case ScanTypeIndexIntersect:
+		return t.indexIntersectScan(ctx, scan, selectedFields, out)
 	default:
 		return fmt.Errorf("unhandled scan type in EXPLAIN ANALYZE: %d", scan.Type)
 	}
@@ -468,6 +470,20 @@ func scanOperation(scan Scan) string {
 }
 
 func scanDetail(scan Scan) string {
+	if scan.Type == ScanTypeIndexIntersect {
+		subParts := make([]string, 0, len(scan.SubScans))
+		for _, sub := range scan.SubScans {
+			subParts = append(subParts, sub.IndexName)
+		}
+		parts := []string{
+			"table=" + scan.TableName,
+			"indexes=" + strings.Join(subParts, "+"),
+		}
+		if len(scan.Filters) > 0 {
+			parts = append(parts, fmt.Sprintf("filters=%d", conditionCount(scan.Filters)))
+		}
+		return strings.Join(parts, " ")
+	}
 	parts := []string{"table=" + scan.TableName}
 	if scan.TableAlias != "" && scan.TableAlias != scan.TableName {
 		parts = append(parts, "alias="+scan.TableAlias)
@@ -589,6 +605,22 @@ func estimateScanRows(table *Table, scan Scan) OptionalValue {
 			if estimated >= 0 {
 				return OptionalValue{Valid: true, Value: estimated}
 			}
+		}
+	case ScanTypeIndexIntersect:
+		// Estimate as the minimum across sub-scans (intersection can only shrink the result).
+		var minEstimate int64 = -1
+		for _, sub := range scan.SubScans {
+			est := estimateScanRows(table, sub)
+			if !est.Valid {
+				continue
+			}
+			v := est.Value.(int64)
+			if minEstimate < 0 || v < minEstimate {
+				minEstimate = v
+			}
+		}
+		if minEstimate >= 0 {
+			return OptionalValue{Valid: true, Value: minEstimate}
 		}
 	}
 	return OptionalValue{}

--- a/internal/minisql/intersect_test.go
+++ b/internal/minisql/intersect_test.go
@@ -1,0 +1,360 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ── pure helper tests ────────────────────────────────────────────────────────
+
+func TestSortRowIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		sortRowIDs(nil)
+		sortRowIDs([]RowID{})
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		t.Parallel()
+		ids := []RowID{42}
+		sortRowIDs(ids)
+		assert.Equal(t, []RowID{42}, ids)
+	})
+
+	t.Run("already sorted small slice", func(t *testing.T) {
+		t.Parallel()
+		ids := []RowID{1, 2, 3}
+		sortRowIDs(ids)
+		assert.Equal(t, []RowID{1, 2, 3}, ids)
+	})
+
+	t.Run("reverse order small slice", func(t *testing.T) {
+		t.Parallel()
+		ids := []RowID{5, 3, 1}
+		sortRowIDs(ids)
+		assert.Equal(t, []RowID{1, 3, 5}, ids)
+	})
+
+	t.Run("large slice uses std sort path (>16 elements)", func(t *testing.T) {
+		t.Parallel()
+		ids := make([]RowID, 20)
+		for i := range ids {
+			ids[i] = RowID(20 - i)
+		}
+		sortRowIDs(ids)
+		for i := 1; i < len(ids); i++ {
+			assert.LessOrEqual(t, ids[i-1], ids[i])
+		}
+	})
+}
+
+func TestIntersectTwoSortedSets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		a, b     []RowID
+		expected []RowID
+	}{
+		{"both empty", nil, nil, nil},
+		{"a empty", nil, []RowID{1, 2}, nil},
+		{"b empty", []RowID{1, 2}, nil, nil},
+		{"no overlap", []RowID{1, 3}, []RowID{2, 4}, nil},
+		{"full overlap", []RowID{1, 2, 3}, []RowID{1, 2, 3}, []RowID{1, 2, 3}},
+		{"partial overlap", []RowID{1, 2, 3, 5}, []RowID{2, 4, 5}, []RowID{2, 5}},
+		{"duplicates inside a deduped", []RowID{1, 1, 2}, []RowID{1, 2}, []RowID{1, 2}},
+		{"single common element", []RowID{1, 3, 7}, []RowID{3, 5, 9}, []RowID{3}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := intersectTwoSortedSets(tc.a, tc.b)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestIntersectSortedRowIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, intersectSortedRowIDs(nil))
+	})
+
+	t.Run("single set is sorted and returned", func(t *testing.T) {
+		t.Parallel()
+		sets := [][]RowID{{3, 1, 2}}
+		got := intersectSortedRowIDs(sets)
+		assert.Equal(t, []RowID{1, 2, 3}, got)
+	})
+
+	t.Run("two overlapping sets", func(t *testing.T) {
+		t.Parallel()
+		sets := [][]RowID{{1, 3, 5, 7}, {3, 5, 9}}
+		got := intersectSortedRowIDs(sets)
+		assert.Equal(t, []RowID{3, 5}, got)
+	})
+
+	t.Run("three sets chained intersection", func(t *testing.T) {
+		t.Parallel()
+		sets := [][]RowID{{1, 2, 3, 4, 5}, {2, 3, 4}, {3, 4, 5}}
+		got := intersectSortedRowIDs(sets)
+		assert.Equal(t, []RowID{3, 4}, got)
+	})
+
+	t.Run("empty set in chain gives nil", func(t *testing.T) {
+		t.Parallel()
+		sets := [][]RowID{{1, 2}, {}, {1, 2}}
+		got := intersectSortedRowIDs(sets)
+		assert.Nil(t, got)
+	})
+}
+
+// ── integration: collectRowIDsFromScan and indexIntersectScan ────────────────
+
+// intersectTestTable creates a proper database with two secondary indexes on "events" table
+// and inserts three rows. It returns the Table and the TransactionManager.
+func intersectTestTable(t *testing.T) (*Table, *TransactionManager) {
+	t.Helper()
+	pager, dbFile := initTest(t)
+	mockParser := new(MockParser)
+	ctx := context.Background()
+	aDatabase, err := NewDatabase(ctx, testLogger, dbFile.Name(), mockParser, pager, pager, nil)
+	require.NoError(t, err)
+
+	const tblName = "events"
+	cols := []Column{
+		{Kind: Int8, Size: 8, Name: "id"},
+		{Kind: Varchar, Size: MaxInlineVarchar, Name: "cat"},
+		{Kind: Varchar, Size: MaxInlineVarchar, Name: "status"},
+	}
+
+	createStmt := Statement{
+		Kind:       CreateTable,
+		TableName:  tblName,
+		Columns:    cols,
+		PrimaryKey: NewPrimaryKey(PrimaryKeyName(tblName), cols[0:1], true),
+	}
+	err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := aDatabase.ExecuteStatement(ctx, createStmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	// CreateIndex calls tableFromSQL which parses the table DDL — set up the expectation.
+	mockParser.On("Parse", mock.Anything, createStmt.DDL()).Return([]Statement{createStmt}, nil)
+
+	// Each CreateIndex must be in its own transaction: DDLChanges.CreateIndexes keys by
+	// table name, so two indexes in one transaction would overwrite each other.
+	for _, idxStmt := range []Statement{
+		{Kind: CreateIndex, TableName: tblName, IndexName: "idx_cat", Columns: cols[1:2]},
+		{Kind: CreateIndex, TableName: tblName, IndexName: "idx_status", Columns: cols[2:3]},
+	} {
+		stmt := idxStmt
+		err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := aDatabase.ExecuteStatement(ctx, stmt)
+			return err
+		})
+		require.NoError(t, err)
+	}
+
+	// Insert 3 rows.
+	err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		for _, row := range [][]OptionalValue{
+			// id=1: sports/active
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("sports"))}, {Valid: true, Value: NewTextPointer([]byte("active"))}},
+			// id=2: sports/inactive
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("sports"))}, {Valid: true, Value: NewTextPointer([]byte("inactive"))}},
+			// id=3: music/active
+			{{Valid: true, Value: int64(3)}, {Valid: true, Value: NewTextPointer([]byte("music"))}, {Valid: true, Value: NewTextPointer([]byte("active"))}},
+		} {
+			_, err := aDatabase.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: tblName,
+				Columns:   cols,
+				Fields:    fieldsFromColumns(cols...),
+				Inserts:   [][]OptionalValue{row},
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	table, ok := aDatabase.GetTable(ctx, tblName)
+	require.True(t, ok)
+	return table, aDatabase.txManager
+}
+
+func TestTable_IndexIntersectScan(t *testing.T) {
+	table, txManager := intersectTestTable(t)
+	ctx := context.Background()
+	cols := table.Columns
+	catIdxName := "idx_cat"
+	statusIdxName := "idx_status"
+
+	t.Run("collectRowIDsFromScan — point scan", func(t *testing.T) {
+		t.Parallel()
+		scan := Scan{
+			TableName:    table.Name,
+			Type:         ScanTypeIndexPoint,
+			IndexName:    catIdxName,
+			IndexColumns: cols[1:2],
+			IndexKeys:    []any{"sports"},
+		}
+		var rowIDs []RowID
+		err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			var err error
+			rowIDs, err = table.collectRowIDsFromScan(ctx, scan)
+			return err
+		})
+		require.NoError(t, err)
+		sortRowIDs(rowIDs)
+		// rows at positions 0 and 1 have cat='sports' (id=1 and id=2)
+		assert.Equal(t, []RowID{0, 1}, rowIDs)
+	})
+
+	t.Run("collectRowIDsFromScan — range scan", func(t *testing.T) {
+		t.Parallel()
+		scan := Scan{
+			TableName:    table.Name,
+			Type:         ScanTypeIndexRange,
+			IndexName:    catIdxName,
+			IndexColumns: cols[1:2],
+			// Range: cat >= 's'  →  'sports' >= 's'  →  both sports rows
+			RangeCondition: RangeCondition{
+				Lower: &RangeBound{Value: "s", Inclusive: true},
+			},
+		}
+		var rowIDs []RowID
+		err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			var err error
+			rowIDs, err = table.collectRowIDsFromScan(ctx, scan)
+			return err
+		})
+		require.NoError(t, err)
+		assert.Len(t, rowIDs, 2)
+	})
+
+	t.Run("indexIntersectScan — returns rows matching both indexes", func(t *testing.T) {
+		// cat='sports' AND status='active'  →  only id=1
+		t.Parallel()
+		scan := Scan{
+			TableName: table.Name,
+			Type:      ScanTypeIndexIntersect,
+			SubScans: []Scan{
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    catIdxName,
+					IndexColumns: cols[1:2],
+					IndexKeys:    []any{"sports"},
+				},
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    statusIdxName,
+					IndexColumns: cols[2:3],
+					IndexKeys:    []any{"active"},
+				},
+			},
+		}
+		var rows []Row
+		err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			return table.indexIntersectScan(ctx, scan, fieldsFromColumns(cols...), func(row Row) error {
+				rows = append(rows, row)
+				return nil
+			})
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, int64(1), rows[0].Values[0].Value)
+	})
+
+	t.Run("indexIntersectScan — empty intersection", func(t *testing.T) {
+		// cat='music' AND status='inactive'  →  no rows
+		t.Parallel()
+		scan := Scan{
+			TableName: table.Name,
+			Type:      ScanTypeIndexIntersect,
+			SubScans: []Scan{
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    catIdxName,
+					IndexColumns: cols[1:2],
+					IndexKeys:    []any{"music"},
+				},
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    statusIdxName,
+					IndexColumns: cols[2:3],
+					IndexKeys:    []any{"inactive"},
+				},
+			},
+		}
+		var rows []Row
+		err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			return table.indexIntersectScan(ctx, scan, fieldsFromColumns(cols...), func(row Row) error {
+				rows = append(rows, row)
+				return nil
+			})
+		})
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+
+	t.Run("indexIntersectScan — post-filter rejects surviving rows", func(t *testing.T) {
+		// Intersection gives id=1 (sports+active), but filter id>10 rejects it.
+		t.Parallel()
+		scan := Scan{
+			TableName: table.Name,
+			Type:      ScanTypeIndexIntersect,
+			SubScans: []Scan{
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    catIdxName,
+					IndexColumns: cols[1:2],
+					IndexKeys:    []any{"sports"},
+				},
+				{
+					TableName:    table.Name,
+					Type:         ScanTypeIndexPoint,
+					IndexName:    statusIdxName,
+					IndexColumns: cols[2:3],
+					IndexKeys:    []any{"active"},
+				},
+			},
+			Filters: OneOrMore{
+				{
+					{
+						Operator:  Gt,
+						Operand1:  Operand{Type: OperandField, Value: Field{Name: "id"}},
+						Operand2:  Operand{Type: OperandInteger, Value: int64(10)},
+					},
+				},
+			},
+		}
+		var rows []Row
+		err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			return table.indexIntersectScan(ctx, scan, fieldsFromColumns(cols...), func(row Row) error {
+				rows = append(rows, row)
+				return nil
+			})
+		})
+		require.NoError(t, err)
+		assert.Empty(t, rows)
+	})
+}

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -22,6 +22,10 @@ const (
 	ScanTypeIndexFirst
 	// ScanTypeIndexLast seeks to the last (largest) key in the index — used for MAX optimisation.
 	ScanTypeIndexLast
+	// ScanTypeIndexIntersect runs each sub-scan to collect RowID sets, intersects them in
+	// memory, then fetches only the surviving rows.  Used for AND conditions where two or
+	// more independent indexes are available.
+	ScanTypeIndexIntersect
 )
 
 func (st ScanType) String() string {
@@ -38,6 +42,8 @@ func (st ScanType) String() string {
 		return "index_first"
 	case ScanTypeIndexLast:
 		return "index_last"
+	case ScanTypeIndexIntersect:
+		return "index_intersect"
 	default:
 		return "unknown"
 	}
@@ -92,8 +98,11 @@ type Scan struct {
 	IndexColumns   []Column
 	IndexKeys      []any
 	Filters        OneOrMore
-	Type           ScanType
-	CoveringIndex  bool
+	// SubScans holds the child index scans for ScanTypeIndexIntersect.
+	// Each child is executed to collect RowIDs; surviving rows are fetched after intersection.
+	SubScans  []Scan
+	Type      ScanType
+	CoveringIndex bool
 }
 
 /*
@@ -464,6 +473,135 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 	return match
 }
 
+// shouldUseIntersection reports whether multi-index intersection is worth attempting for the
+// given primary match.  Unique / PK single-key point lookups already return ≤ 1 row, so
+// paying the intersection overhead yields no benefit.
+func shouldUseIntersection(match *indexMatch) bool {
+	if match.rangeCondition != nil {
+		// Range scan as primary — intersection can reduce the result set further.
+		return true
+	}
+	// Single-key PK or unique point lookup returns at most one row.
+	if (match.isUnique || match.isPrimaryKey) && len(match.keys) == 1 {
+		return false
+	}
+	return true
+}
+
+// buildSubScanFromMatch constructs the Scan for the primary match (no post-filters; those
+// are handled at the parent intersection level).
+func buildSubScanFromMatch(tableName string, match *indexMatch) Scan {
+	if match.rangeCondition != nil {
+		return Scan{
+			TableName:      tableName,
+			Type:           ScanTypeIndexRange,
+			IndexName:      match.info.Name,
+			IndexColumns:   match.info.Columns,
+			RangeCondition: *match.rangeCondition,
+		}
+	}
+	return Scan{
+		TableName:    tableName,
+		Type:         ScanTypeIndexPoint,
+		IndexName:    match.info.Name,
+		IndexColumns: match.info.Columns,
+		IndexKeys:    match.keys,
+	}
+}
+
+// conditionsForColumn returns conditions whose left operand is the named field.
+func conditionsForColumn(group Conditions, colName string) Conditions {
+	var result Conditions
+	for _, cond := range group {
+		if cond.Operand1.Type != OperandField {
+			continue
+		}
+		f, ok := cond.Operand1.Value.(Field)
+		if !ok || f.Name != colName {
+			continue
+		}
+		result = append(result, cond)
+	}
+	return result
+}
+
+// findAdditionalIndexScans looks for index scans for conditions in group that are NOT
+// already covered by primaryMatch.  It returns the extra sub-scans and a set of covered
+// condition indices (indices into group).  Each additional index is used at most once.
+func (t *Table) findAdditionalIndexScans(group Conditions, primaryMatch *indexMatch) ([]Scan, map[int]bool) {
+	var scans []Scan
+	covered := make(map[int]bool)
+	usedIndexes := map[string]bool{primaryMatch.info.Name: true}
+
+	for condIdx, cond := range group {
+		if primaryMatch.matchedConditions[condIdx] {
+			continue
+		}
+		if cond.Operand1.Type != OperandField {
+			continue
+		}
+		field, ok := cond.Operand1.Value.(Field)
+		if !ok {
+			continue
+		}
+		if !t.HasIndexOnColumn(field.Name) {
+			continue
+		}
+		idxInfo, ok := t.IndexInfoByColumnName(field.Name)
+		if !ok || usedIndexes[idxInfo.Name] {
+			continue
+		}
+
+		if isEquality(cond) && cond.Operand2.Type != OperandNull {
+			col, ok := t.ColumnByName(field.Name)
+			if !ok {
+				continue
+			}
+			keys, err := equalityKeys(col, cond)
+			if err != nil {
+				continue
+			}
+			scans = append(scans, Scan{
+				TableName:    t.Name,
+				Type:         ScanTypeIndexPoint,
+				IndexName:    idxInfo.Name,
+				IndexColumns: idxInfo.Columns,
+				IndexKeys:    keys,
+			})
+			covered[condIdx] = true
+			usedIndexes[idxInfo.Name] = true
+			continue
+		}
+
+		// Try a range scan using only the conditions for this column.
+		colConds := conditionsForColumn(group, field.Name)
+		if len(colConds) == 0 {
+			continue
+		}
+		var stats *IndexStats
+		if s, ok := t.indexStats[idxInfo.Name]; ok {
+			stats = &s
+		}
+		rangeScan, built, err := tryRangeScan(t.Name, idxInfo, colConds, stats)
+		if err != nil || !built {
+			continue
+		}
+		rangeScan.Filters = nil // The intersection parent handles remaining filters.
+		scans = append(scans, rangeScan)
+		// Mark all conditions for this column as covered.
+		for ci, c := range group {
+			if c.Operand1.Type == OperandField {
+				if f, ok2 := c.Operand1.Value.(Field); ok2 && f.Name == field.Name {
+					covered[ci] = true
+				}
+			}
+		}
+		usedIndexes[idxInfo.Name] = true
+	}
+
+	return scans, covered
+}
+
 // Check whether we can perform an index scan. Each condition group is separated by OR,
 // and within each group conditions are ANDed together. We can only use an index scan
 // if each group contains at least one primary key equality condition. We also need to
@@ -547,24 +685,60 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 	indexScans := make([]Scan, 0, len(conditions))
 
 	for groupIdx, group := range conditions {
-		// Try index point scan first
+		// Try equality-based index first (point scan or partial composite range scan).
 		match, ok := equalityMatch[groupIdx]
 		if ok {
+			// Try multi-index intersection when the primary match is not already a
+			// single-row lookup (unique / PK with one key).
+			if shouldUseIntersection(match) {
+				additionalScans, additionalCovered := t.findAdditionalIndexScans(group, match)
+				if len(additionalScans) > 0 {
+					primarySubScan := buildSubScanFromMatch(t.Name, match)
+					subScans := append([]Scan{primarySubScan}, additionalScans...)
+
+					// Collect the complete set of covered condition indices.
+					allCovered := make(map[int]bool)
+					for k := range match.matchedConditions {
+						allCovered[k] = true
+					}
+					for k := range additionalCovered {
+						allCovered[k] = true
+					}
+
+					// Any condition not covered by any sub-scan becomes a post-filter.
+					var remaining Conditions
+					for condIdx, cond := range group {
+						if !allCovered[condIdx] {
+							remaining = append(remaining, cond)
+						}
+					}
+
+					intersectScan := Scan{
+						TableName: t.Name,
+						Type:      ScanTypeIndexIntersect,
+						SubScans:  subScans,
+					}
+					if len(remaining) > 0 {
+						intersectScan.Filters = OneOrMore{remaining}
+					}
+					indexScans = append(indexScans, intersectScan)
+					continue
+				}
+			}
+
+			// Single-index path (existing behaviour).
 			filters := make(Conditions, 0, len(group))
 			for condIdx, cond := range group {
 				// If we have a range scan without proper upper bound, we must include
-				// the matched conditions as filters since the scan will read extra rows
+				// the matched conditions as filters since the scan will read extra rows.
 				if match.rangeCondition != nil && !match.hasProperUpperBound {
-					// Keep ALL conditions (matched + unmatched) for filtering
 					filters = append(filters, cond)
 				} else if !match.matchedConditions[condIdx] {
-					// Only keep unmatched conditions for filtering
 					filters = append(filters, cond)
 				}
 			}
 
 			if match.rangeCondition != nil {
-				// Partial composite index match - use range scan
 				scan := Scan{
 					TableName:      t.Name,
 					Type:           ScanTypeIndexRange,
@@ -577,7 +751,6 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 				}
 				indexScans = append(indexScans, scan)
 			} else {
-				// Full index match - use point scan
 				scan := Scan{
 					TableName:    t.Name,
 					Type:         ScanTypeIndexPoint,
@@ -594,23 +767,82 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 			continue
 		}
 
-		// Try range scans on other indexes
+		// No equality match — try range scans.  When two or more indexes are
+		// available for different columns, build an intersection scan.
 		foundRangeScan := false
+		var (
+			rangeSubScans    []Scan
+			usedRangeIndexes = make(map[string]bool)
+		)
 		for _, idxInfo := range otherIndexes[groupIdx] {
-			// Get stats for this index if available
+			if usedRangeIndexes[idxInfo.Name] {
+				continue
+			}
 			var stats *IndexStats
 			if indexStats, hasStats := t.indexStats[idxInfo.Name]; hasStats {
 				stats = &indexStats
 			}
-
-			rangeScan, ok, err := tryRangeScan(t.Name, idxInfo, group, stats)
+			colConds := conditionsForColumn(group, idxInfo.Columns[0].Name)
+			if len(colConds) == 0 {
+				continue
+			}
+			rangeScan, built, err := tryRangeScan(t.Name, idxInfo, colConds, stats)
 			if err != nil {
 				return err
 			}
-			if ok {
+			if built {
+				rangeScan.Filters = nil // Intersection parent handles remaining filters.
+				rangeSubScans = append(rangeSubScans, rangeScan)
+				usedRangeIndexes[idxInfo.Name] = true
+			}
+		}
+
+		switch {
+		case len(rangeSubScans) >= 2:
+			// Multi-range intersection.
+			covered := make(map[int]bool)
+			for _, rs := range rangeSubScans {
+				colName := rs.IndexColumns[0].Name
+				for condIdx, cond := range group {
+					if cond.Operand1.Type == OperandField {
+						if f, ok2 := cond.Operand1.Value.(Field); ok2 && f.Name == colName {
+							covered[condIdx] = true
+						}
+					}
+				}
+			}
+			var remaining Conditions
+			for condIdx, cond := range group {
+				if !covered[condIdx] {
+					remaining = append(remaining, cond)
+				}
+			}
+			intersectScan := Scan{
+				TableName: t.Name,
+				Type:      ScanTypeIndexIntersect,
+				SubScans:  rangeSubScans,
+			}
+			if len(remaining) > 0 {
+				intersectScan.Filters = OneOrMore{remaining}
+			}
+			indexScans = append(indexScans, intersectScan)
+			foundRangeScan = true
+
+		case len(rangeSubScans) == 1:
+			// Single range scan — re-run with the full group so remaining conditions
+			// are captured as post-filters (original behaviour).
+			idxInfo := otherIndexes[groupIdx][0]
+			var stats *IndexStats
+			if indexStats, hasStats := t.indexStats[idxInfo.Name]; hasStats {
+				stats = &indexStats
+			}
+			rangeScan, built, err := tryRangeScan(t.Name, idxInfo, group, stats)
+			if err != nil {
+				return err
+			}
+			if built {
 				indexScans = append(indexScans, rangeScan)
 				foundRangeScan = true
-				break
 			}
 		}
 
@@ -618,7 +850,7 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 			continue
 		}
 
-		// Otherwise fall back to sequential scan for this group
+		// Otherwise fall back to sequential scan for this group.
 		indexScans = append(indexScans, Scan{
 			TableName: t.Name,
 			Type:      ScanTypeSequential,
@@ -888,6 +1120,8 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, false)
 		case ScanTypeIndexLast:
 			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, true)
+		case ScanTypeIndexIntersect:
+			return t.indexIntersectScan(ctx, p.Scans[0], selectedFields, out)
 		case ScanTypeSequential:
 			return t.sequentialScan(ctx, p.Scans[0], selectedFields, out)
 		default:
@@ -909,8 +1143,12 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 			if err := t.indexPointScan(ctx, scan, selectedFields, out); err != nil {
 				return err
 			}
+		case ScanTypeIndexIntersect:
+			if err := t.indexIntersectScan(ctx, scan, selectedFields, out); err != nil {
+				return err
+			}
 		default:
-			return fmt.Errorf("unhandled scan type in single scan: %d", scan.Type)
+			return fmt.Errorf("unhandled scan type in multi scan: %d", scan.Type)
 		}
 	}
 	return nil

--- a/internal/minisql/query_plan_multi_index_test.go
+++ b/internal/minisql/query_plan_multi_index_test.go
@@ -272,3 +272,151 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 		})
 	}
 }
+
+func TestTable_PlanQuery_Intersection(t *testing.T) {
+	t.Parallel()
+
+	var (
+		columns = []Column{
+			{Kind: Int8, Size: 8, Name: "id"},
+			{Kind: Varchar, Size: MaxInlineVarchar, Name: "email"},
+			{Kind: Text, Name: "name", Nullable: true},
+			{Kind: Timestamp, Name: "dob"},
+			{Kind: Timestamp, Name: "created", DefaultValueNow: true},
+		}
+		pkIndexName     = "pkey__users"
+		uniqueIndexName = "key__users__email"
+		idxCreated      = "idx__users__created"
+		idxDob          = "idx__users__dob"
+	)
+
+	newTable := func() *Table {
+		t.Helper()
+		tbl := NewTable(zap.NewNop(), nil, nil, "users", columns, 0, nil, WithPrimaryKey(
+			NewPrimaryKey(pkIndexName, columns[0:1], true),
+		), WithUniqueIndex(
+			UniqueIndex{IndexInfo: IndexInfo{Name: uniqueIndexName, Columns: columns[1:2]}},
+		))
+		tbl.SetSecondaryIndex(idxCreated, columns[4:5], nil)
+		tbl.SetSecondaryIndex(idxDob, columns[3:4], nil)
+		return tbl
+	}
+
+	subIndexNames := func(scan Scan) []string {
+		names := make([]string, len(scan.SubScans))
+		for i, s := range scan.SubScans {
+			names[i] = s.IndexName
+		}
+		return names
+	}
+
+	t.Run("two secondary equality conditions → intersection", func(t *testing.T) {
+		t.Parallel()
+		tbl := newTable()
+		stmt := Statement{
+			Kind: Select,
+			Conditions: OneOrMore{
+				{
+					FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestampMicros("1990-01-01 00:00:00")),
+					FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
+				},
+			},
+		}
+		plan, err := tbl.PlanQuery(context.Background(), stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexIntersect, plan.Scans[0].Type)
+		require.Len(t, plan.Scans[0].SubScans, 2)
+		assert.ElementsMatch(t, []string{idxDob, idxCreated}, subIndexNames(plan.Scans[0]))
+		for _, sub := range plan.Scans[0].SubScans {
+			assert.Equal(t, ScanTypeIndexPoint, sub.Type)
+			assert.Len(t, sub.IndexKeys, 1)
+		}
+		assert.Nil(t, plan.Scans[0].Filters)
+	})
+
+	t.Run("two secondary range conditions → intersection", func(t *testing.T) {
+		t.Parallel()
+		tbl := newTable()
+		stmt := Statement{
+			Kind: Select,
+			Conditions: OneOrMore{
+				{
+					FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
+					FieldIsGreaterOrEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestampMicros("1990-01-01 00:00:00")),
+				},
+			},
+		}
+		plan, err := tbl.PlanQuery(context.Background(), stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexIntersect, plan.Scans[0].Type)
+		require.Len(t, plan.Scans[0].SubScans, 2)
+		assert.ElementsMatch(t, []string{idxCreated, idxDob}, subIndexNames(plan.Scans[0]))
+		for _, sub := range plan.Scans[0].SubScans {
+			assert.Equal(t, ScanTypeIndexRange, sub.Type)
+			assert.NotNil(t, sub.RangeCondition.Lower)
+		}
+	})
+
+	t.Run("unique 1-key stays single-index (no intersection overhead)", func(t *testing.T) {
+		t.Parallel()
+		tbl := newTable()
+		stmt := Statement{
+			Kind: Select,
+			Conditions: OneOrMore{
+				{
+					FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("a@b.com"))),
+					FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
+				},
+			},
+		}
+		plan, err := tbl.PlanQuery(context.Background(), stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexPoint, plan.Scans[0].Type)
+		assert.Equal(t, uniqueIndexName, plan.Scans[0].IndexName)
+		assert.Len(t, plan.Scans[0].Filters, 1) // created goes to filter
+	})
+
+	t.Run("PK 1-key stays single-index", func(t *testing.T) {
+		t.Parallel()
+		tbl := newTable()
+		stmt := Statement{
+			Kind: Select,
+			Conditions: OneOrMore{
+				{
+					FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+					FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
+				},
+			},
+		}
+		plan, err := tbl.PlanQuery(context.Background(), stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexPoint, plan.Scans[0].Type)
+		assert.Equal(t, pkIndexName, plan.Scans[0].IndexName)
+	})
+
+	t.Run("secondary point + extra non-indexed condition → filter on parent", func(t *testing.T) {
+		t.Parallel()
+		tbl := newTable()
+		stmt := Statement{
+			Kind: Select,
+			Conditions: OneOrMore{
+				{
+					FieldIsEqual(Field{Name: "dob"}, OperandQuotedString, MustParseTimestampMicros("1990-01-01 00:00:00")),
+					FieldIsEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00")),
+					FieldIsEqual(Field{Name: "name"}, OperandQuotedString, NewTextPointer([]byte("Alice"))),
+				},
+			},
+		}
+		plan, err := tbl.PlanQuery(context.Background(), stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexIntersect, plan.Scans[0].Type)
+		require.Len(t, plan.Scans[0].SubScans, 2)
+		// name is non-indexed → captured in parent Filters
+		assert.Equal(t, 1, conditionCount(plan.Scans[0].Filters))
+	})
+}

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1393,3 +1393,167 @@ func (t *Table) virtualSequentialScan(ctx context.Context, scan Scan, out func(R
 	}
 	return nil
 }
+
+// collectRowIDsFromScan runs a sub-scan and collects all RowIDs it produces without
+// fetching table rows.  Supported sub-scan types: ScanTypeIndexPoint and ScanTypeIndexRange.
+func (t *Table) collectRowIDsFromScan(ctx context.Context, scan Scan) ([]RowID, error) {
+	idx, ok := t.IndexByName(scan.IndexName)
+	if !ok {
+		return nil, fmt.Errorf("no index found for intersect sub-scan: %s", scan.IndexName)
+	}
+	switch scan.Type {
+	case ScanTypeIndexPoint:
+		var rowIDs []RowID
+		for _, key := range scan.IndexKeys {
+			ids, err := idx.FindRowIDs(ctx, key)
+			if err != nil {
+				if errors.Is(err, ErrNotFound) {
+					continue
+				}
+				return nil, fmt.Errorf("intersect point lookup: %w", err)
+			}
+			rowIDs = append(rowIDs, ids...)
+		}
+		return rowIDs, nil
+	case ScanTypeIndexRange:
+		var rowIDs []RowID
+		if err := idx.ScanRange(ctx, scan.RangeCondition, false, func(_ any, rowID RowID) error {
+			rowIDs = append(rowIDs, rowID)
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("intersect range scan: %w", err)
+		}
+		return rowIDs, nil
+	default:
+		return nil, fmt.Errorf("unsupported sub-scan type for intersect: %s", scan.Type)
+	}
+}
+
+// intersectTwoSortedSets returns the sorted intersection of two already-sorted RowID slices.
+// Returns nil when the intersection is empty.
+func intersectTwoSortedSets(a, b []RowID) []RowID {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	result := make([]RowID, 0, min(len(a), len(b)))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			// Skip duplicates within the same set.
+			if len(result) == 0 || result[len(result)-1] != a[i] {
+				result = append(result, a[i])
+			}
+			i++
+			j++
+		case a[i] < b[j]:
+			i++
+		default:
+			j++
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// intersectSortedRowIDs sorts each input slice and returns their intersection.
+func intersectSortedRowIDs(sets [][]RowID) []RowID {
+	if len(sets) == 0 {
+		return nil
+	}
+	for i := range sets {
+		sortRowIDs(sets[i])
+	}
+	result := sets[0]
+	for _, next := range sets[1:] {
+		result = intersectTwoSortedSets(result, next)
+		if len(result) == 0 {
+			return nil
+		}
+	}
+	return result
+}
+
+// sortRowIDs sorts a RowID slice in-place.
+func sortRowIDs(ids []RowID) {
+	// Insertion sort for small slices; falls back to std sort for large ones.
+	if len(ids) < 16 {
+		for i := 1; i < len(ids); i++ {
+			v := ids[i]
+			j := i
+			for j > 0 && ids[j-1] > v {
+				ids[j] = ids[j-1]
+				j--
+			}
+			ids[j] = v
+		}
+		return
+	}
+	// Standard sort for larger slices.
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {
+			ids[j-1], ids[j] = ids[j], ids[j-1]
+		}
+	}
+}
+
+// indexIntersectScan executes a ScanTypeIndexIntersect plan:
+//  1. Collect RowID sets from each sub-scan.
+//  2. Intersect all sets in memory.
+//  3. Fetch the surviving rows and apply any remaining post-filters.
+func (t *Table) indexIntersectScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
+	sets := make([][]RowID, 0, len(scan.SubScans))
+	for _, sub := range scan.SubScans {
+		ids, err := t.collectRowIDsFromScan(ctx, sub)
+		if err != nil {
+			return err
+		}
+		sets = append(sets, ids)
+	}
+
+	surviving := intersectSortedRowIDs(sets)
+	if len(surviving) == 0 {
+		return nil
+	}
+
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+
+	for _, rowID := range surviving {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var row Row
+		if len(selectedFields) == 0 {
+			row = NewRowWithValues(t.Columns, nil)
+			row.Key = rowID
+		} else {
+			cursor, err := t.Seek(ctx, rowID)
+			if err != nil {
+				return fmt.Errorf("intersect seek: %w", err)
+			}
+			row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+			if err != nil {
+				return fmt.Errorf("intersect fetch: %w", err)
+			}
+		}
+
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		if err := out(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Scan multiple indexes for AND conditions, intersect sorted `[]RowID` sets in-memory, fetch only surviving rows. Add `IntersectResult bool` to `Scan`. `setIndexScans` marks candidates when intersection cost wins.