### PR TITLE
refactor: move errors useful to clients (for retries etc) outside of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,7 +947,7 @@ _, err = db.Exec(`insert into "orders" (user_id, amount) values (1, 100)`)
 // Example: this fails with ErrForeignKeyViolation — user_id 99 does not exist
 _, err = db.Exec(`insert into "orders" (user_id, amount) values (99, 100)`)
 if err != nil {
-    var fkErr minisql.ErrForeignKeyViolation
+    var fkErr minisqlErrors.ErrForeignKeyViolation
     if errors.As(err, &fkErr) {
         fmt.Printf("FK violation: %s.%s → %s.%s\n",
             fkErr.ChildTable, fkErr.ChildColumn,
@@ -958,7 +958,7 @@ if err != nil {
 // Example: deleting a parent row that still has children fails with ErrForeignKeyParentViolation
 _, err = db.Exec(`delete from "users" where id = 1`)
 if err != nil {
-    var fkErr minisql.ErrForeignKeyParentViolation
+    var fkErr minisqlErrors.ErrForeignKeyParentViolation
     if errors.As(err, &fkErr) {
         fmt.Printf("parent FK violation: %s.%s referenced by %s.%s\n",
             fkErr.ParentTable, fkErr.ParentColumn,

--- a/e2e_tests/foreign_key_test.go
+++ b/e2e_tests/foreign_key_test.go
@@ -3,7 +3,7 @@ package e2etests
 import (
 	"errors"
 
-	"github.com/RichardKnop/minisql/internal/minisql"
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 // createParentChildTables sets up a users (parent) + orders (child with FK) schema.
@@ -130,7 +130,7 @@ func (s *TestSuite) TestForeignKey_Insert_InvalidFK() {
 
 	_, err := s.db.Exec(`insert into "orders" (user_id, amount) values (99, 100)`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyViolation, got %T: %v", err, err)
 	s.Equal("orders", fkErr.ChildTable)
 	s.Equal([]string{"user_id"}, fkErr.ChildColumns)
@@ -191,7 +191,7 @@ func (s *TestSuite) TestForeignKey_Delete_ParentReferencedRow_Blocked() {
 	// Deleting the parent row must fail.
 	_, err = s.db.Exec(`delete from "users" where id = 1`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyParentViolation
+	var fkErr minisqlErrors.ErrForeignKeyParentViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyParentViolation, got %T: %v", err, err)
 	s.Equal("users", fkErr.ParentTable)
 	s.Equal([]string{"id"}, fkErr.ParentColumns)
@@ -260,7 +260,7 @@ func (s *TestSuite) TestForeignKey_Update_ChildFKColumn_InvalidTarget() {
 	// Reassign order to non-existent user — must fail.
 	_, err = s.db.Exec(`update "orders" set user_id = 999 where id = 1`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyViolation, got %T: %v", err, err)
 }
 
@@ -287,7 +287,7 @@ func (s *TestSuite) TestForeignKey_DropTable_ReferencedTable_Blocked() {
 	// Dropping the parent table while the child FK still references it must fail.
 	_, err := s.db.Exec(`drop table "users"`)
 	s.Require().Error(err)
-	s.True(errors.Is(err, minisql.ErrDropTableReferencedByFK) || s.Contains(err.Error(), "referenced by a foreign key"),
+	s.True(errors.Is(err, minisqlErrors.ErrDropTableReferencedByFK) || s.Contains(err.Error(), "referenced by a foreign key"),
 		"expected ErrDropTableReferencedByFK, got: %v", err)
 }
 
@@ -320,7 +320,7 @@ func (s *TestSuite) TestForeignKey_Reopen_StillEnforced() {
 	// FK should still be enforced after reopen.
 	_, err = s.db.Exec(`insert into "orders" (user_id, amount) values (99, 50)`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyViolation after reopen, got %T: %v", err, err)
 }
 
@@ -347,7 +347,7 @@ func (s *TestSuite) TestForeignKey_SelfReferential() {
 	// Invalid parent reference.
 	_, err = s.db.Exec(`insert into "categories" (name, parent_id) values ('Bad', 99)`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr))
 }
 
@@ -364,7 +364,7 @@ func (s *TestSuite) TestForeignKey_BatchInsert_OneInvalidRow() {
 	// Second row references non-existent user_id=99 — the whole batch should fail.
 	_, err = s.db.Exec(`insert into "orders" (user_id, amount) values (1, 10), (99, 20)`)
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr))
 }
 
@@ -684,7 +684,7 @@ func (s *TestSuite) TestForeignKey_MultiColumn_InvalidFK() {
 	defer stmt2.Close()
 	_, err = stmt2.Exec(int64(1), int64(99), int64(3))
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyViolation, got %T: %v", err, err)
 }
 
@@ -724,7 +724,7 @@ func (s *TestSuite) TestForeignKey_MultiColumn_DeleteParent_Blocked() {
 	defer stmt3.Close()
 	_, err = stmt3.Exec(int64(1), int64(10))
 	s.Require().Error(err)
-	var fkErr minisql.ErrForeignKeyParentViolation
+	var fkErr minisqlErrors.ErrForeignKeyParentViolation
 	s.True(errors.As(err, &fkErr), "expected ErrForeignKeyParentViolation, got %T: %v", err, err)
 }
 

--- a/errors/foreign_key.go
+++ b/errors/foreign_key.go
@@ -1,0 +1,45 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrForeignKeyViolation is returned when a child row's FK value does not exist
+// in the parent table.
+type ErrForeignKeyViolation struct {
+	ChildTable    string
+	ChildColumns  []string
+	ParentTable   string
+	ParentColumns []string
+}
+
+func (e ErrForeignKeyViolation) Error() string {
+	return fmt.Sprintf(
+		"foreign key constraint violation: %s.(%s) references non-existent value in %s.(%s)",
+		e.ChildTable, strings.Join(e.ChildColumns, ", "),
+		e.ParentTable, strings.Join(e.ParentColumns, ", "),
+	)
+}
+
+// ErrForeignKeyParentViolation is returned when deleting or updating a parent row
+// that is still referenced by one or more child rows.
+type ErrForeignKeyParentViolation struct {
+	ParentTable   string
+	ParentColumns []string
+	ChildTable    string
+	ChildColumns  []string
+}
+
+func (e ErrForeignKeyParentViolation) Error() string {
+	return fmt.Sprintf(
+		"foreign key constraint violation: %s.(%s) is still referenced by %s.(%s)",
+		e.ParentTable, strings.Join(e.ParentColumns, ", "),
+		e.ChildTable, strings.Join(e.ChildColumns, ", "),
+	)
+}
+
+// ErrDropTableReferencedByFK is the base error for dropping a table that is
+// still referenced by a foreign key in another table.
+var ErrDropTableReferencedByFK = errors.New("cannot drop table: it is still referenced by a foreign key constraint")

--- a/errors/tx.go
+++ b/errors/tx.go
@@ -1,0 +1,8 @@
+package errors
+
+import (
+	"errors"
+)
+
+// ErrTxConflict is returned when an optimistic concurrency check fails at commit time.
+var ErrTxConflict = errors.New("transaction conflict detected")

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -8,8 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/RichardKnop/minisql/pkg/lrucache"
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
+	"github.com/RichardKnop/minisql/pkg/lrucache"
 )
 
 var (
@@ -1228,7 +1230,7 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 	if d.foreignKeysEnabled {
 		if inbounds := d.referencedBy[name]; len(inbounds) > 0 {
 			return fmt.Errorf("%w: referenced by %s.%v",
-				ErrDropTableReferencedByFK, inbounds[0].ChildTable, inbounds[0].FK.Columns)
+				minisqlErrors.ErrDropTableReferencedByFK, inbounds[0].ChildTable, inbounds[0].FK.Columns)
 		}
 	}
 

--- a/internal/minisql/foreign_key.go
+++ b/internal/minisql/foreign_key.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 // FKAction defines the referential action for ON DELETE / ON UPDATE.
@@ -45,44 +47,6 @@ type ForeignKey struct {
 	OnDelete      FKAction // default FKActionRestrict
 	OnUpdate      FKAction // default FKActionRestrict
 }
-
-// ErrForeignKeyViolation is returned when a child row's FK value does not exist
-// in the parent table.
-type ErrForeignKeyViolation struct {
-	ChildTable    string
-	ChildColumns  []string
-	ParentTable   string
-	ParentColumns []string
-}
-
-func (e ErrForeignKeyViolation) Error() string {
-	return fmt.Sprintf(
-		"foreign key constraint violation: %s.(%s) references non-existent value in %s.(%s)",
-		e.ChildTable, strings.Join(e.ChildColumns, ", "),
-		e.ParentTable, strings.Join(e.ParentColumns, ", "),
-	)
-}
-
-// ErrForeignKeyParentViolation is returned when deleting or updating a parent row
-// that is still referenced by one or more child rows.
-type ErrForeignKeyParentViolation struct {
-	ParentTable   string
-	ParentColumns []string
-	ChildTable    string
-	ChildColumns  []string
-}
-
-func (e ErrForeignKeyParentViolation) Error() string {
-	return fmt.Sprintf(
-		"foreign key constraint violation: %s.(%s) is still referenced by %s.(%s)",
-		e.ParentTable, strings.Join(e.ParentColumns, ", "),
-		e.ChildTable, strings.Join(e.ChildColumns, ", "),
-	)
-}
-
-// ErrDropTableReferencedByFK is the base error for dropping a table that is
-// still referenced by a foreign key in another table.
-var ErrDropTableReferencedByFK = errors.New("cannot drop table: it is still referenced by a foreign key constraint")
 
 // inboundFK records a child-side FK pointing at a given parent table.
 type inboundFK struct {
@@ -142,7 +106,7 @@ func (d *Database) checkChildFK(ctx context.Context, childTable *Table, row Row)
 			return fmt.Errorf("FK check %q: %w", fk.Name, err)
 		}
 		if !exists {
-			return ErrForeignKeyViolation{
+			return minisqlErrors.ErrForeignKeyViolation{
 				ChildTable:    childTable.Name,
 				ChildColumns:  fk.Columns,
 				ParentTable:   fk.TargetTable,
@@ -183,7 +147,7 @@ func (d *Database) enforceParentFKOnDelete(ctx context.Context, parentTable *Tab
 				return fmt.Errorf("FK parent check for %s.%v: %w", parentTable.Name, inbound.FK.TargetColumns, err)
 			}
 			if found {
-				return ErrForeignKeyParentViolation{
+				return minisqlErrors.ErrForeignKeyParentViolation{
 					ParentTable:   parentTable.Name,
 					ParentColumns: inbound.FK.TargetColumns,
 					ChildTable:    inbound.ChildTable,
@@ -238,7 +202,7 @@ func (d *Database) enforceParentFKOnUpdate(ctx context.Context, parentTable *Tab
 				return fmt.Errorf("FK parent update check for %s.%v: %w", parentTable.Name, inbound.FK.TargetColumns, err)
 			}
 			if found {
-				return ErrForeignKeyParentViolation{
+				return minisqlErrors.ErrForeignKeyParentViolation{
 					ParentTable:   parentTable.Name,
 					ParentColumns: inbound.FK.TargetColumns,
 					ChildTable:    inbound.ChildTable,

--- a/internal/minisql/foreign_key_test.go
+++ b/internal/minisql/foreign_key_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 func TestFKAction_String(t *testing.T) {
@@ -30,7 +32,7 @@ func TestFKAction_String(t *testing.T) {
 func TestErrForeignKeyViolation_Error(t *testing.T) {
 	t.Parallel()
 
-	err := ErrForeignKeyViolation{
+	err := minisqlErrors.ErrForeignKeyViolation{
 		ChildTable:    "orders",
 		ChildColumns:  []string{"user_id"},
 		ParentTable:   "users",
@@ -46,7 +48,7 @@ func TestErrForeignKeyViolation_Error(t *testing.T) {
 func TestErrForeignKeyParentViolation_Error(t *testing.T) {
 	t.Parallel()
 
-	err := ErrForeignKeyParentViolation{
+	err := minisqlErrors.ErrForeignKeyParentViolation{
 		ParentTable:   "users",
 		ParentColumns: []string{"id"},
 		ChildTable:    "orders",
@@ -592,7 +594,7 @@ func TestCheckChildFK_MultiColumn_VirtualParent(t *testing.T) {
 	}
 	err := db.checkChildFK(context.Background(), childTable, badRow)
 	require.Error(t, err)
-	var fkErr ErrForeignKeyViolation
+	var fkErr minisqlErrors.ErrForeignKeyViolation
 	require.ErrorAs(t, err, &fkErr)
 }
 
@@ -680,7 +682,7 @@ func TestEnforceParentFKOnDelete_RESTRICT_ChildExists(t *testing.T) {
 	row := Row{Columns: cols, Values: []OptionalValue{{Value: int64(1), Valid: true}}}
 	err := db.enforceParentFKOnDelete(context.Background(), &Table{Name: "users", Columns: cols}, row)
 	require.Error(t, err)
-	var fkErr ErrForeignKeyParentViolation
+	var fkErr minisqlErrors.ErrForeignKeyParentViolation
 	require.ErrorAs(t, err, &fkErr)
 }
 
@@ -812,7 +814,7 @@ func TestEnforceParentFKOnUpdate_RESTRICT_ChildExists(t *testing.T) {
 	newRow := Row{Columns: cols, Values: []OptionalValue{{Value: int64(2), Valid: true}}}
 	err := db.enforceParentFKOnUpdate(context.Background(), &Table{Name: "users", Columns: cols}, oldRow, newRow)
 	require.Error(t, err)
-	var fkErr ErrForeignKeyParentViolation
+	var fkErr minisqlErrors.ErrForeignKeyParentViolation
 	require.ErrorAs(t, err, &fkErr)
 }
 

--- a/internal/minisql/snapshot_isolation_test.go
+++ b/internal/minisql/snapshot_isolation_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 // snapshotColumns are a minimal column set used by all snapshot isolation tests.
@@ -218,7 +220,7 @@ func TestSnapshotIsolation_CheckpointBlockedByReader(t *testing.T) {
 }
 
 // TestSnapshotIsolation_ConcurrentReadWrite verifies that concurrent reads and
-// writes do not race.  Run with -race to detect data races.
+// writes do not race. Run with -race to detect data races.
 func TestSnapshotIsolation_ConcurrentReadWrite(t *testing.T) {
 	table, txManager, _ := newTestTable(t, snapshotColumns)
 	ctx := context.Background()
@@ -237,9 +239,7 @@ func TestSnapshotIsolation_ConcurrentReadWrite(t *testing.T) {
 
 	// Concurrent readers.
 	for r := 0; r < readers; r++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := 0; i < rounds; i++ {
 				err := txManager.ExecuteReadOnlyTransaction(ctx, func(rCtx context.Context) error {
 					selectAllSnapshot(rCtx, t, table)
@@ -249,17 +249,17 @@ func TestSnapshotIsolation_ConcurrentReadWrite(t *testing.T) {
 					errs <- err
 				}
 			}
-		}()
+		})
 	}
 
-	// Concurrent writers.  We allow ErrTxConflict (two writers collide) but
+	// Concurrent writers. We allow ErrTxConflict (two writers collide) but
 	// not any other error.
-	nextID := int64(100)
-	var idMu sync.Mutex
+	var (
+		nextID = int64(100)
+		idMu   sync.Mutex
+	)
 	for w := 0; w < writers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := 0; i < rounds; i++ {
 				idMu.Lock()
 				id := nextID
@@ -281,11 +281,11 @@ func TestSnapshotIsolation_ConcurrentReadWrite(t *testing.T) {
 					})
 					return err
 				})
-				if err != nil && !errors.Is(err, ErrTxConflict) {
+				if err != nil && !errors.Is(err, minisqlErrors.ErrTxConflict) {
 					errs <- err
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 // pageVersion is one historical snapshot of a page stored in the version
@@ -249,9 +251,6 @@ func (tm *TransactionManager) BeginReadOnlyTransaction(ctx context.Context) *Tra
 	return tx
 }
 
-// ErrTxConflict is returned when an optimistic concurrency check fails at commit time.
-var ErrTxConflict = errors.New("transaction conflict detected")
-
 // ErrCheckpointBlockedByReaders is returned when a checkpoint cannot proceed
 // because one or more read-only transactions hold snapshots that predate the
 // current commitSeq.  Callers should retry after the readers have finished.
@@ -385,13 +384,13 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 		for pageIdx, readVersion := range tx.GetReadVersions() {
 			if tm.globalPageVersions[pageIdx] > readVersion {
 				tx.Abort()
-				return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+				return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", minisqlErrors.ErrTxConflict, tx.ID, pageIdx)
 			}
 		}
 		if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
 			if tm.globalDBHeaderVersion > readDBHeaderVersion {
 				tx.Abort()
-				return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+				return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", minisqlErrors.ErrTxConflict, tx.ID)
 			}
 		}
 	}
@@ -489,14 +488,14 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 				if tm.globalPageVersions[pageIdx] > readVersion {
 					tx.Abort()
 					tm.mu.Unlock()
-					return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+					return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", minisqlErrors.ErrTxConflict, tx.ID, pageIdx)
 				}
 			}
 			if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
 				if tm.globalDBHeaderVersion > readDBHeaderVersion {
 					tx.Abort()
 					tm.mu.Unlock()
-					return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+					return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", minisqlErrors.ErrTxConflict, tx.ID)
 				}
 			}
 		}
@@ -525,7 +524,7 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 			tx.Abort()
 			tm.mu.Unlock()
 			tm.walWriteMu.Unlock()
-			return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", ErrTxConflict, tx.ID, pageIdx)
+			return fmt.Errorf("%w: tx %d aborted due to conflict on page %d", minisqlErrors.ErrTxConflict, tx.ID, pageIdx)
 		}
 	}
 	if readDBHeaderVersion, exists := tx.GetDBHeaderReadVersion(); exists {
@@ -533,7 +532,7 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 			tx.Abort()
 			tm.mu.Unlock()
 			tm.walWriteMu.Unlock()
-			return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", ErrTxConflict, tx.ID)
+			return fmt.Errorf("%w: tx %d aborted due to conflict on DB header", minisqlErrors.ErrTxConflict, tx.ID)
 		}
 	}
 	tm.mu.Unlock()

--- a/internal/minisql/transaction_manager_test.go
+++ b/internal/minisql/transaction_manager_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 func TestTransactionManager_Commit(t *testing.T) {
@@ -143,7 +145,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		// Now, committing the reading transaction should fail due to conflict
 		err = txManager.CommitTransaction(ctx, readTx)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrTxConflict)
+		assert.ErrorIs(t, err, minisqlErrors.ErrTxConflict)
 		assert.Equal(t, "transaction conflict detected: tx 1 aborted due to conflict on page 3", err.Error())
 
 		// Writing transaction should have updated page version, no other changes expected
@@ -208,7 +210,7 @@ func TestTransactionManager_Commit(t *testing.T) {
 		// Now, committing the first transaction should fail due to conflict
 		err = txManager.CommitTransaction(ctx, writeTx1)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrTxConflict)
+		assert.ErrorIs(t, err, minisqlErrors.ErrTxConflict)
 		assert.Equal(t, "transaction conflict detected: tx 1 aborted due to conflict on page 4", err.Error())
 
 		// Second transaction should have updated page version, no other changes expected
@@ -398,7 +400,7 @@ func TestTransactionManager_WAL_Commit(t *testing.T) {
 		// txA now conflicts (page 5 version changed to 4, but txA read at version 3).
 		err := txManager.CommitTransaction(ctx, txA)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrTxConflict)
+		assert.ErrorIs(t, err, minisqlErrors.ErrTxConflict)
 		assert.Equal(t, TxAborted, txA.Status)
 
 		// Only one WAL frame (for txB).

--- a/internal/minisql/transaction_pager.go
+++ b/internal/minisql/transaction_pager.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/errors"
 )
 
 // TransactionalPager wraps a base Pager and routes reads and writes through the current transaction.
@@ -126,7 +128,7 @@ func (tp *TransactionalPager) ModifyPage(ctx context.Context, pageIdx PageIndex)
 		if readVersion, ok := tx.GetReadVersion(pageIdx); ok {
 			currentVersion := tp.txManager.GlobalPageVersion(ctx, pageIdx)
 			if currentVersion != readVersion {
-				return nil, ErrTxConflict
+				return nil, minisqlErrors.ErrTxConflict
 			}
 		}
 	}


### PR DESCRIPTION
…internal so they can be imported