### PR TITLE
feat: initial sequential full-text phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ rows.Scan(&owner)
 | String functions | `UPPER(s)`, `LOWER(s)` — case conversion; `TRIM(s[, chars])`, `LTRIM(s[, chars])`, `RTRIM(s[, chars])` — strip whitespace or custom characters; `LENGTH(s)` — byte length; `SUBSTR(s, start[, len])` — 1-based substring; `REPLACE(s, from, to)` — replace all occurrences; `CONCAT(a, b, ...)` — concatenate (NULLs skipped). All usable in `SELECT`, `UPDATE SET`, and composable with each other and arithmetic |
 | Numeric functions | `ABS(n)` — absolute value (preserves input type); `FLOOR(n)`, `CEIL(n)` — floor/ceiling; `ROUND(n[, d])` — round to `d` decimal places (default 0); `MOD(a, b)` — modulo (integer or float). All usable in `SELECT`, `UPDATE SET`, composable with each other and arithmetic |
 | Date/time functions | `NOW()` — current UTC timestamp; `DATE_TRUNC('unit', ts)` — truncate to `year`/`month`/`week`/`day`/`hour`/`minute`/`second`; `EXTRACT('field', ts)` / `DATE_PART('field', ts)` — extract numeric field (`year`, `month`, `day`, `hour`, `minute`, `second`, `dow`); `TO_TIMESTAMP('str')` — parse timestamp string into a TIMESTAMP value. All usable in `SELECT`, `UPDATE SET`, composable with other expressions |
+| Full-text search functions | `MATCH(doc, query)` and `TS_RANK(doc, query)` provide initial full-text semantics via sequential scans. No full-text index is used yet. |
 | `CASE WHEN` | Searched form: `CASE WHEN cond THEN result … ELSE default END`; simple form: `CASE expr WHEN val THEN result … ELSE default END`. Multiple WHEN clauses, optional ELSE (omitting returns NULL). Usable in `SELECT` (including nested in arithmetic), `UPDATE SET`, supports `IS NULL` / `IS NOT NULL` / all comparison operators in conditions |
 | `UNION` / `UNION ALL` | Combine results of two or more `SELECT` statements. `UNION ALL` concatenates all rows (duplicates kept); `UNION` deduplicates the combined result. Chains of three or more branches supported (e.g. `SELECT … UNION ALL SELECT … UNION SELECT …`). Each branch may have its own `WHERE` clause. |
 | `CAST(expr AS type)` | Standard SQL type coercion. Supported target types: `BOOLEAN`, `INT4`, `INT8`, `REAL`, `DOUBLE`, `TEXT`, `VARCHAR(n)`, `TIMESTAMP`, `JSON`, `UUID`. Follows SQLite semantics: float→int truncates toward zero; text→int/float parses leading digits (non-numeric input → 0). `CAST(x AS JSON)` validates and compacts the value. `CAST(x AS UUID)` parses a UUID string and stores it in binary form. `CAST(uuid_col AS TEXT)` formats the 16-byte value back to a hyphenated lowercase string. NULL propagates. Usable anywhere an expression is valid (e.g. `SELECT CAST(price AS INT8)`, `SELECT CAST(n AS TEXT) AS label`, `SELECT CAST(id AS TEXT) FROM widgets`). |
@@ -624,6 +625,24 @@ rows.Scan(&owner)
 | `JSON_VALID(val)` | `1` if `val` is valid JSON, `0` otherwise. |
 | `JSON_TYPE(doc[, path])` | JSON type name of the value (`object`, `array`, `text`, `integer`, `real`, `true`, `false`, `null`). |
 | `JSON_ARRAY_LENGTH(doc)` | Number of elements in a JSON array. |
