### PR TITLE
feat: predicate pushdown through joins

### DIFF
--- a/e2e_tests/predicate_pushdown_test.go
+++ b/e2e_tests/predicate_pushdown_test.go
@@ -1,0 +1,171 @@
+package e2etests
+
+// TestPredicatePushdownJoin verifies that single-table WHERE conditions pushed
+// into individual table scans within a JOIN use index scans when a matching
+// index exists, rather than always falling back to a sequential scan.
+func (s *TestSuite) TestPredicatePushdownJoin() {
+	// departments has a PK on dept_id (autoincrement) and a secondary index on name.
+	_, err := s.db.Exec(`create table "pd_departments" (
+		dept_id  int8 primary key autoincrement,
+		name     varchar(50) not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create index "idx_pd_dept_name" on "pd_departments" (name)`)
+	s.Require().NoError(err)
+
+	// pd_employees.dept_id has NO index — join on it forces hash join.
+	// pd_employees.salary HAS an index — pushed-down WHERE on salary uses it.
+	_, err = s.db.Exec(`create table "pd_employees" (
+		emp_id   int8 primary key autoincrement,
+		dept_id  int8 not null,
+		name     varchar(50) not null,
+		salary   int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create index "idx_pd_emp_salary" on "pd_employees" (salary)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "pd_departments" (name) values
+		('Engineering'),
+		('Marketing'),
+		('HR')`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "pd_employees" (dept_id, name, salary) values
+		(1, 'Alice',   90000),
+		(1, 'Bob',     85000),
+		(2, 'Carol',   70000),
+		(3, 'Dave',    60000),
+		(1, 'Eve',     95000)`)
+	s.Require().NoError(err)
+
+	s.Run("base_table_index_pushdown_point", func() {
+		// d.dept_id = 1 is an equality on the PK of pd_departments.
+		// The planner should use an index_point scan on the base table, not sequential.
+		rows := s.collectExplain(`
+			EXPLAIN SELECT e.name
+			FROM "pd_departments" AS d
+			INNER JOIN "pd_employees" AS e ON d.dept_id = e.dept_id
+			WHERE d.dept_id = 1`)
+		var baseScanRow *explainResult
+		for i := range rows {
+			if rows[i].Operation == "index_point" || rows[i].Operation == "index_range" {
+				baseScanRow = &rows[i]
+				break
+			}
+		}
+		s.Require().NotNil(baseScanRow, "expected an index scan for pushed-down PK condition on base table")
+	})
+
+	s.Run("base_table_index_pushdown_by_name", func() {
+		// d.name = 'Engineering' matches idx_pd_dept_name on the base table.
+		rows := s.collectExplain(`
+			EXPLAIN SELECT e.name
+			FROM "pd_departments" AS d
+			INNER JOIN "pd_employees" AS e ON d.dept_id = e.dept_id
+			WHERE d.name = 'Engineering'`)
+		var baseScanRow *explainResult
+		for i := range rows {
+			if rows[i].Operation == "index_point" {
+				baseScanRow = &rows[i]
+				break
+			}
+		}
+		s.Require().NotNil(baseScanRow, "expected an index_point scan for d.name pushed-down to base table")
+	})
+
+	s.Run("inner_table_index_pushdown_salary_range", func() {
+		// e.salary > 80000 matches idx_pd_emp_salary on the hash-join build side.
+		// The build scan should use an index_range scan instead of sequential.
+		rows := s.collectExplain(`
+			EXPLAIN SELECT e.name
+			FROM "pd_departments" AS d
+			INNER JOIN "pd_employees" AS e ON d.dept_id = e.dept_id
+			WHERE e.salary > 80000`)
+		var innerScanRow *explainResult
+		for i := range rows {
+			if rows[i].Operation == "index_range" {
+				innerScanRow = &rows[i]
+				break
+			}
+		}
+		s.Require().NotNil(innerScanRow, "expected an index_range scan for e.salary pushed-down to inner table")
+	})
+
+	s.Run("pushed_down_base_condition_correct_results", func() {
+		// Even with index pushdown, results must be identical to the unoptimized path.
+		rows, err := s.db.Query(`
+			select e.name
+			from   "pd_departments" as d
+			inner join "pd_employees" as e on d.dept_id = e.dept_id
+			where  d.dept_id = 1
+			order by e.name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var got []string
+		for rows.Next() {
+			var name string
+			s.Require().NoError(rows.Scan(&name))
+			got = append(got, name)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Equal([]string{"Alice", "Bob", "Eve"}, got)
+	})
+
+	s.Run("pushed_down_inner_condition_correct_results", func() {
+		// e.salary > 80000 pushed down to the hash-join build side — only
+		// high-earners should be joined.
+		rows, err := s.db.Query(`
+			select e.name, e.salary
+			from   "pd_departments" as d
+			inner join "pd_employees" as e on d.dept_id = e.dept_id
+			where  e.salary > 80000
+			order by e.name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type result struct {
+			name   string
+			salary int64
+		}
+		var got []result
+		for rows.Next() {
+			var r result
+			s.Require().NoError(rows.Scan(&r.name, &r.salary))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 3)
+		s.Equal("Alice", got[0].name)
+		s.Equal(int64(90000), got[0].salary)
+		s.Equal("Bob", got[1].name)
+		s.Equal(int64(85000), got[1].salary)
+		s.Equal("Eve", got[2].name)
+		s.Equal(int64(95000), got[2].salary)
+	})
+
+	s.Run("both_tables_index_pushdown_correct_results", func() {
+		// Both base and inner table conditions pushed down with index acceleration.
+		rows, err := s.db.Query(`
+			select e.name
+			from   "pd_departments" as d
+			inner join "pd_employees" as e on d.dept_id = e.dept_id
+			where  d.name = 'Engineering'
+			and    e.salary >= 90000
+			order by e.name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var got []string
+		for rows.Next() {
+			var name string
+			s.Require().NoError(rows.Scan(&name))
+			got = append(got, name)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Equal([]string{"Alice", "Eve"}, got)
+	})
+}

--- a/internal/minisql/hash_join.go
+++ b/internal/minisql/hash_join.go
@@ -35,7 +35,7 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 			innerColumns: innerTable.Columns,
 		}
 		innerFields := fieldsFromColumns(innerTable.Columns...)
-		if err := innerTable.sequentialScan(ctx, innerScan, innerFields, func(row Row) error {
+		if err := runTableScan(ctx, plan, innerTable, innerScan, innerFields, func(row Row) error {
 			key := buildSideHashKey(join, row)
 			if key == "" {
 				return nil // NULL join key — never matches

--- a/internal/minisql/predicate_pushdown_test.go
+++ b/internal/minisql/predicate_pushdown_test.go
@@ -1,0 +1,103 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanJoinTableScan_NoConditions(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns[0:2],
+		WithPrimaryKey(NewPrimaryKey(PrimaryKeyName(testTableName), testColumns[0:1], true)),
+	)
+
+	scan := planJoinTableScan(table, testTableName, "t", nil)
+	assert.Equal(t, ScanTypeSequential, scan.Type)
+	assert.Empty(t, scan.Filters)
+}
+
+func TestPlanJoinTableScan_NoIndex(t *testing.T) {
+	// Table with no indexes — planJoinTableScan must fall back to sequential.
+	table, _, _ := newTestTable(t, testColumns[0:2])
+
+	conds := OneOrMore{{
+		FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+	}}
+	scan := planJoinTableScan(table, testTableName, "t", conds)
+	assert.Equal(t, ScanTypeSequential, scan.Type)
+	assert.Equal(t, conds, scan.Filters)
+}
+
+func TestPlanJoinTableScan_PKEqualityUsesIndexPoint(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns[0:2],
+		WithPrimaryKey(NewPrimaryKey(PrimaryKeyName(testTableName), testColumns[0:1], true)),
+	)
+
+	conds := OneOrMore{{
+		FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(7)),
+	}}
+	scan := planJoinTableScan(table, testTableName, "t", conds)
+	assert.Equal(t, ScanTypeIndexPoint, scan.Type)
+	assert.Equal(t, "t", scan.TableAlias)
+	assert.Equal(t, testTableName, scan.TableName)
+	assert.Equal(t, []any{int64(7)}, scan.IndexKeys)
+}
+
+func TestPlanJoinTableScan_AliasedConditionUsesIndex(t *testing.T) {
+	// Conditions with AliasPrefix are common in JOIN WHERE clauses (e.g. "t.id = 7").
+	// planJoinTableScan must match them against column names, ignoring the prefix.
+	table, _, _ := newTestTable(t, testColumns[0:2],
+		WithPrimaryKey(NewPrimaryKey(PrimaryKeyName(testTableName), testColumns[0:1], true)),
+	)
+
+	conds := OneOrMore{{
+		FieldIsEqual(Field{Name: "id", AliasPrefix: "t"}, OperandInteger, int64(7)),
+	}}
+	scan := planJoinTableScan(table, testTableName, "t", conds)
+	assert.Equal(t, ScanTypeIndexPoint, scan.Type, "aliased equality condition should use PK index")
+}
+
+func TestPlanJoinTableScan_MultipleORGroupsFallsBackToSequential(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns[0:2],
+		WithPrimaryKey(NewPrimaryKey(PrimaryKeyName(testTableName), testColumns[0:1], true)),
+	)
+
+	// Two OR groups each with an index match produce two scans — fall back to
+	// sequential to avoid multi-scan union complexity in the JOIN execution path.
+	conds := OneOrMore{
+		{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(1))},
+		{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(2))},
+	}
+	scan := planJoinTableScan(table, testTableName, "t", conds)
+	assert.Equal(t, ScanTypeSequential, scan.Type)
+	assert.Equal(t, conds, scan.Filters)
+}
+
+func TestRunTableScan_SequentialDispatch(t *testing.T) {
+	// Verify runTableScan dispatches sequential scans correctly and returns rows.
+	ctx := context.Background()
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+
+	mustInsert(ctx, t, table, txManager, Statement{
+		Kind:    Insert,
+		Columns: table.Columns,
+		Fields:  fieldsFromColumns(table.Columns...),
+		Inserts: [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("a@example.com"))}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("b@example.com"))}},
+		},
+	})
+
+	scan := Scan{TableName: testTableName, TableAlias: "t", Type: ScanTypeSequential}
+	var got []Row
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		return runTableScan(ctx, QueryPlan{}, table, scan, fieldsFromColumns(table.Columns...), func(row Row) error {
+			got = append(got, row)
+			return nil
+		})
+	})
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+}

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -24,16 +24,12 @@ func chanRowCallback(ctx context.Context, ch chan<- Row) func(Row) error {
 // Optimizations:
 // 1. Use index on inner table join column when available (index nested loop join).
 // 2. Push single-table WHERE conditions into individual table scans.
+// 3. Use index scans for pushed-down conditions when a matching index exists.
 func (t *Table) planJoinQuery(ctx context.Context, stmt Statement) (QueryPlan, error) {
 	baseTableFilters, joinTableFilters := pushDownFilters(stmt.Conditions, stmt.TableAlias, stmt.Joins)
 
 	plan := QueryPlan{
-		Scans: []Scan{{
-			TableName:  t.Name,
-			TableAlias: stmt.TableAlias,
-			Type:       ScanTypeSequential,
-			Filters:    baseTableFilters,
-		}},
+		Scans:        []Scan{planJoinTableScan(t, t.Name, stmt.TableAlias, baseTableFilters)},
 		Joins:        make([]JoinPlan, 0),
 		OrderBy:      stmt.OrderBy,
 		SortInMemory: len(stmt.OrderBy) > 0,
@@ -131,15 +127,25 @@ func (t *Table) flattenJoinTree(
 			}
 		}
 
-		joinScan := Scan{
-			TableName:  join.TableName,
-			TableAlias: join.TableAlias,
-			Type:       innerScanType,
-			Filters:    joinTableFilters[join.TableAlias],
-		}
-		if innerScanType == ScanTypeIndexPoint && innerIndexInfo != nil {
-			joinScan.IndexName = innerIndexInfo.Name
-			joinScan.IndexColumns = innerIndexInfo.Columns
+		var joinScan Scan
+		if innerScanType == ScanTypeSequential {
+			// No index on the join column: try to accelerate the scan using an index
+			// on any pushed-down WHERE condition (e.g. salary > 80000 on the build
+			// side of a hash join).
+			joinScan = planJoinTableScan(joinedTable, join.TableName, join.TableAlias, joinTableFilters[join.TableAlias])
+		} else {
+			// Index nested-loop join: the join key drives the index point scan;
+			// pushed-down filters are applied as post-lookup row filters.
+			joinScan = Scan{
+				TableName:  join.TableName,
+				TableAlias: join.TableAlias,
+				Type:       innerScanType,
+				Filters:    joinTableFilters[join.TableAlias],
+			}
+			if innerScanType == ScanTypeIndexPoint && innerIndexInfo != nil {
+				joinScan.IndexName = innerIndexInfo.Name
+				joinScan.IndexColumns = innerIndexInfo.Columns
+			}
 		}
 
 		plan.Scans = append(plan.Scans, joinScan)
@@ -284,6 +290,52 @@ func collectJoinAliases(joins []Join, dst map[string]struct{}) {
 	}
 }
 
+// planJoinTableScan returns an optimized Scan for a table participating in a JOIN.
+// It tries index selection on the pushed-down conditions. When index selection
+// produces exactly one scan (the common case: single AND group in WHERE), that
+// index scan is returned. Otherwise the conditions are kept as sequential-scan
+// post-filters to avoid the complexity of unioning multiple OR-group index scans
+// inside the JOIN execution path.
+func planJoinTableScan(t *Table, tableName, tableAlias string, conditions OneOrMore) Scan {
+	defaultScan := Scan{
+		TableName:  tableName,
+		TableAlias: tableAlias,
+		Type:       ScanTypeSequential,
+		Filters:    conditions,
+	}
+	if len(conditions) == 0 || t.HasNoIndex() {
+		return defaultScan
+	}
+	tempPlan := &QueryPlan{Scans: []Scan{defaultScan}}
+	if err := tempPlan.setIndexScans(t, conditions); err != nil {
+		return defaultScan
+	}
+	if len(tempPlan.Scans) != 1 {
+		// Multiple OR groups each with an index — keep sequential for simplicity.
+		return defaultScan
+	}
+	scan := tempPlan.Scans[0]
+	scan.TableAlias = tableAlias
+	return scan
+}
+
+// runTableScan dispatches a single-table scan to the appropriate method based on
+// the scan type. Used in the JOIN execution path where the scan type may have been
+// optimized to an index scan by planJoinTableScan.
+// plan is forwarded to index range scans (which need the sort-direction hint).
+func runTableScan(ctx context.Context, plan QueryPlan, t *Table, scan Scan, fields []Field, out func(Row) error) error {
+	switch scan.Type {
+	case ScanTypeIndexPoint:
+		return t.indexPointScan(ctx, scan, fields, out)
+	case ScanTypeIndexRange:
+		return t.indexRangeScan(ctx, plan, scan, fields, out)
+	case ScanTypeIndexIntersect:
+		return t.indexIntersectScan(ctx, scan, fields, out)
+	default:
+		return t.sequentialScan(ctx, scan, fields, out)
+	}
+}
+
 // pushDownFilters separates WHERE conditions by table alias, pushing filters to
 // the appropriate per-table scan. Handles arbitrary join topologies by collecting
 // all join aliases recursively before distributing conditions.
@@ -387,7 +439,7 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 
 	go func() {
 		defer close(baseRowChan)
-		if err := baseTable.sequentialScan(ctx, baseScan, baseFields, chanRowCallback(ctx, baseRowChan)); err != nil {
+		if err := runTableScan(ctx, p, baseTable, baseScan, baseFields, chanRowCallback(ctx, baseRowChan)); err != nil {
 			baseErrChan <- err
 		}
 	}()


### PR DESCRIPTION
  **Predicate Pushdown Through Joins**                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                       
  The condition splitting via pushDownFilters was already in place — it correctly routes single-table WHERE conditions to each table's Scan.Filters. What was missing was index acceleration for those pushed-down conditions. Everything was always falling back to sequential scan + 
  row-by-row filter evaluation.                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                       
  **Changes**                                                   

  internal/minisql/query_plan_join.go

  - planJoinTableScan(t, tableName, alias, conditions) — new helper that calls setIndexScans on a temporary plan. If index selection produces exactly one scan (the common case: single AND group in WHERE), returns that index scan. Falls back to sequential otherwise (avoids       
  multi-scan union complexity in the JOIN execution path).
  - runTableScan(ctx, plan, t, scan, fields, out) — new dispatcher that routes to indexPointScan, indexRangeScan, indexIntersectScan, or sequentialScan based on scan.Type. Used in the JOIN execution path where the scan type may now be an index scan.                              
  - planJoinQuery updated to use planJoinTableScan for the base table instead of hardcoding ScanTypeSequential.                                                                                                                                                                        
  - flattenJoinTree updated to use planJoinTableScan for sequential inner table scans (hash join build side). Indexed nested-loop joins keep their existing index point scan for the join column.                                                                                      
  - executeNestedLoopJoin updated to use runTableScan for the base table instead of always calling sequentialScan.                                                                                                                                                                     
                                                                                                                                                                                                                                                                                       
  internal/minisql/hash_join.go                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                       
  - buildHashBuckets updated to use runTableScan instead of always calling sequentialScan, so hash join build phases also benefit from index-accelerated WHERE condition filters.                                                                                                      
  
  **Tests**                                                                                                                                                                                                                                                                                
                                                            
  - 6 unit tests in internal/minisql/predicate_pushdown_test.go covering the planning logic                                                                                                                                                                                            
  - 5 e2e tests in e2e_tests/predicate_pushdown_test.go verifying EXPLAIN shows index scans for pushed-down conditions and that query results remain correct