### PR TITLE
feat: equi-depth histograms for ANALYZE statistics

### DIFF
--- a/internal/minisql/analyze.go
+++ b/internal/minisql/analyze.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -187,11 +188,11 @@ func (d *Database) analyzeTable(ctx context.Context, statsTable, table *Table) e
 }
 
 func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableName, indexName string, index BTreeIndex, isUnique bool) error {
-	// Get the index columns to determine if this is a composite index
-	var indexColumns []Column
-	table := d.tables[tableName]
+	var (
+		indexColumns []Column
+		table        = d.tables[tableName]
+	)
 
-	// Find the columns for this index
 	if table.PrimaryKey.Name == indexName {
 		indexColumns = table.PrimaryKey.Columns
 	} else {
@@ -211,35 +212,42 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		}
 	}
 
-	numColumns := len(indexColumns)
-	entryCount := int64(0)
+	var (
+		numColumns = len(indexColumns)
+		entryCount = int64(0)
+	)
 
-	// Track distinct values for each prefix level
-	// prefixMaps[0] = distinct values for first column only
-	// prefixMaps[1] = distinct values for first 2 columns combined
-	// etc.
+	// Track distinct values for each prefix level.
 	prefixMaps := make([]map[string]struct{}, numColumns)
 	for i := range numColumns {
 		prefixMaps[i] = make(map[string]struct{})
 	}
 