+
+#### Full-Text Search Functions
+
+MiniSQL currently supports initial full-text search semantics without a full-text index. Queries using `MATCH` scan candidate rows, tokenize the document and query in memory, and evaluate the match during the normal `WHERE` filter.
+
+| Function | Description |
+|----------|-------------|
+| `MATCH(doc, query)` | Returns `true` when every non-stop-word query token appears in `doc`. Usable directly as `WHERE MATCH(body, 'mini database')`. |
+| `TS_RANK(doc, query)` | Returns a simple relevance score using log-scaled term frequency: `sum(log(1 + term_frequency)) / query_terms`. |
+
+Tokenizer v1 lowercases text, splits on non-letter/non-digit boundaries, removes a small built-in English stop-word list, and does not perform stemming. For example, `database` and `databases` are different tokens.
+
+```sql
+SELECT id, TS_RANK(body, 'mini database') AS score
+FROM articles
+WHERE MATCH(body, 'mini database')
+ORDER BY score DESC;
+```
 
 ### Operators Reference
 

--- a/e2e_tests/full_text_test.go
+++ b/e2e_tests/full_text_test.go
@@ -1,0 +1,65 @@
+package e2etests
+
+func (s *TestSuite) TestFullTextSearch_SequentialMatchAndRank() {
+	_, err := s.db.Exec(`create table "articles" (
+		id    int8 primary key autoincrement,
+		title varchar(100) not null,
+		body  text not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "articles" (title, body) values
+		('MiniSQL', 'MiniSQL is a tiny embedded database. MiniSQL stores rows in B tree pages and database pages.'),
+		('Postgres', 'Postgres has a generalized inverted index for full text search.'),
+		('SQLite', 'SQLite has FTS5 tables for full text search.'),
+		('Storage', 'A small database stores data in pages.');`)
+	s.Require().NoError(err)
+
+	s.Run("MATCH filters rows with implicit AND semantics", func() {
+		rows, err := s.db.Query(`select title from "articles" where MATCH(body, 'minisql database');`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var titles []string
+		for rows.Next() {
+			var title string
+			s.Require().NoError(rows.Scan(&title))
+			titles = append(titles, title)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"MiniSQL"}, titles)
+	})
+
+	s.Run("ts_rank can be projected and ordered by alias", func() {
+		rows, err := s.db.Query(`
+			select title, ts_rank(body, 'database pages') as score
+			from "articles"
+			where MATCH(body, 'database')
+			order by score desc;
+		`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var titles []string
+		var scores []float64
+		for rows.Next() {
+			var title string
+			var score float64
+			s.Require().NoError(rows.Scan(&title, &score))
+			titles = append(titles, title)
+			scores = append(scores, score)
+		}
+		s.Require().NoError(rows.Err())
+
+		s.Equal([]string{"MiniSQL", "Storage"}, titles)
+		s.Len(scores, 2)
+		s.Greater(scores[0], scores[1])
+	})
+
+	s.Run("EXPLAIN shows sequential scan while no full-text index exists", func() {
+		rows := s.collectExplain(`EXPLAIN SELECT title FROM "articles" WHERE MATCH(body, 'database');`)
+		s.Require().NotEmpty(rows)
+		s.Equal("sequential", rows[0].Operation)
+		s.Contains(rows[0].Detail, "table=articles")
+	})
+}

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -1213,6 +1213,58 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		}
 		return TimestampMicros(t.TotalMicroseconds()), nil
 
