### PR TITLE
feat: parallel full table scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ MiniSQL supports optional connection string parameters:
 | `max_cached_pages` | positive integer | `2000` | Maximum number of pages to keep in memory cache |
 | `slow_query_threshold` | Go duration, e.g. `50ms`, `2s` | `0` | Log queries taking at least this long at WARN level (0 = disabled) |
 | `synchronous` | `off`, `normal`, `full` | `normal` | WAL fsync mode (see [WAL durability](#wal-durability-modes) below) |
+| `parallel_scan` | `on`, `off` | `off` | Enable concurrent leaf-page scanning for full table scans (see [Parallel Full Table Scan](#parallel-full-table-scan) below) |
 
 **Examples:**
 ```go
@@ -71,6 +72,9 @@ db, err := sql.Open("minisql", "./my.db?synchronous=full")
 
 // Log queries that take at least 50ms
 db, err := sql.Open("minisql", "./my.db?slow_query_threshold=50ms")
+
+// Enable parallel full table scans
+db, err := sql.Open("minisql", "./my.db?parallel_scan=on")
 
 // Combine multiple parameters
 db, err := sql.Open("minisql", "/path/to/db.db?log_level=info&max_cached_pages=2000")
@@ -123,6 +127,33 @@ PRAGMA synchronous = full;
 PRAGMA synchronous = normal;
 PRAGMA synchronous = off;
 ```
+
+## Parallel Full Table Scan
+
+When a query requires a full table scan (no usable index, or explicit sequential scan), MiniSQL normally reads leaf pages one at a time in a single goroutine. **Parallel scan** splits the leaf-page chain across up to `runtime.NumCPU()` goroutines so that multiple pages are decoded and filtered concurrently.
+
+Parallel scan is **off by default** because it adds overhead for small tables and single-CPU environments. It is most beneficial for large tables on multi-core machines running filter-heavy queries that touch many pages.
+
+**Note:** Parallel scan does **not** guarantee row-ID ordering. Queries that rely on insertion order without an explicit `ORDER BY` may observe a different row sequence.
+
+Enable at connection open time via the connection string:
+
+```go
+db, err := sql.Open("minisql", "./my.db?parallel_scan=on")
+```
+
+Or toggle at runtime with PRAGMA (affects all existing tables on the connection immediately):
+
+```sql
+PRAGMA parallel_scan = on;
+PRAGMA parallel_scan;     -- returns 0 (off) or 1 (on)
+PRAGMA parallel_scan = off;
+```
+
+| Mode | Connection string | PRAGMA | Description |
+|------|------------------|--------|-------------|
+| off | _(default)_ | `PRAGMA parallel_scan = off` | Single-goroutine sequential leaf scan. Best for small tables or single-CPU environments. |
+| on | `parallel_scan=on` | `PRAGMA parallel_scan = on` | Leaf pages partitioned across `runtime.NumCPU()` goroutines. Rows delivered in arrival order (not row-ID order). |
 
 ## Storage
 
@@ -379,6 +410,8 @@ Important behavior and current non-goals:
 | `PRAGMA wal_checkpoint` | Manually flush WAL frames to the main database file and truncate the WAL. |
 | `PRAGMA synchronous` | Read current WAL fsync mode (returns 0/1/2). |
 | `PRAGMA synchronous = off\|normal\|full` | Set WAL fsync mode for the current connection. See [WAL Durability Modes](#wal-durability-modes). |
+| `PRAGMA parallel_scan` | Read current parallel scan state (returns 0 = off, 1 = on). |
+| `PRAGMA parallel_scan = on\|off` | Enable or disable concurrent leaf-page scanning for full table scans. See [Parallel Full Table Scan](#parallel-full-table-scan). |
 
 
 Prepared statements are supported using `?` as a placeholder. For example:

--- a/connection_string.go
+++ b/connection_string.go
@@ -41,6 +41,7 @@ type ConnectionConfig struct {
 	MaxCachedPages         int             // Maximum number of pages to cache (default: 2000, 0 = use default)
 	SlowQueryThreshold     time.Duration   // Log queries at WARN when elapsed time meets or exceeds this duration (0 = disabled)
 	Synchronous            SynchronousMode // WAL fsync mode: off, normal (default), full
+	ParallelScan           bool            // Enable concurrent leaf-page scanning (default: false)
 }
 
 // DefaultConnectionConfig returns default configuration.
@@ -66,6 +67,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //   - max_cached_pages=N                : Page cache size in pages (default: 2000)
 //   - slow_query_threshold=50ms         : Log queries taking at least this long (0 = disabled)
 //   - synchronous=off|normal|full       : WAL fsync mode (default: normal, matching SQLite WAL default)
+//   - parallel_scan=on|off              : Enable concurrent leaf-page scanning (default: off)
 //
 // Examples:
 //   - "./my.db"                                       : Default settings
@@ -73,6 +75,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //   - "./my.db?wal_checkpoint_threshold=500"          : Auto-checkpoint every 500 frames
 //   - "./my.db?wal_write_buffer_size=0"               : Disable write batching (flush every commit)
 //   - "./my.db?synchronous=full"                      : fsync on every commit (maximum durability)
+//   - "./my.db?parallel_scan=on"                      : Enable parallel full table scans
 //   - "./my.db?log_level=info&max_cached_pages=500"   : Multiple parameters
 func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 	// Split on first '?' to separate path from query params
@@ -152,6 +155,18 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 			config.Synchronous = SynchronousFull
 		default:
 			return nil, fmt.Errorf("invalid synchronous parameter: expected off, normal, or full, got %q", syncStr)
+		}
+	}
+
+	// Parse parallel_scan parameter
+	if psStr := queryParams.Get("parallel_scan"); psStr != "" {
+		switch strings.ToLower(psStr) {
+		case "on", "1", "true":
+			config.ParallelScan = true
+		case "off", "0", "false":
+			config.ParallelScan = false
+		default:
+			return nil, fmt.Errorf("invalid parallel_scan parameter: expected on or off, got %q", psStr)
 		}
 	}
 

--- a/connection_string_test.go
+++ b/connection_string_test.go
@@ -223,6 +223,40 @@ func TestParseConnectionString(t *testing.T) {
 			wantErr:     true,
 			errContains: "invalid synchronous parameter",
 		},
+		{
+			name:    "parallel_scan=on",
+			connStr: "./test.db?parallel_scan=on",
+			wantConfig: &ConnectionConfig{
+				FilePath:               "./test.db",
+				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
+				LogLevel:               "warn",
+				MaxCachedPages:         minisql.PageCacheSize,
+				Synchronous:            SynchronousNormal,
+				ParallelScan:           true,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "parallel_scan=off explicit",
+			connStr: "./test.db?parallel_scan=off",
+			wantConfig: &ConnectionConfig{
+				FilePath:               "./test.db",
+				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
+				LogLevel:               "warn",
+				MaxCachedPages:         minisql.PageCacheSize,
+				Synchronous:            SynchronousNormal,
+				ParallelScan:           false,
+			},
+			wantErr: false,
+		},
+		{
+			name:        "invalid parallel_scan value",
+			connStr:     "./test.db?parallel_scan=maybe",
+			wantErr:     true,
+			errContains: "invalid parallel_scan parameter",
+		},
 	}
 
 	for _, tt := range tests {

--- a/e2e_tests/parallel_scan_test.go
+++ b/e2e_tests/parallel_scan_test.go
@@ -1,0 +1,120 @@
+package e2etests
+
+import (
+	"context"
+	"sort"
+)
+
+func (s *TestSuite) TestParallelScan_PragmaReadDefault() {
+	rows, err := s.db.QueryContext(context.Background(), `PRAGMA parallel_scan;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	s.Require().NoError(err)
+	s.Equal([]string{"parallel_scan"}, columns)
+
+	s.Require().True(rows.Next())
+	var v int32
+	s.Require().NoError(rows.Scan(&v))
+	s.Equal(int32(0), v, "parallel_scan should be off by default")
+}
+
+func (s *TestSuite) TestParallelScan_PragmaEnableDisable() {
+	// Enable
+	_, err := s.db.Exec(`PRAGMA parallel_scan = on;`)
+	s.Require().NoError(err)
+
+	rows, err := s.db.QueryContext(context.Background(), `PRAGMA parallel_scan;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+	s.Require().True(rows.Next())
+	var v int32
+	s.Require().NoError(rows.Scan(&v))
+	s.Equal(int32(1), v)
+	rows.Close()
+
+	// Disable
+	_, err = s.db.Exec(`PRAGMA parallel_scan = off;`)
+	s.Require().NoError(err)
+
+	rows2, err := s.db.QueryContext(context.Background(), `PRAGMA parallel_scan;`)
+	s.Require().NoError(err)
+	defer rows2.Close()
+	s.Require().True(rows2.Next())
+	var v2 int32
+	s.Require().NoError(rows2.Scan(&v2))
+	s.Equal(int32(0), v2)
+}
+
+func (s *TestSuite) TestParallelScan_ResultsMatchSequential() {
+	// Create a table with enough rows to span multiple leaf pages.
+	_, err := s.db.Exec(createUsersTableSQL)
+	s.Require().NoError(err)
+
+	stmt, err := s.db.Prepare(`insert into "users" (email, name) values (?, ?)`)
+	s.Require().NoError(err)
+
+	users := gen.Users(200)
+	for _, u := range users {
+		_, err := stmt.Exec(u.Email, u.Name)
+		s.Require().NoError(err)
+	}
+
+	// Collect rows with sequential scan (parallel_scan off by default).
+	type row struct{ id int64; email, name string }
+	collectRows := func() []row {
+		rs, err := s.db.QueryContext(context.Background(), `select id, email, name from "users";`)
+		s.Require().NoError(err)
+		defer rs.Close()
+		var out []row
+		for rs.Next() {
+			var r row
+			s.Require().NoError(rs.Scan(&r.id, &r.email, &r.name))
+			out = append(out, r)
+		}
+		s.Require().NoError(rs.Err())
+		return out
+	}
+
+	seqRows := collectRows()
+	s.Require().Len(seqRows, 200)
+
+	// Enable parallel scan and collect again.
+	_, err = s.db.Exec(`PRAGMA parallel_scan = on;`)
+	s.Require().NoError(err)
+
+	parRows := collectRows()
+	s.Require().Len(parRows, 200)
+
+	// Parallel scan may return rows in a different order — sort by id before comparing.
+	sort.Slice(seqRows, func(i, j int) bool { return seqRows[i].id < seqRows[j].id })
+	sort.Slice(parRows, func(i, j int) bool { return parRows[i].id < parRows[j].id })
+	s.Equal(seqRows, parRows)
+}
+
+func (s *TestSuite) TestParallelScan_FilterCorrect() {
+	// Verify WHERE predicates are applied correctly under parallel scan.
+	_, err := s.db.Exec(createUsersTableSQL)
+	s.Require().NoError(err)
+
+	stmt, err := s.db.Prepare(`insert into "users" (email, name) values (?, ?)`)
+	s.Require().NoError(err)
+
+	users := gen.Users(100)
+	for _, u := range users {
+		_, err := stmt.Exec(u.Email, u.Name)
+		s.Require().NoError(err)
+	}
+
+	_, err = s.db.Exec(`PRAGMA parallel_scan = on;`)
+	s.Require().NoError(err)
+
+	rows, err := s.db.QueryContext(context.Background(), `select count(*) from "users" where id > 50;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+	s.Require().True(rows.Next())
+	var cnt int64
+	s.Require().NoError(rows.Scan(&cnt))
+	s.Equal(int64(50), cnt)
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -48,6 +48,7 @@ type Database struct {
 	rowCounts      map[string]int64
 	dbFilePath     string
 	rowCountsMu    sync.RWMutex
+	parallelScan   bool
 }
 
 type clock func() Time
@@ -704,6 +705,8 @@ func (d *Database) tableFromSQL(ctx context.Context, schema Schema) (*Table, err
 		opts = append(opts, WithUniqueIndex(uniqueIndex))
 	}
 
+	opts = append(opts, WithParallelScan(d.parallelScan))
+
 	return NewTable(
 		d.logger,
 		tp,
@@ -1052,6 +1055,8 @@ func (d *Database) createTable(ctx context.Context, stmt Statement) (*Table, err
 	for _, uniqueIndex := range stmt.UniqueIndexes {
 		opts = append(opts, WithUniqueIndex(uniqueIndex))
 	}
+
+	opts = append(opts, WithParallelScan(d.parallelScan))
 
 	createdTable := NewTable(
 		d.logger,

--- a/internal/minisql/database_options.go
+++ b/internal/minisql/database_options.go
@@ -17,3 +17,10 @@ func WithMaxCachedStatements(maxStatements int) DatabaseOption {
 		}
 	}
 }
+
+// WithParallelScanEnabled turns on concurrent leaf-page scanning for all user tables.
+func WithParallelScanEnabled() DatabaseOption {
+	return func(d *Database) {
+		d.parallelScan = true
+	}
+}

--- a/internal/minisql/parallel_scan.go
+++ b/internal/minisql/parallel_scan.go
@@ -1,0 +1,199 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+type parallelScanResult struct {
+	row Row
+	err error
+}
+
+// leafPageList walks the leaf chain from the leftmost leaf and returns every leaf PageIndex.
+func (t *Table) leafPageList(ctx context.Context) ([]PageIndex, error) {
+	cursor, err := t.SeekFirst(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cursor.EndOfTable {
+		return nil, nil
+	}
+
+	var pages []PageIndex
+	pageIdx := cursor.PageIdx
+	for {
+		pages = append(pages, pageIdx)
+		page, err := t.pager.ReadPage(ctx, pageIdx)
+		if err != nil {
+			return nil, fmt.Errorf("leaf page list: %w", err)
+		}
+		if page.LeafNode.Header.NextLeaf == 0 {
+			break
+		}
+		pageIdx = page.LeafNode.Header.NextLeaf
+	}
+	return pages, nil
+}
+
+// parallelSequentialScan partitions leaf pages across up to runtime.NumCPU() goroutines.
+// Each worker reads its own page slice independently; matching rows are fanned in through
+// a buffered channel and delivered to out in arrival order (not row-ID order).
+func (t *Table) parallelSequentialScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
+	pages, err := t.leafPageList(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pages) == 0 {
+		return nil
+	}
+
+	fullMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+
+	filterMask := fullMask
+	twoPhase := tableFilter != nil
+	if twoPhase {
+		filterMask = filterOnlyMask(t.Columns, scan.Filters)
+		twoPhase = maskHasTrue(filterMask) && !masksEqual(filterMask, fullMask)
+	}
+
+	numWorkers := min(runtime.NumCPU(), len(pages))
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ch := make(chan parallelScanResult, numWorkers*16)
+
+	var wg sync.WaitGroup
+	pagesPerWorker := (len(pages) + numWorkers - 1) / numWorkers
+	for i := range numWorkers {
+		start := i * pagesPerWorker
+		end := min(start+pagesPerWorker, len(pages))
+		if start >= len(pages) {
+			break
+		}
+		wg.Add(1)
+		go func(workerPages []PageIndex) {
+			defer wg.Done()
+			t.parallelScanWorker(ctx, workerPages, fullMask, filterMask, twoPhase, tableFilter, ch)
+		}(pages[start:end])
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for result := range ch {
+		if result.err != nil {
+			return result.err
+		}
+		if err := out(result.row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *Table) parallelScanWorker(
+	ctx context.Context,
+	pages []PageIndex,
+	fullMask, filterMask []bool,
+	twoPhase bool,
+	tableFilter func(Row) (bool, error),
+	ch chan<- parallelScanResult,
+) {
+	send := func(r parallelScanResult) bool {
+		select {
+		case ch <- r:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	for _, pageIdx := range pages {
+		if ctx.Err() != nil {
+			return
+		}
+
+		page, err := t.pager.ReadPage(ctx, pageIdx)
+		if err != nil {
+			send(parallelScanResult{err: fmt.Errorf("parallel scan worker: %w", err)})
+			return
+		}
+
+		for i := range page.LeafNode.Header.Cells {
+			if ctx.Err() != nil {
+				return
+			}
+
+			cell := page.LeafNode.Cells[i]
+
+			if !twoPhase {
+				row := t.newRow()
+				row, err = row.UnmarshalWithMask(cell, fullMask)
+				if err != nil {
+					send(parallelScanResult{err: err})
+					return
+				}
+				row.Key = cell.Key
+				if tableFilter != nil {
+					ok, err := tableFilter(row)
+					if err != nil {
+						send(parallelScanResult{err: err})
+						return
+					}
+					if !ok {
+						continue
+					}
+				}
+				row, err = row.readOverflowTexts(ctx, t.pager)
+				if err != nil {
+					send(parallelScanResult{err: err})
+					return
+				}
+				if !send(parallelScanResult{row: row}) {
+					return
+				}
+				continue
+			}
+
+			// Two-phase: decode only predicate columns first to skip non-matching rows cheaply.
+			filterRow := t.newRow()
+			filterRow, err = filterRow.UnmarshalWithMask(cell, filterMask)
+			if err != nil {
+				send(parallelScanResult{err: err})
+				return
+			}
+			ok, err := tableFilter(filterRow)
+			if err != nil {
+				send(parallelScanResult{err: err})
+				return
+			}
+			if !ok {
+				continue
+			}
+
+			row := t.newRow()
+			row, err = row.UnmarshalWithMask(cell, fullMask)
+			if err != nil {
+				send(parallelScanResult{err: err})
+				return
+			}
+			row.Key = cell.Key
+			row, err = row.readOverflowTexts(ctx, t.pager)
+			if err != nil {
+				send(parallelScanResult{err: err})
+				return
+			}
+			if !send(parallelScanResult{row: row}) {
+				return
+			}
+		}
+	}
+}

--- a/internal/minisql/parallel_scan_test.go
+++ b/internal/minisql/parallel_scan_test.go
@@ -1,0 +1,168 @@
+package minisql
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeafPageList_Empty(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+
+	pages, err := table.leafPageList(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, pages)
+}
+
+func TestLeafPageList_NonEmpty(t *testing.T) {
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+
+	mustInsert(ctx, t, table, txManager, Statement{
+		Kind:    Insert,
+		Columns: table.Columns,
+		Fields:  fieldsFromColumns(table.Columns...),
+		Inserts: [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("a@example.com"))}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("b@example.com"))}},
+		},
+	})
+
+	var pages []PageIndex
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		var err error
+		pages, err = table.leafPageList(ctx)
+		return err
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, pages)
+	// All returned indices must be distinct.
+	seen := make(map[PageIndex]bool)
+	for _, p := range pages {
+		assert.False(t, seen[p], "duplicate page index %d", p)
+		seen[p] = true
+	}
+}
+
+func TestParallelSequentialScan_MatchesSequential(t *testing.T) {
+	// Insert enough rows to guarantee multiple leaf pages, then compare the row
+	// sets produced by sequential and parallel scans.
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+
+	const n = 200
+	inserts := make([][]OptionalValue, 0, n)
+	for i := range n {
+		inserts = append(inserts, []OptionalValue{
+			{Valid: true, Value: int64(i + 1)},
+			{Valid: true, Value: NewTextPointer([]byte("user@example.com"))},
+		})
+	}
+	mustInsert(ctx, t, table, txManager, Statement{
+		Kind:    Insert,
+		Columns: table.Columns,
+		Fields:  fieldsFromColumns(table.Columns...),
+		Inserts: inserts,
+	})
+
+	scan := Scan{TableName: testTableName, TableAlias: "t", Type: ScanTypeSequential}
+	fields := fieldsFromColumns(table.Columns...)
+
+	var seqRows []Row
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		return runTableScan(ctx, QueryPlan{}, table, scan, fields, func(row Row) error {
+			seqRows = append(seqRows, row)
+			return nil
+		})
+	})
+	require.NoError(t, err)
+
+	table.parallelScan = true
+	var parRows []Row
+	err = txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		return runTableScan(ctx, QueryPlan{}, table, scan, fields, func(row Row) error {
+			parRows = append(parRows, row)
+			return nil
+		})
+	})
+	require.NoError(t, err)
+
+	// Parallel scan may deliver rows in a different order — sort both by key before comparing.
+	sortRowsByKey := func(rows []Row) {
+		sort.Slice(rows, func(i, j int) bool {
+			vi, _ := rows[i].GetValue(table.Columns[0].Name)
+			vj, _ := rows[j].GetValue(table.Columns[0].Name)
+			return vi.Value.(int64) < vj.Value.(int64)
+		})
+	}
+	sortRowsByKey(seqRows)
+	sortRowsByKey(parRows)
+
+	assert.Equal(t, len(seqRows), len(parRows))
+	assert.Equal(t, seqRows, parRows)
+}
+
+func TestParallelSequentialScan_WithFilter(t *testing.T) {
+	// Verify the filter predicate is applied correctly under parallel scan.
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+
+	const n = 100
+	inserts := make([][]OptionalValue, 0, n)
+	for i := range n {
+		inserts = append(inserts, []OptionalValue{
+			{Valid: true, Value: int64(i + 1)},
+			{Valid: true, Value: NewTextPointer([]byte("user@example.com"))},
+		})
+	}
+	mustInsert(ctx, t, table, txManager, Statement{
+		Kind:    Insert,
+		Columns: table.Columns,
+		Fields:  fieldsFromColumns(table.Columns...),
+		Inserts: inserts,
+	})
+
+	// Filter: id > 50
+	conds := OneOrMore{{
+		FieldIsGreater(Field{Name: "id"}, OperandInteger, int64(50)),
+	}}
+	scan := Scan{
+		TableName:  testTableName,
+		TableAlias: "t",
+		Type:       ScanTypeSequential,
+		Filters:    conds,
+	}
+	fields := fieldsFromColumns(table.Columns...)
+
+	table.parallelScan = true
+	var parRows []Row
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		return runTableScan(ctx, QueryPlan{}, table, scan, fields, func(row Row) error {
+			parRows = append(parRows, row)
+			return nil
+		})
+	})
+	require.NoError(t, err)
+	assert.Len(t, parRows, 50)
+}
+
+func TestParallelSequentialScan_EmptyTable(t *testing.T) {
+	table, txManager, _ := newTestTable(t, testColumns[0:2])
+	ctx := context.Background()
+
+	table.parallelScan = true
+	scan := Scan{TableName: testTableName, TableAlias: "t", Type: ScanTypeSequential}
+	var got []Row
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		return runTableScan(ctx, QueryPlan{}, table, scan, fieldsFromColumns(table.Columns...), func(row Row) error {
+			got = append(got, row)
+			return nil
+		})
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/minisql/pragma.go
+++ b/internal/minisql/pragma.go
@@ -41,6 +41,8 @@ func (d *Database) executePragmaStatement(ctx context.Context, stmt Statement) (
 		return walCheckpointResult(), nil
 	case "synchronous":
 		return d.executeSynchronousPragma(stmt)
+	case "parallel_scan":
+		return d.executeParallelScanPragma(stmt)
 	default:
 		return StatementResult{}, fmt.Errorf("%w: %s", errUnknownPragma, stmt.PragmaName)
 	}
@@ -65,6 +67,57 @@ func (d *Database) executeSynchronousPragma(stmt Statement) (StatementResult, er
 		d.wal.SetSynchronous(mode)
 	}
 	return synchronousResult(mode), nil
+}
+
+var parallelScanResultColumns = []Column{
+	{Kind: Int4, Size: 4, Name: "parallel_scan"},
+}
+
+func (d *Database) executeParallelScanPragma(stmt Statement) (StatementResult, error) {
+	if stmt.PragmaValue == "" {
+		// Read: return current state.
+		d.dbLock.RLock()
+		enabled := d.parallelScan
+		d.dbLock.RUnlock()
+		return boolPragmaResult(parallelScanResultColumns, enabled), nil
+	}
+
+	enabled, err := parseBoolPragma(stmt.PragmaValue)
+	if err != nil {
+		return StatementResult{}, err
+	}
+
+	d.dbLock.Lock()
+	d.parallelScan = enabled
+	for _, table := range d.tables {
+		table.parallelScan = enabled
+	}
+	d.dbLock.Unlock()
+
+	return boolPragmaResult(parallelScanResultColumns, enabled), nil
+}
+
+func parseBoolPragma(s string) (bool, error) {
+	switch s {
+	case "on", "1", "true":
+		return true, nil
+	case "off", "0", "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean pragma value %q: expected on or off", s)
+	}
+}
+
+func boolPragmaResult(cols []Column, enabled bool) StatementResult {
+	v := int32(0)
+	if enabled {
+		v = 1
+	}
+	row := NewRowWithValues(cols, []OptionalValue{{Value: v, Valid: true}})
+	return StatementResult{
+		Columns: cols,
+		Rows:    rowsIterator([]Row{row}),
+	}
 }
 
 func parseSynchronousMode(s string) (SynchronousMode, error) {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1201,6 +1201,9 @@ func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []
 	if t.virtualRows != nil {
 		return t.virtualSequentialScan(ctx, scan, out)
 	}
+	if t.parallelScan {
+		return t.parallelSequentialScan(ctx, scan, selectedFields, out)
+	}
 	cursor, err := t.SeekFirst(ctx)
 	if err != nil {
 		return err

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -27,6 +27,9 @@ type Table struct {
 	// executeSelectFromDerivedTable. When set, sequentialScan iterates these
 	// in-memory rows instead of reading from the B+ tree pager.
 	virtualRows []Row
+	// parallelScan enables concurrent leaf-page scanning via parallelSequentialScan.
+	// Toggled by PRAGMA parallel_scan = on/off.
+	parallelScan bool
 	// rightmostTablePage caches the last leaf page index for SeekNextRowID so that
 	// sequential (autoincrement) inserts skip the O(log N) root→leaf traversal.
 	// lastTxIDTablePage guards against stale hints from rolled-back transactions.
@@ -59,6 +62,13 @@ func WithUniqueIndex(index UniqueIndex) TableOption {
 func WithSecondaryIndex(index SecondaryIndex) TableOption {
 	return func(t *Table) {
 		t.SecondaryIndexes[index.Name] = index
+	}
+}
+
+// WithParallelScan enables or disables concurrent leaf-page scanning for this table.
+func WithParallelScan(enabled bool) TableOption {
+	return func(t *Table) {
+		t.parallelScan = enabled
 	}
 }
 

--- a/minisql.go
+++ b/minisql.go
@@ -100,6 +100,11 @@ func (d *Driver) newDB(config *ConnectionConfig) (*minisql.Database, error) {
 			zap.Int("frames_in_index", walIndex.Size()))
 	}
 
+	dbOpts := []minisql.DatabaseOption{}
+	if config.ParallelScan {
+		dbOpts = append(dbOpts, minisql.WithParallelScanEnabled())
+	}
+
 	return minisql.NewDatabase(
 		context.Background(),
 		d.logger,
@@ -115,6 +120,7 @@ func (d *Driver) newDB(config *ConnectionConfig) (*minisql.Database, error) {
 			WALWriteBufferSize:  config.WALWriteBufferSize,
 			Synchronous:         config.Synchronous,
 		},
+		dbOpts...,
 	)
 }
 


### PR DESCRIPTION
**Parallel Full Table Scans**

  **New file:** internal/minisql/parallel_scan.go                                                                                                                                                                                                                                          
  - leafPageList(ctx) — walks the leaf chain from the leftmost leaf (correctly handles page 0 as the root by terminating on NextLeaf == 0 rather than pageIdx != 0)
  - parallelSequentialScan(ctx, scan, selectedFields, out) — partitions leaf pages across min(runtime.NumCPU(), numPages) goroutines, fans results in via a buffered channel, cancels workers via derived context when out returns an error                                            
  - parallelScanWorker(...) — per-worker loop: reads each assigned page, applies the same two-phase unmarshal + filter logic as sequentialScan, sends rows through the channel with a select/ctx.Done() guard to prevent goroutine leaks   
                                                                                                                                                                                                                                                                                       
  **Modified files:**                                                                                                                                                                                                                                                                      
  - table.go — parallelScan bool field + WithParallelScan(bool) option                                                                                                                                                                                                                 
  - select.go — hook in sequentialScan: check t.parallelScan before the cursor-based path                                                                                                                                                                                              
  - database.go — parallelScan bool field; propagated via WithParallelScan(d.parallelScan) in tableFromSQL and createTable
  - database_options.go — WithParallelScanEnabled() DatabaseOption                                                                                                                                                                                                                     
  - pragma.go — PRAGMA parallel_scan = on/off handler; parseBoolPragma and boolPragmaResult helpers                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                       
  **Tests:** 5 unit tests (parallel_scan_test.go) + 4 e2e tests (e2e_tests/parallel_scan_test.go). All 2346 tests pass.