-	// The index is a generic type, need to handle different key types
-	// For simplicity, use ScanAll which works for all index types
+	// Collect first-column numeric values for histogram building.
+	collectHist := len(indexColumns) > 0 && isNumericColumn(indexColumns[0])
+	var histValues []float64
+
 	if scanErr := index.ScanAll(ctx, false, func(key any, rowID RowID) error {
 		entryCount += 1
 
-		// Handle composite keys by tracking each prefix
 		if ck, isComposite := key.(CompositeKey); isComposite && numColumns > 1 {
-			// For each prefix level (1 column, 2 columns, ..., all columns)
 			for prefixLen := 1; prefixLen <= numColumns; prefixLen++ {
-				// Build a key string for this prefix
 				prefixKey := buildPrefixKey(ck.Values[:prefixLen])
 				prefixMaps[prefixLen-1][prefixKey] = struct{}{}
 			}
+			if collectHist && len(ck.Values) > 0 {
+				if f, ok := anyToFloat64(ck.Values[0]); ok {
+					histValues = append(histValues, f)
+				}
+			}
 		} else {
-			// Single column index - just track the full key
 			keyStr := fmt.Sprintf("%v", key)
 			prefixMaps[0][keyStr] = struct{}{}
+			if collectHist {
+				if f, ok := anyToFloat64(key); ok {
+					histValues = append(histValues, f)
+				}
+			}
 		}
 
 		return nil
@@ -247,31 +255,22 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		return scanErr
 	}
 
-	// Build stat string in SQLite format: "nEntry nDistinct1 nDistinct2 ..."
-	// For single-column index: "100 50" means 100 entries, 50 distinct values
-	// For composite (col1, col2): "100 50 80" means 100 entries, 50 distinct col1 values, 80 distinct (col1,col2) pairs
 	stat := strings.Builder{}
 	fmt.Fprintf(&stat, "%d", entryCount)
 
 	for i := range numColumns {
 		distinctCount := int64(len(prefixMaps[i]))
-
-		// For unique indexes, only the final prefix (all columns) should have distinctCount == entryCount
-		// Intermediate prefixes can have fewer distinct values
 		if isUnique && i == numColumns-1 {
 			distinctCount = entryCount
 		}
-
 		fmt.Fprintf(&stat, " %d", distinctCount)
 	}
 
-	// Store stat in SQLite format
-	// Single-column example: "100 50" means 100 entries, 50 distinct values (avg 2 entries per value)
-	// Composite example: "100 10 50 100" for (col1, col2, col3) means:
-	//   - 100 total entries
-	//   - 10 distinct col1 values (avg 10 entries per col1 value)
-	//   - 50 distinct (col1, col2) combinations (avg 2 entries per combination)
-	//   - 100 distinct (col1, col2, col3) combinations (all unique)
+	if len(histValues) > 0 {
+		sort.Float64s(histValues)
+		hist := buildEquiDepthHistogram(histValues, histogramBuckets)
+		serializeHistogram(&stat, hist)
+	}
 
 	_, err := statsTable.Insert(ctx, Statement{
 		Kind:      Insert,
@@ -279,9 +278,9 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		Fields:    statsTableFields,
 		Inserts: [][]OptionalValue{
 			{
-				{Value: NewTextPointer([]byte(tableName)), Valid: true},     // tbl
-				{Value: NewTextPointer([]byte(indexName)), Valid: true},     // idx
-				{Value: NewTextPointer([]byte(stat.String())), Valid: true}, // stat
+				{Value: NewTextPointer([]byte(tableName)), Valid: true},
+				{Value: NewTextPointer([]byte(indexName)), Valid: true},
+				{Value: NewTextPointer([]byte(stat.String())), Valid: true},
 			},
 		},
 	})

--- a/internal/minisql/analyze_test.go
+++ b/internal/minisql/analyze_test.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,25 +94,39 @@ func TestDatabase_Analyze(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, stats, 4)
-	assert.Equal(t, Stats{
-		TableName: testTableName,
-		StatValue: "100",
-	}, stats[0])
-	assert.Equal(t, Stats{
-		TableName: testTableName,
-		IndexName: "pkey__test_table",
-		StatValue: "100 100",
-	}, stats[1])
+
+	// Table-level stat has no index name and just the row count.
+	assert.Equal(t, Stats{TableName: testTableName, StatValue: "100"}, stats[0])
+
+	// PK on id (Int8) — numeric, so a histogram suffix is appended.
+	assert.Equal(t, testTableName, stats[1].TableName)
+	assert.Equal(t, "pkey__test_table", stats[1].IndexName)
+	assert.True(t, strings.HasPrefix(stats[1].StatValue, "100 100"), "pk stat should start with '100 100'")
+	pkStats, err := parseIndexStats(stats[1].StatValue)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), pkStats.NEntry)
+	assert.Equal(t, []int64{100}, pkStats.NDistinct)
+	assert.NotNil(t, pkStats.Hist, "PK on Int8 column should have a histogram")
+	assert.Equal(t, histogramBuckets+1, len(pkStats.Hist.Bounds))
+
+	// Unique index on email (Varchar) — no histogram for text columns.
 	assert.Equal(t, Stats{
 		TableName: testTableName,
 		IndexName: "key__test_table__email",
 		StatValue: "100 100",
 	}, stats[2])
-	assert.Equal(t, Stats{
-		TableName: testTableName,
-		IndexName: "idx_created",
-		StatValue: "100 10",
-	}, stats[3])
+
+	// Secondary index on created (Timestamp) — numeric, so a histogram suffix is appended.
+	assert.Equal(t, testTableName, stats[3].TableName)
+	assert.Equal(t, "idx_created", stats[3].IndexName)
+	assert.True(t, strings.HasPrefix(stats[3].StatValue, "100 10"), "created stat should start with '100 10'")
+	createdStats, err := parseIndexStats(stats[3].StatValue)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), createdStats.NEntry)
+	assert.Equal(t, []int64{10}, createdStats.NDistinct)
+	assert.NotNil(t, createdStats.Hist, "Timestamp index should have a histogram")
+	// 10 distinct timestamps — histogram has at most 10 distinct boundaries.
+	assert.GreaterOrEqual(t, len(createdStats.Hist.Bounds), 2)
 
 	mock.AssertExpectationsForObjects(t, mockParser)
 }