+	// ── Text search functions ──────────────────────────────────────────────────
+
+	case "MATCH":
+		if len(e.Args) != 2 {
+			return nil, fmt.Errorf("MATCH requires exactly 2 arguments")
+		}
+		docVal, err := e.Args[0].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		queryVal, err := e.Args[1].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		if docVal == nil || queryVal == nil {
+			return false, nil
+		}
+		doc, ok := toStringVal(docVal)
+		if !ok {
+			return nil, fmt.Errorf("MATCH: first argument must be a string")
+		}
+		query, ok := toStringVal(queryVal)
+		if !ok {
+			return nil, fmt.Errorf("MATCH: second argument must be a string")
+		}
+		return textSearchMatch(doc, query), nil
+
+	case "TS_RANK":
+		if len(e.Args) != 2 {
+			return nil, fmt.Errorf("TS_RANK requires exactly 2 arguments")
+		}
+		docVal, err := e.Args[0].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		queryVal, err := e.Args[1].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		if docVal == nil || queryVal == nil {
+			return float64(0), nil
+		}
+		doc, ok := toStringVal(docVal)
+		if !ok {
+			return nil, fmt.Errorf("TS_RANK: first argument must be a string")
+		}
+		query, ok := toStringVal(queryVal)
+		if !ok {
+			return nil, fmt.Errorf("TS_RANK: second argument must be a string")
+		}
+		return textSearchRank(doc, query), nil
+
 	// ── JSON functions ──────────────────────────────────────────────────────────
 
 	case "JSON_VALID":

--- a/internal/minisql/expr_index.go
+++ b/internal/minisql/expr_index.go
@@ -60,6 +60,10 @@ func inferExprResultKind(expr *Expr, tableCols []Column) ColumnKind {
 		switch expr.FuncName {
 		case "LOWER", "UPPER", "TRIM", "LTRIM", "RTRIM", "SUBSTR", "REPLACE", "CONCAT":
 			return Varchar
+		case "MATCH":
+			return Boolean
+		case "TS_RANK":
+			return Double
 		case "LENGTH", "MOD":
 			return Int8
 		case "EXTRACT", "DATE_PART":

--- a/internal/minisql/expr_test.go
+++ b/internal/minisql/expr_test.go
@@ -438,6 +438,57 @@ func TestExpr_Eval_UPPER_LOWER(t *testing.T) {
 	})
 }
 
+func TestExpr_Eval_TextSearch(t *testing.T) {
+	t.Parallel()
+
+	row := rowWithText("body", "MiniSQL is a small embedded database. MiniSQL stores data in pages.")
+
+	t.Run("MATCH uses implicit AND over query terms", func(t *testing.T) {
+		t.Parallel()
+		e := &Expr{FuncName: "MATCH", Args: []*Expr{{Column: "body"}, textExpr("minisql database")}}
+		v, err := e.Eval(row)
+		require.NoError(t, err)
+		assert.Equal(t, true, v)
+	})
+
+	t.Run("MATCH ignores stop words and punctuation", func(t *testing.T) {
+		t.Parallel()
+		e := &Expr{FuncName: "MATCH", Args: []*Expr{{Column: "body"}, textExpr("the small, embedded!")}}
+		v, err := e.Eval(row)
+		require.NoError(t, err)
+		assert.Equal(t, true, v)
+	})
+
+	t.Run("MATCH returns false when any query term is missing", func(t *testing.T) {
+		t.Parallel()
+		e := &Expr{FuncName: "MATCH", Args: []*Expr{{Column: "body"}, textExpr("minisql postgres")}}
+		v, err := e.Eval(row)
+		require.NoError(t, err)
+		assert.Equal(t, false, v)
+	})
+
+	t.Run("TS_RANK uses log-scaled term frequency", func(t *testing.T) {
+		t.Parallel()
+		e := &Expr{FuncName: "TS_RANK", Args: []*Expr{{Column: "body"}, textExpr("minisql database")}}
+		v, err := e.Eval(row)
+		require.NoError(t, err)
+		assert.InDelta(t, 0.8958, v.(float64), 0.0001)
+	})
+
+	t.Run("null arguments produce false match and zero rank", func(t *testing.T) {
+		t.Parallel()
+		nullRow := NewRowWithValues([]Column{{Name: "body", Kind: Text}}, []OptionalValue{{Valid: false}})
+
+		match, err := (&Expr{FuncName: "MATCH", Args: []*Expr{{Column: "body"}, textExpr("minisql")}}).Eval(nullRow)
+		require.NoError(t, err)
+		assert.Equal(t, false, match)
+
+		rank, err := (&Expr{FuncName: "TS_RANK", Args: []*Expr{{Column: "body"}, textExpr("minisql")}}).Eval(nullRow)
+		require.NoError(t, err)
+		assert.Equal(t, float64(0), rank)
+	})
+}
+
 func TestExpr_Eval_TRIM(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -733,6 +733,12 @@ func (t *Table) selectStreaming(stmt Statement, scanned []Row, requestedFields [
 }
 
 func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, allRows []Row, requestedFields []Field) (StatementResult, error) {
+	var err error
+	allRows, err = addOrderByOutputFields(allRows, requestedFields, plan.OrderBy)
+	if err != nil {
+		return StatementResult{}, err
+	}
+
 	// Check if we can use heap optimization for LIMIT queries
 	var limit int
 	hasLimit := stmt.Limit.Valid
@@ -803,6 +809,58 @@ func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, allRows []Row, re
 	})
 
 	return result, nil
