### PR TITLE
refactor: use VisitRowIDs callback method for index point scan to avo…

### DIFF
--- a/internal/minisql/index_cursor.go
+++ b/internal/minisql/index_cursor.go
@@ -18,55 +18,82 @@ type IndexCursor[T IndexKey] struct {
 // ErrNotFound ...
 var ErrNotFound = errors.New("not found")
 
-// FindRowIDs ...
-func (ui *Index[T]) FindRowIDs(ctx context.Context, keyAny any) ([]RowID, error) {
+// VisitRowIDs calls fn for each row ID stored under key, reading overflow pages
+// one at a time so the caller never holds more than one page worth of IDs in memory.
+// fn may return an error to stop iteration early; that error is returned unchanged.
+func (ui *Index[T]) VisitRowIDs(ctx context.Context, keyAny any, fn func(RowID) error) error {
 	key, ok := keyAny.(T)
 	if !ok {
-		return nil, fmt.Errorf("invalid key type: %T", keyAny)
+		return fmt.Errorf("invalid key type: %T", keyAny)
 	}
 
 	rootPage, err := ui.pager.ReadPage(ctx, ui.GetRootPageIdx())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	cursor, ok, err := ui.Seek(ctx, rootPage, key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if !ok {
-		return nil, fmt.Errorf("%w: %v", ErrNotFound, key)
+		return fmt.Errorf("%w: %v", ErrNotFound, key)
 	}
 
 	page, err := cursor.Index.pager.ReadPage(ctx, cursor.PageIdx)
 	if err != nil {
-		return nil, fmt.Errorf("read page: %w", err)
+		return fmt.Errorf("read page: %w", err)
 	}
 	node := page.IndexNode.(*IndexNode[T])
 	if cursor.CellIdx >= node.Header.Keys {
-		return nil, fmt.Errorf("invalid cell index: %d", cursor.CellIdx)
-	}
-
-	if node.Cells[cursor.CellIdx].unique {
-		return []RowID{node.Cells[cursor.CellIdx].UniqueRowID}, nil
+		return fmt.Errorf("invalid cell index: %d", cursor.CellIdx)
 	}
 
 	cell := node.Cells[cursor.CellIdx]
+
+	if cell.unique {
+		return fn(cell.UniqueRowID)
+	}
+
 	if len(cell.RowIDs) == 0 {
-		return nil, fmt.Errorf("no row IDs for key: %v", key)
+		return fmt.Errorf("no row IDs for key: %v", key)
 	}
 
-	rowIDs := make([]RowID, len(cell.RowIDs))
-	copy(rowIDs, cell.RowIDs)
-
-	if cell.Overflow != 0 {
-		overflowIDs, err := readOverflowRowIDs[T](ctx, cursor.Index.pager, cell.Overflow)
-		if err != nil {
-			return nil, fmt.Errorf("read overflow row IDs: %w", err)
+	for _, rowID := range cell.RowIDs {
+		if err := fn(rowID); err != nil {
+			return err
 		}
-		rowIDs = append(rowIDs, overflowIDs...)
 	}
 
+	overflowIdx := cell.Overflow
+	for overflowIdx != 0 {
+		overflowPage, err := cursor.Index.pager.ReadPage(ctx, overflowIdx)
+		if err != nil {
+			return fmt.Errorf("read index overflow page %d: %w", overflowIdx, err)
+		}
+		node := overflowPage.IndexOverflowNode
+		for _, rowID := range node.RowIDs[:node.Header.ItemCount] {
+			if err := fn(rowID); err != nil {
+				return err
+			}
+		}
+		overflowIdx = node.Header.NextPage
+	}
+
+	return nil
+}
+
+// FindRowIDs returns all row IDs for key as a slice.
+// For large non-unique secondary indexes prefer VisitRowIDs to avoid materialising the full list.
+func (ui *Index[T]) FindRowIDs(ctx context.Context, keyAny any) ([]RowID, error) {
+	var rowIDs []RowID
+	err := ui.VisitRowIDs(ctx, keyAny, func(rowID RowID) error {
+		rowIDs = append(rowIDs, rowID)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return rowIDs, nil
 }
 

--- a/internal/minisql/ports.go
+++ b/internal/minisql/ports.go
@@ -71,7 +71,13 @@ type TxPager interface {
 // BTreeIndex ...
 type BTreeIndex interface {
 	GetRootPageIdx() PageIndex
+	// FindRowIDs returns all row IDs for the given key as a slice.
+	// For large non-unique indexes prefer VisitRowIDs to avoid materialising the full list.
 	FindRowIDs(ctx context.Context, key any) ([]RowID, error)
+	// VisitRowIDs calls fn for each row ID associated with key, reading overflow pages
+	// lazily one at a time.  fn may return an error to stop early (e.g. a LIMIT sentinel);
+	// that error is propagated unchanged to the caller.
+	VisitRowIDs(ctx context.Context, key any, fn func(RowID) error) error
 	SeekLastKey(ctx context.Context, pageIdx PageIndex) (any, error)
 	Insert(ctx context.Context, key any, rowID RowID) error
 	Delete(ctx context.Context, key any, rowID RowID) error

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -649,12 +649,12 @@ func (t *Table) selectStreamingDirect(
 			seen[key] = struct{}{}
 		}
 		if hasOffset && offset > 0 {
-			offset--
+			offset -= 1
 			return nil
 		}
 		projected = append(projected, p)
 		if hasLimit {
-			remaining--
+			remaining -= 1
 			if remaining == 0 {
 				return errLimitReached
 			}
@@ -713,12 +713,12 @@ func (t *Table) selectStreaming(stmt Statement, scanned []Row, requestedFields [
 			seen[key] = struct{}{}
 		}
 		if hasOffset && offset > 0 {
-			offset--
+			offset -= 1
 			continue
 		}
 		projected = append(projected, p)
 		if hasLimit {
-			limit--
+			limit -= 1
 			if limit == 0 {
 				break
 			}
@@ -951,19 +951,11 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 	tableFilter := compileScanFilter(t.Columns, scan.Filters)
 	coveringFilter := compileScanFilter(scan.IndexColumns, scan.Filters)
 
-	// Lookup each primary key value
+	// Lookup each key value and process matching row IDs one at a time.
+	// VisitRowIDs reads overflow pages lazily, so a LIMIT sentinel returned by
+	// out stops iteration before all overflow pages are loaded.
 	for _, indexValue := range scan.IndexKeys {
-		// Find row ID from primary key index
-		rowIDs, err := idx.FindRowIDs(ctx, indexValue)
-		if err != nil {
-			if errors.Is(err, ErrNotFound) {
-				// Key not found, skip
-				continue
-			}
-			return fmt.Errorf("index lookup failed: %w", err)
-		}
-
-		for _, rowID := range rowIDs {
+		err := idx.VisitRowIDs(ctx, indexValue, func(rowID RowID) error {
 			var row Row
 
 			switch {
@@ -973,48 +965,47 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 				row = NewRowWithValues(t.Columns, nil)
 				row.Key = rowID
 			default:
-				// Find the row by ID
 				cursor, err := t.Seek(ctx, rowID)
 				if err != nil {
 					return fmt.Errorf("find row failed: %w", err)
 				}
 
-				// Fetch the row
 				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
 				if err != nil {
 					return fmt.Errorf("fetch row failed: %w", err)
 				}
 
-				// Apply remaining filters
 				if tableFilter != nil {
 					ok, err := tableFilter(row)
 					if err != nil {
 						return err
 					}
 					if !ok {
-						continue // Skip this row
+						return nil
 					}
 				}
 			}
 
-			// For covering index scans, filters still need to be applied
-			// (all filter columns are guaranteed to be in the index).
 			if scan.CoveringIndex && coveringFilter != nil {
 				ok, err := coveringFilter(row)
 				if err != nil {
 					return err
 				}
 				if !ok {
-					continue
+					return nil
 				}
 			}
 
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			if err := out(row); err != nil {
-				return err
+			return out(row)
+		})
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				continue
 			}
+			return fmt.Errorf("index lookup failed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
  - indexPointScan materializes all row IDs (including all overflow pages) before the row loop begins. For SELECT ... WHERE status = 'active' LIMIT 10 with 1M active rows that means ~8MB of IDs allocated up front even though only 10 will be consumed.                             
  - selectStreamingDirect already sends errLimitReached through the callback chain to stop early — but the FindRowIDs call happens before that chain starts, so LIMIT can never stop overflow page reads.                                                                              
  - ScanRange and all the full-scan paths already use the callback pattern and naturally avoid this problem.                                                                                                                                                                           
  - collectRowIDsFromScan (multi-index intersection) genuinely needs a materialized list for intersectTwoSortedSets, so it should stay as-is.                                                                                                                                          
  - The PK/unique callers in insert.go / foreign_key.go always return exactly 1 ID — no memory concern, no change needed.                                                                                                                                                              
                                                                                                                                                                                                                                                                                       
  Add a VisitRowIDs callback method to the interface, use it in indexPointScan, and re-implement FindRowIDs on top of it to eliminate duplication