--- a/internal/minisql/query_plan_stats.go
+++ b/internal/minisql/query_plan_stats.go
@@ -2,21 +2,195 @@ package minisql
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 )
+
+const (
+	// histogramBuckets is the number of equi-depth histogram buckets built
+	// during ANALYZE for numeric index columns.
+	histogramBuckets = 32
+
+	// Cost thresholds for index vs table scan decision
+	indexScanThreshold = 0.3 // If index scan returns >30% of rows, table scan may be faster
+
+	// Cost threshold for ORDER BY optimization
+	// If filtered result set is larger than this, prefer ORDER BY index to avoid sorting
+	sortCostThreshold = 1000
+)
+
+// Histogram is an equi-depth histogram for a numeric index column.
+// Bounds contains numBuckets+1 boundary values: Bounds[0] is the minimum
+// observed value, Bounds[N] is the maximum. Each of the N buckets between
+// consecutive boundaries holds approximately the same number of entries.
+type Histogram struct {
+	Bounds []float64
+}
 
 // IndexStats holds parsed statistics for an index
 type IndexStats struct {
 	NDistinct []int64
 	NEntry    int64
+	Hist      *Histogram // nil when not collected or column type is non-numeric
 }
 
-// parseIndexStats parses a stat string in SQLite format: "nEntry nDistinct1 nDistinct2 ..."
-// Example: "100 50" means 100 entries, 50 distinct values
-// Example: "100 10 50" means 100 entries, 10 distinct col1, 50 distinct (col1,col2)
+// isNumericColumn reports whether c supports histogram collection.
+func isNumericColumn(c Column) bool {
+	switch c.Kind {
+	case Int4, Int8, Real, Double, Timestamp:
+		return true
+	default:
+		return false
+	}
+}
+
+// anyToFloat64 converts a numeric index key value to float64 for histogram use.
+func anyToFloat64(v any) (float64, bool) {
+	switch x := v.(type) {
+	case int32:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case float32:
+		return float64(x), true
+	case float64:
+		return x, true
+	default:
+		return 0, false
+	}
+}
+
+// buildEquiDepthHistogram constructs an equi-depth histogram from a sorted
+// slice of float64 values. The returned Histogram has numBuckets+1 boundary
+// values. Returns nil if sorted is empty or numBuckets <= 0.
+func buildEquiDepthHistogram(sorted []float64, numBuckets int) *Histogram {
+	n := len(sorted)
+	if n == 0 || numBuckets <= 0 {
+		return nil
+	}
+	if numBuckets > n {
+		numBuckets = n
+	}
+	bounds := make([]float64, numBuckets+1)
+	bounds[0] = sorted[0]
+	bounds[numBuckets] = sorted[n-1]
+	for i := 1; i < numBuckets; i++ {
+		idx := i * n / numBuckets
+		bounds[i] = sorted[idx]
+	}
+	return &Histogram{Bounds: bounds}
+}
+
+// histogramCDF returns the estimated fraction of entries with value <= v,
+// using linear interpolation within each bucket.
+func histogramCDF(bounds []float64, v float64) float64 {
+	n := len(bounds) - 1
+	if n <= 0 {
+		return 0.5
+	}
+	if v <= bounds[0] {
+		return 0
+	}
+	if v >= bounds[n] {
+		return 1.0
+	}
+	// Binary search for the largest i such that bounds[i] <= v.
+	lo, hi := 0, n-1
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if bounds[mid] <= v {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	// v is in bucket lo: [bounds[lo], bounds[lo+1]).
+	bucketStart := float64(lo) / float64(n)
+	if bounds[lo+1] == bounds[lo] {
+		return bucketStart + 1.0/float64(n)
+	}
+	withinBucket := (v - bounds[lo]) / (bounds[lo+1] - bounds[lo])
+	return bucketStart + withinBucket/float64(n)
+}
+
+// estimateSelectivityWithHistogram estimates the fraction of entries satisfying
+// rc. Uses histogram CDF when available; falls back to fixed constants otherwise.
+func estimateSelectivityWithHistogram(hist *Histogram, rc RangeCondition) float64 {
+	if hist == nil || len(hist.Bounds) < 2 {
+		return estimateRangeSelectivity(rc)
+	}
+
+	lower := 0.0
+	if rc.Lower != nil {
+		if f, ok := anyToFloat64(rc.Lower.Value); ok {
+			lower = histogramCDF(hist.Bounds, f)
+		}
+	}
+
+	upper := 1.0
+	if rc.Upper != nil {
+		if f, ok := anyToFloat64(rc.Upper.Value); ok {
+			upper = histogramCDF(hist.Bounds, f)
+		}
+	}
+
+	sel := upper - lower
+	if sel < 0 {
+		return 0
+	}
+	if sel > 1 {
+		return 1
+	}
+	return sel
+}
+
+// serializeHistogram appends the histogram to a stat string builder.
+func serializeHistogram(b *strings.Builder, h *Histogram) {
+	if h == nil || len(h.Bounds) == 0 {
+		return
+	}
+	b.WriteString("|h=")
+	for i, v := range h.Bounds {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(strconv.FormatFloat(v, 'g', -1, 64))
+	}
+}
+
+// parseHistogram parses a histogram from the "|h=b0,b1,...,bN" suffix.
+func parseHistogram(s string) (*Histogram, error) {
+	parts := strings.Split(s, ",")
+	bounds := make([]float64, 0, len(parts))
+	for _, p := range parts {
+		f, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid histogram bound %q: %w", p, err)
+		}
+		bounds = append(bounds, f)
+	}
+	if len(bounds) < 2 {
+		return nil, nil
+	}
+	sort.Float64s(bounds)
+	return &Histogram{Bounds: bounds}, nil
+}
+
+// parseIndexStats parses a stat string: "nEntry nDistinct1 [nDistinct2 ...][|h=b0,b1,...]"
 func parseIndexStats(statString string) (IndexStats, error) {
-	parts := strings.Fields(statString)
+	mainPart := statString
+	var hist *Histogram
+	if before, histStr, ok := strings.Cut(statString, "|h="); ok {
+		mainPart = before
+		var err error
+		hist, err = parseHistogram(histStr)
+		if err != nil {
+			return IndexStats{}, err
+		}
+	}
+
+	parts := strings.Fields(mainPart)
 	if len(parts) < 2 {
 		return IndexStats{}, fmt.Errorf("invalid stat format: %s", statString)
 	}
@@ -38,6 +212,7 @@ func parseIndexStats(statString string) (IndexStats, error) {
 	return IndexStats{
 		NEntry:    nEntry,
 		NDistinct: nDistinct,
+		Hist:      hist,
 	}, nil
 }
 
@@ -58,18 +233,13 @@ func (s IndexStats) Selectivity() float64 {
 
 // EstimateRangeRows estimates the number of rows that will match a range condition.
 // Returns the estimated row count, or -1 if estimation isn't possible.
-// Uses uniform distribution assumption for simplicity.
+// Uses histogram data when available, otherwise assumes uniform distribution.
 func (s IndexStats) EstimateRangeRows(rangeCondition RangeCondition, columnIndex int) int64 {
 	if s.NEntry == 0 || len(s.NDistinct) == 0 {
 		return -1 // Can't estimate
 	}
 
-	// For simplicity, assume uniform distribution
-	// This could be enhanced with histogram data in the future
-
-	// Calculate selectivity based on bounds
-	selectivity := estimateRangeSelectivity(rangeCondition)
-
+	selectivity := estimateSelectivityWithHistogram(s.Hist, rangeCondition)
 	return int64(float64(s.NEntry) * selectivity)
 }
 
@@ -116,25 +286,9 @@ func estimateFilteredRows(stats *IndexStats, rangeCondition *RangeCondition) int
 	return -1
 }
 
-const (
-	// Cost thresholds for index vs table scan decision
-	indexScanThreshold = 0.3 // If index scan returns >30% of rows, table scan may be faster
-
-	// Cost threshold for ORDER BY optimization
-	// If filtered result set is larger than this, prefer ORDER BY index to avoid sorting
-	sortCostThreshold = 1000
-)
-
-// estimateRangeSelectivity estimates the selectivity of a range condition.
-// Uses conservative estimates based on whether bounds are present.
-// This assumes uniform distribution and can be enhanced with histogram data.
+// estimateRangeSelectivity estimates the selectivity of a range condition
+// using conservative fixed constants (fallback when no histogram is available).
 func estimateRangeSelectivity(rangeCondition RangeCondition) float64 {
-	// Default estimates based on presence of bounds:
-	// Both bounds: assume 30% selectivity (fairly selective)
-	// One bound: assume 50% selectivity (half the data)
-	// No bounds: 100% (full scan)
-	// This is conservative and can be refined with actual min/max tracking
-
 	if rangeCondition.Lower != nil && rangeCondition.Upper != nil {
 		return 0.3 // Both bounds - estimated 30% of rows
 	}

--- a/internal/minisql/query_plan_stats_test.go
+++ b/internal/minisql/query_plan_stats_test.go
@@ -1,6 +1,8 @@
 package minisql
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,4 +342,243 @@ func TestShouldUseIndexForRange(t *testing.T) {
 			assert.Equal(t, tt.want, got, "shouldUseIndexForRange() = %v, want %v", got, tt.want)
 		})
 	}