+}
+
+func addOrderByOutputFields(rows []Row, fields []Field, orderBy []OrderBy) ([]Row, error) {
+	if len(rows) == 0 || len(orderBy) == 0 {
+		return rows, nil
+	}
+
+	outputFields := make(map[string]Field)
+	for _, field := range fields {
+		outputFields[field.OutputName()] = field
+	}
+
+	for rowIdx, row := range rows {
+		updated := row
+		for _, clause := range orderBy {
+			if _, found := updated.GetValue(clause.Field.Name); found {
+				continue
+			}
+
+			field, ok := outputFields[clause.Field.Name]
+			if !ok {
+				continue
+			}
+
+			var value OptionalValue
+			if field.Expr != nil {
+				result, err := field.Expr.Eval(updated)
+				if err != nil {
+					return nil, fmt.Errorf("evaluating ORDER BY expression %q: %w", field.OutputName(), err)
+				}
+				if result != nil {
+					value = OptionalValue{Value: result, Valid: true}
+				}
+			} else {
+				lookupName := field.Name
+				if field.AliasPrefix != "" {
+					lookupName = field.AliasPrefix + "." + field.Name
+				}
+				existing, found := updated.GetValue(lookupName)
+				if !found {
+					continue
+				}
+				value = existing
+			}
+
+			updated.Columns = append(updated.Columns, Column{Name: field.OutputName()})
+			updated.Values = append(updated.Values, value)
+		}
+		rows[rowIdx] = updated
+	}
+
+	return rows, nil
 }
 
 func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -329,43 +329,43 @@ type CTE struct {
 // a single SQL statement of any kind (DML, DDL, transaction control, etc.) and
 // is passed through preparation, binding, validation, and execution unchanged.
 type Statement struct {
-	PrimaryKey        PrimaryKey
-	Aliases           map[string]string
-	Functions         map[string]Function
-	Updates           map[string]OptionalValue
-	Offset            OptionalValue
-	Limit             OptionalValue
-	TableName         string
-	TableAlias        string
-	IndexExpression    *Expr  // nil = column index; non-nil = expression index
+	PrimaryKey         PrimaryKey
+	Aliases            map[string]string
+	Functions          map[string]Function
+	Updates            map[string]OptionalValue
+	Offset             OptionalValue
+	Limit              OptionalValue
+	TableName          string
+	TableAlias         string
+	IndexExpression    *Expr // nil = column index; non-nil = expression index
 	IndexName          string
 	IndexWhereClause   string // raw SQL of the partial index predicate (empty = full index)
 	IndexExpressionSQL string // raw SQL of the index expression (empty = column index)
-	Target            string
-	PragmaName        string
-	PragmaValue       string
-	Fields            []Field
-	Inserts           [][]OptionalValue
-	Aggregates        []AggregateExpr
-	GroupBy           []Field
-	Having            OneOrMore
-	Unions            []UnionClause
-	Joins             []Join
-	OrderBy           []OrderBy
-	UniqueIndexes     []UniqueIndex
-	ForeignKeys       []ForeignKey
-	Columns           []Column
-	Conditions        OneOrMore
-	ReturningFields   []Field
-	ExplainStatement  *Statement
-	FromSubquery      *Statement // non-nil when FROM clause is a derived table
-	FromSubqueryAlias string     // alias for the derived table (e.g. "t" in FROM (...) t)
-	CTEs              []CTE      // non-nil for WITH … SELECT statements
-	Kind              StatementKind
-	ConflictAction    ConflictAction
-	IfNotExists       bool
-	ExplainAnalyze    bool
-	Distinct          bool
+	Target             string
+	PragmaName         string
+	PragmaValue        string
+	Fields             []Field
+	Inserts            [][]OptionalValue
+	Aggregates         []AggregateExpr
+	GroupBy            []Field
+	Having             OneOrMore
+	Unions             []UnionClause
+	Joins              []Join
+	OrderBy            []OrderBy
+	UniqueIndexes      []UniqueIndex
+	ForeignKeys        []ForeignKey
+	Columns            []Column
+	Conditions         OneOrMore
+	ReturningFields    []Field
+	ExplainStatement   *Statement
+	FromSubquery       *Statement // non-nil when FROM clause is a derived table
+	FromSubqueryAlias  string     // alias for the derived table (e.g. "t" in FROM (...) t)
+	CTEs               []CTE      // non-nil for WITH … SELECT statements
+	Kind               StatementKind
+	ConflictAction     ConflictAction
+	IfNotExists        bool
+	ExplainAnalyze     bool
+	Distinct           bool
 }
 
 // NumPlaceholders returns the number of placeholder parameters (?) in the statement.
@@ -442,36 +442,36 @@ func (s Statement) Clone() Statement {
 	}
 
 	stmt := Statement{
-		Kind:              s.Kind,
-		IfNotExists:       s.IfNotExists,
-		TableName:         s.TableName,
-		TableAlias:        s.TableAlias,
+		Kind:               s.Kind,
+		IfNotExists:        s.IfNotExists,
+		TableName:          s.TableName,
+		TableAlias:         s.TableAlias,
 		IndexName:          s.IndexName,
 		IndexWhereClause:   s.IndexWhereClause,
 		IndexExpression:    s.IndexExpression,
 		IndexExpressionSQL: s.IndexExpressionSQL,
-		Target:            s.Target,
-		PragmaName:        s.PragmaName,
-		PragmaValue:       s.PragmaValue,
-		ConflictAction:    s.ConflictAction,
-		Columns:           s.Columns,
-		Distinct:          s.Distinct,
-		Fields:            fields,
-		Aggregates:        s.Aggregates, // slice of value types, safe to share
-		Aliases:           s.Aliases,
-		Inserts:           make([][]OptionalValue, len(s.Inserts)),
-		Functions:         s.Functions,
-		Conditions:        make(OneOrMore, len(s.Conditions)),
-		GroupBy:           s.GroupBy,
-		Having:            s.Having,
-		Joins:             s.Joins,
-		OrderBy:           s.OrderBy,
-		Limit:             s.Limit,
-		Offset:            s.Offset,
-		ReturningFields:   s.ReturningFields,
-		ExplainAnalyze:    s.ExplainAnalyze,
-		FromSubqueryAlias: s.FromSubqueryAlias,
-		ForeignKeys:       s.ForeignKeys, // slice of value structs, safe to share
+		Target:             s.Target,
+		PragmaName:         s.PragmaName,
+		PragmaValue:        s.PragmaValue,
+		ConflictAction:     s.ConflictAction,
+		Columns:            s.Columns,
+		Distinct:           s.Distinct,
+		Fields:             fields,
+		Aggregates:         s.Aggregates, // slice of value types, safe to share
+		Aliases:            s.Aliases,
+		Inserts:            make([][]OptionalValue, len(s.Inserts)),
+		Functions:          s.Functions,
+		Conditions:         make(OneOrMore, len(s.Conditions)),
+		GroupBy:            s.GroupBy,
+		Having:             s.Having,
+		Joins:              s.Joins,
+		OrderBy:            s.OrderBy,
+		Limit:              s.Limit,
+		Offset:             s.Offset,
+		ReturningFields:    s.ReturningFields,
+		ExplainAnalyze:     s.ExplainAnalyze,
+		FromSubqueryAlias:  s.FromSubqueryAlias,
+		ForeignKeys:        s.ForeignKeys, // slice of value structs, safe to share
 	}
 	for i := range s.Inserts {
 		stmt.Inserts[i] = make([]OptionalValue, len(s.Inserts[i]))
@@ -1546,13 +1546,23 @@ func (s Statement) validateSelect(table *Table) error {
 	if len(s.OrderBy) > 0 {
 		for _, anOrderBy := range s.OrderBy {
 			_, ok := table.ColumnByName(anOrderBy.Field.Name)
-			if !ok {
+			if !ok && !s.HasOutputField(anOrderBy.Field.Name) {
 				return fmt.Errorf("unknown field %q in ORDER BY clause", anOrderBy.Field.Name)
 			}
 		}
 	}
 
 	return nil
+}
+
+// HasOutputField reports whether SELECT emits a field with the given output name.
+func (s Statement) HasOutputField(name string) bool {
+	for _, field := range s.Fields {
+		if field.OutputName() == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (s Statement) validateColumnValue(table *Table, col Column, val OptionalValue) error {

--- a/internal/minisql/text_search.go
+++ b/internal/minisql/text_search.go
@@ -1,0 +1,100 @@
+package minisql
+
+import (
+	"math"
+	"unicode"
+)
+
+var textSearchStopWords = map[string]struct{}{
+	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "by": {},
+	"for": {}, "from": {}, "in": {}, "is": {}, "it": {}, "of": {}, "on": {}, "or": {},
+	"that": {}, "the": {}, "to": {}, "was": {}, "with": {},
+}
+
+func textSearchTokens(input string) []string {
+	tokens := make([]string, 0)
+	current := make([]rune, 0, 16)
+
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		token := string(current)
+		current = current[:0]
+		if _, stop := textSearchStopWords[token]; stop {
+			return
+		}
+		tokens = append(tokens, token)
+	}
+
+	for _, r := range input {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current = append(current, unicode.ToLower(r))
+			continue
+		}
+		flush()
+	}
+	flush()
+
+	return tokens
+}
+
+func uniqueTextSearchTokens(input string) []string {
+	tokens := textSearchTokens(input)
+	seen := make(map[string]struct{}, len(tokens))
+	unique := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if _, ok := seen[token]; ok {
+			continue
+		}
+		seen[token] = struct{}{}
+		unique = append(unique, token)
+	}
+	return unique
+}
+
+func textSearchMatch(document, query string) bool {
+	queryTokens := uniqueTextSearchTokens(query)
+	if len(queryTokens) == 0 {
+		return false
+	}
+
+	docTokens := textSearchTokens(document)
+	if len(docTokens) == 0 {
+		return false
+	}
+
+	docSet := make(map[string]struct{}, len(docTokens))
+	for _, token := range docTokens {
+		docSet[token] = struct{}{}
+	}
+	for _, token := range queryTokens {
+		if _, ok := docSet[token]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func textSearchRank(document, query string) float64 {
+	queryTokens := uniqueTextSearchTokens(query)
+	if len(queryTokens) == 0 {
+		return 0
+	}
+
+	docTokens := textSearchTokens(document)
+	if len(docTokens) == 0 {
+		return 0
+	}
+
+	frequencies := make(map[string]int, len(docTokens))
+	for _, token := range docTokens {
+		frequencies[token] += 1
+	}
+
+	var score float64
+	for _, token := range queryTokens {
+		score += math.Log1p(float64(frequencies[token]))
+	}
+	return score / float64(len(queryTokens))
+}

--- a/internal/minisql/text_search_test.go
+++ b/internal/minisql/text_search_test.go
@@ -1,0 +1,155 @@
+package minisql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTextSearchTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "lowercases and splits on punctuation",
+			input: "MiniSQL, Database-pages!",
+			want:  []string{"minisql", "database", "pages"},
+		},
+		{
+			name:  "keeps digits inside tokens",
+			input: "SQLite FTS5 and JSON2",
+			want:  []string{"sqlite", "fts5", "json2"},
+		},
+		{
+			name:  "drops stop words",
+			input: "the database and the index",
+			want:  []string{"database", "index"},
+		},
+		{
+			name:  "unicode letters are preserved",
+			input: "Café DATABASE",
+			want:  []string{"café", "database"},
+		},
+		{
+			name:  "empty and stop-word-only input returns no tokens",
+			input: "the and of",
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, textSearchTokens(tt.input))
+		})
+	}
+}
+
+func TestUniqueTextSearchTokens(t *testing.T) {
+	t.Parallel()
+
+	got := uniqueTextSearchTokens("MiniSQL minisql database MiniSQL")
+	assert.Equal(t, []string{"minisql", "database"}, got)
+}
+
+func TestTextSearchMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		document string
+		query    string
+		want     bool
+	}{
+		{
+			name:     "matches when all unique query terms are present",
+			document: "MiniSQL is an embedded database with database pages",
+			query:    "minisql database",
+			want:     true,
+		},
+		{
+			name:     "query stop words are ignored",
+			document: "MiniSQL stores pages",
+			query:    "the minisql",
+			want:     true,
+		},
+		{
+			name:     "missing term fails implicit AND",
+			document: "MiniSQL stores pages",
+			query:    "minisql database",
+			want:     false,
+		},
+		{
+			name:     "stop-word-only query does not match",
+			document: "MiniSQL stores pages",
+			query:    "the and of",
+			want:     false,
+		},
+		{
+			name:     "empty document does not match",
+			document: "",
+			query:    "minisql",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, textSearchMatch(tt.document, tt.query))
+		})
+	}
+}
+
+func TestTextSearchRank(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		document string
+		query    string
+		want     float64
+	}{
+		{
+			name:     "log-scaled average term frequency",
+			document: "MiniSQL database database",
+			query:    "minisql database",
+			want:     0.8958797346140275,
+		},
+		{
+			name:     "missing query term contributes zero",
+			document: "MiniSQL database",
+			query:    "minisql postgres",
+			want:     0.34657359027997264,
+		},
+		{
+			name:     "duplicate query tokens are counted once",
+			document: "MiniSQL MiniSQL database",
+			query:    "minisql minisql database",
+			want:     0.8958797346140275,
+		},
+		{
+			name:     "stop-word-only query has zero rank",
+			document: "MiniSQL database",
+			query:    "the and of",
+			want:     0,
+		},
+		{
+			name:     "empty document has zero rank",
+			document: "",
+			query:    "minisql",
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.InDelta(t, tt.want, textSearchRank(tt.document, tt.query), 0.0000000001)
+		})
+	}
+}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -451,7 +451,8 @@ func isBuiltinFunction(name string) bool {
 		"DATE_TRUNC",
 		"EXTRACT", "DATE_PART",
 		"TO_TIMESTAMP",
-		"JSON_EXTRACT", "JSON_VALID", "JSON_TYPE", "JSON_ARRAY_LENGTH":
+		"JSON_EXTRACT", "JSON_VALID", "JSON_TYPE", "JSON_ARRAY_LENGTH",
+		"MATCH", "TS_RANK":
 		return true
 	}
 	return false

--- a/internal/parser/full_text_test.go
+++ b/internal/parser/full_text_test.go
@@ -1,0 +1,47 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_FullTextSearchFunctions(t *testing.T) {
+	t.Parallel()
+
+	stmts, err := New().Parse(context.Background(), `
+		SELECT id, ts_rank(body, 'mini database') AS score
+		FROM articles
+		WHERE MATCH(body, 'mini database')
+		ORDER BY score DESC;
+	`)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	require.Len(t, stmt.Fields, 2)
+	assert.Equal(t, minisql.Field{Name: "id"}, stmt.Fields[0])
+	require.NotNil(t, stmt.Fields[1].Expr)
+	assert.Equal(t, "TS_RANK", stmt.Fields[1].Expr.FuncName)
+	assert.Equal(t, "score", stmt.Fields[1].Alias)
+
+	require.Len(t, stmt.Conditions, 1)
+	require.Len(t, stmt.Conditions[0], 1)
+	cond := stmt.Conditions[0][0]
+	assert.Equal(t, minisql.Eq, cond.Operator)
+	assert.Equal(t, minisql.OperandBoolean, cond.Operand2.Type)
+	assert.Equal(t, true, cond.Operand2.Value)
+	require.Equal(t, minisql.OperandExpr, cond.Operand1.Type)
+	matchExpr := cond.Operand1.Value.(*minisql.Expr)
+	assert.Equal(t, "MATCH", matchExpr.FuncName)
+	require.Len(t, matchExpr.Args, 2)
+	assert.Equal(t, "body", matchExpr.Args[0].Column)
+	assert.Equal(t, minisql.NewTextPointer([]byte("mini database")), matchExpr.Args[1].Literal)
+
+	require.Len(t, stmt.OrderBy, 1)
+	assert.Equal(t, minisql.Field{Name: "score"}, stmt.OrderBy[0].Field)
+	assert.Equal(t, minisql.Desc, stmt.OrderBy[0].Direction)
+}