+}
+
+func TestBuildEquiDepthHistogram(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uniform_distribution", func(t *testing.T) {
+		t.Parallel()
+		sorted := make([]float64, 100)
+		for i := range sorted {
+			sorted[i] = float64(i + 1)
+		}
+		h := buildEquiDepthHistogram(sorted, 10)
+		require.NotNil(t, h)
+		assert.Len(t, h.Bounds, 11) // numBuckets+1
+		assert.Equal(t, float64(1), h.Bounds[0])
+		assert.Equal(t, float64(100), h.Bounds[10])
+	})
+
+	t.Run("fewer_values_than_buckets", func(t *testing.T) {
+		t.Parallel()
+		sorted := []float64{1, 2, 3}
+		h := buildEquiDepthHistogram(sorted, 10)
+		require.NotNil(t, h)
+		// Capped at n=3 buckets → 4 bounds
+		assert.Len(t, h.Bounds, 4)
+	})
+
+	t.Run("empty_slice_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, buildEquiDepthHistogram(nil, 10))
+		assert.Nil(t, buildEquiDepthHistogram([]float64{}, 10))
+	})
+
+	t.Run("zero_buckets_returns_nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, buildEquiDepthHistogram([]float64{1, 2, 3}, 0))
+	})
+}
+
+func TestHistogramCDF(t *testing.T) {
+	t.Parallel()
+	// 4 buckets: [0,25), [25,50), [50,75), [75,100] → bounds = [0,25,50,75,100]
+	bounds := []float64{0, 25, 50, 75, 100}
+
+	t.Run("below_min_returns_0", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0.0, histogramCDF(bounds, -1))
+	})
+
+	t.Run("at_min_returns_0", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0.0, histogramCDF(bounds, 0))
+	})
+
+	t.Run("at_max_returns_1", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 1.0, histogramCDF(bounds, 100))
+	})
+
+	t.Run("midpoint_of_first_bucket", func(t *testing.T) {
+		t.Parallel()
+		// v=12.5 is midpoint of [0,25) → bucket 0, within=0.5 → 0 + 0.5/4 = 0.125
+		got := histogramCDF(bounds, 12.5)
+		assert.InDelta(t, 0.125, got, 0.001)
+	})
+
+	t.Run("midpoint_of_second_bucket", func(t *testing.T) {
+		t.Parallel()
+		// v=37.5 is midpoint of [25,50) → bucket 1, within=0.5 → 1/4 + 0.5/4 = 0.375
+		got := histogramCDF(bounds, 37.5)
+		assert.InDelta(t, 0.375, got, 0.001)
+	})
+
+	t.Run("at_bucket_boundary", func(t *testing.T) {
+		t.Parallel()
+		// v=50 is at start of bucket 2: [50,75) → bucket 2, within=0 → 2/4 = 0.5
+		got := histogramCDF(bounds, 50)
+		assert.InDelta(t, 0.5, got, 0.001)
+	})
+}
+
+func TestEstimateSelectivityWithHistogram(t *testing.T) {
+	t.Parallel()
+	// Uniform 0..100, 10 buckets: [0,10,20,30,40,50,60,70,80,90,100]
+	bounds := make([]float64, 11)
+	for i := range bounds {
+		bounds[i] = float64(i * 10)
+	}
+	hist := &Histogram{Bounds: bounds}
+
+	t.Run("no_histogram_falls_back_to_fixed_constants", func(t *testing.T) {
+		t.Parallel()
+		rc := RangeCondition{Lower: &RangeBound{Value: int64(10), Inclusive: true}}
+		got := estimateSelectivityWithHistogram(nil, rc)
+		assert.Equal(t, 0.5, got) // fixed constant for single bound
+	})
+
+	t.Run("lower_bound_only", func(t *testing.T) {
+		t.Parallel()
+		// value > 50 → 1 - CDF(50) = 1 - 0.5 = 0.5
+		rc := RangeCondition{Lower: &RangeBound{Value: int64(50), Inclusive: false}}
+		got := estimateSelectivityWithHistogram(hist, rc)
+		assert.InDelta(t, 0.5, got, 0.01)
+	})
+
+	t.Run("upper_bound_only", func(t *testing.T) {
+		t.Parallel()
+		// value < 30 → CDF(30) = 0.3
+		rc := RangeCondition{Upper: &RangeBound{Value: int64(30), Inclusive: false}}
+		got := estimateSelectivityWithHistogram(hist, rc)
+		assert.InDelta(t, 0.3, got, 0.01)
+	})
+
+	t.Run("both_bounds", func(t *testing.T) {
+		t.Parallel()
+		// 20 < value < 60 → CDF(60) - CDF(20) = 0.6 - 0.2 = 0.4
+		rc := RangeCondition{
+			Lower: &RangeBound{Value: int64(20), Inclusive: false},
+			Upper: &RangeBound{Value: int64(60), Inclusive: false},
+		}
+		got := estimateSelectivityWithHistogram(hist, rc)
+		assert.InDelta(t, 0.4, got, 0.01)
+	})
+
+	t.Run("non_convertible_bound_falls_back_to_fixed", func(t *testing.T) {
+		t.Parallel()
+		// string value can't be converted → lower stays 0, upper stays 1 for unbounded
+		rc := RangeCondition{Lower: &RangeBound{Value: "text", Inclusive: true}}
+		got := estimateSelectivityWithHistogram(hist, rc)
+		// lower=0 (failed conversion), upper=1.0 → sel = 1.0
+		assert.Equal(t, 1.0, got)
+	})
+}
+
+func TestParseIndexStats_WithHistogram(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses_histogram_bounds", func(t *testing.T) {
+		t.Parallel()
+		s := "100 50|h=1,25,50,75,100"
+		stats, err := parseIndexStats(s)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), stats.NEntry)
+		assert.Equal(t, []int64{50}, stats.NDistinct)
+		require.NotNil(t, stats.Hist)
+		assert.Equal(t, []float64{1, 25, 50, 75, 100}, stats.Hist.Bounds)
+	})
+
+	t.Run("no_histogram_section", func(t *testing.T) {
+		t.Parallel()
+		stats, err := parseIndexStats("100 50")
+		require.NoError(t, err)
+		assert.Nil(t, stats.Hist)
+	})
+
+	t.Run("invalid_histogram_bound", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseIndexStats("100 50|h=1,abc,100")
+		assert.Error(t, err)
+	})
+}
+
+func TestSerializeHistogram(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_histogram_writes_nothing", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		serializeHistogram(&b, nil)
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("serializes_bounds", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		h := &Histogram{Bounds: []float64{0, 50, 100}}
+		serializeHistogram(&b, h)
+		assert.Equal(t, "|h=0,50,100", b.String())
+	})
+
+	t.Run("roundtrip", func(t *testing.T) {
+		t.Parallel()
+		sorted := make([]float64, 100)
+		for i := range sorted {
+			sorted[i] = float64(i + 1)
+		}
+		h := buildEquiDepthHistogram(sorted, 16)
+		require.NotNil(t, h)
+
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d %d", 100, 100)
+		serializeHistogram(&b, h)
+
+		parsed, err := parseIndexStats(b.String())
+		require.NoError(t, err)
+		require.NotNil(t, parsed.Hist)
+		assert.Equal(t, len(h.Bounds), len(parsed.Hist.Bounds))
+		for i := range h.Bounds {
+			assert.InDelta(t, h.Bounds[i], parsed.Hist.Bounds[i], 0.0001)
+		}
+	})
+}
+
+func TestEstimateRangeRows_WithHistogram(t *testing.T) {
+	t.Parallel()
+
+	// Build histogram for values 1..100
+	sorted := make([]float64, 100)
+	for i := range sorted {
+		sorted[i] = float64(i + 1)
+	}
+	hist := buildEquiDepthHistogram(sorted, 10)
+
+	stats := IndexStats{
+		NEntry:    100,
+		NDistinct: []int64{100},
+		Hist:      hist,
+	}
+
+	t.Run("narrow_range_uses_histogram", func(t *testing.T) {
+		t.Parallel()
+		// value between 40 and 60 should be ~20 rows
+		rc := RangeCondition{
+			Lower: &RangeBound{Value: int64(40), Inclusive: true},
+			Upper: &RangeBound{Value: int64(60), Inclusive: true},
+		}
+		got := stats.EstimateRangeRows(rc, 0)
+		assert.InDelta(t, 20, float64(got), 5.0)
+	})
+
+	t.Run("full_range_returns_all", func(t *testing.T) {
+		t.Parallel()
+		rc := RangeCondition{
+			Lower: &RangeBound{Value: int64(1), Inclusive: true},
+			Upper: &RangeBound{Value: int64(100), Inclusive: true},
+		}
+		got := stats.EstimateRangeRows(rc, 0)
+		assert.InDelta(t, 100, float64(got), 5.0)
+	})
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1444,12 +1444,12 @@ func intersectTwoSortedSets(a, b []RowID) []RowID {
 			if len(result) == 0 || result[len(result)-1] != a[i] {
 				result = append(result, a[i])
 			}
-			i++
-			j++
+			i += 1
+			j += 1
 		case a[i] < b[j]:
-			i++
+			i += 1
 		default:
-			j++
+			j += 1
 		}
 	}
 	if len(result) == 0 {


### PR DESCRIPTION
  **Equi-depth histograms for ANALYZE statistics:**

  internal/minisql/query_plan_stats.go:
  - Added Histogram struct with Bounds []float64 (N+1 boundaries for N buckets)
  - Added Hist *Histogram field to IndexStats
  - Added histogramBuckets = 32 constant
  - Added isNumericColumn — returns true for Int4, Int8, Real, Double, Timestamp
  - Added anyToFloat64 — converts int32/int64/float32/float64 index key values to float64
  - Added buildEquiDepthHistogram(sorted []float64, numBuckets int) — divides sorted values into equal-count buckets
  - Added histogramCDF(bounds, v) — estimates fraction of entries ≤ v using linear interpolation
  - Added estimateSelectivityWithHistogram — uses CDF for histogram-based selectivity, falls back to fixed constants (0.3/0.5/1.0) when no histogram
  - Updated parseIndexStats to parse optional |h=b0,b1,...,bN suffix
  - Added serializeHistogram helper for stat string output
  - Updated EstimateRangeRows to call estimateSelectivityWithHistogram

  internal/minisql/analyze.go:
  - Updated analyzeIndex to collect first-column numeric values during the B-tree scan, build an equi-depth histogram, and serialize it into the stat string

  **Tests:**
  - Updated TestDatabase_Analyze to check histogram presence for numeric index columns (Int8 PK and Timestamp secondary index) while confirming Varchar indexes have no histogram
  - Added 8 new unit tests: TestBuildEquiDepthHistogram, TestHistogramCDF, TestEstimateSelectivityWithHistogram, TestParseIndexStats_WithHistogram, TestSerializeHistogram, TestEstimateRangeRows_WithHistogram