--- a/internal/parser/where.go
+++ b/internal/parser/where.go
@@ -157,6 +157,15 @@ func (p *parserItem) parsePrimaryCondExpr() (*minisql.ConditionNode, error) {
 	return p.parseLeafCondition()
 }
 
+func nextTokenIsConditionOperator(token string) bool {
+	switch strings.ToUpper(token) {
+	case "IS NULL", "IS NOT NULL", "=", "!=", ">", ">=", "<", "<=", "LIKE", "NOT LIKE":
+		return true
+	default:
+		return false
+	}
+}
+
 // parseLeafCondition parses a single WHERE/HAVING condition: field op value.
 // In HAVING clauses the left-side "field" may be a synthetic aggregate result
 // column name such as "SUM(total_paid)" or "COUNT(*)".
@@ -173,6 +182,11 @@ func (p *parserItem) parseLeafCondition() (*minisql.ConditionNode, error) {
 		}
 		cond := minisql.Condition{
 			Operand1: minisql.Operand{Type: minisql.OperandExpr, Value: expr},
+		}
+		if upperIdent == "MATCH" && !nextTokenIsConditionOperator(p.peek()) {
+			cond.Operator = minisql.Eq
+			cond.Operand2 = minisql.Operand{Type: minisql.OperandBoolean, Value: true}
+			return &minisql.ConditionNode{Leaf: &cond}, nil
 		}
 		return p.parseCondOperatorAndRHS(&cond)
 	}


### PR DESCRIPTION
Implemented the initial sequential full-text phase.

What changed:

- Added `MATCH(doc, query)` and `TS_RANK(doc, query)` as built-in SQL functions.
- `WHERE MATCH(body, 'query')` now parses as a boolean predicate, equivalent to `MATCH(...) = true`.
- Added a simple reusable tokenizer in text_search.go: lowercase, split on non-letter/digit, small English stop-word list, no stemming.
- `MATCH` uses implicit AND over unique query tokens.
- `TS_RANK` uses local log-scaled term frequency:
   - sum(log(1 + term_frequency)) / unique_query_terms.
- Added support for `ORDER BY` score where score is a projected output alias like `ts_rank(...) AS score`.