### PR TITLE
feat: add metadata for index access methods

### DIFF
--- a/e2e_tests/index_method_test.go
+++ b/e2e_tests/index_method_test.go
@@ -1,0 +1,50 @@
+package e2etests
+
+func (s *TestSuite) TestIndexMethods_StrictScaffold() {
+	_, err := s.db.Exec(`create table "articles_index_method" (
+		id int8 primary key autoincrement,
+		body text not null,
+		title varchar(100) not null,
+		score int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "events_index_method" (
+		id int8 primary key autoincrement,
+		payload json not null,
+		name varchar(100) not null
+	);`)
+	s.Require().NoError(err)
+
+	s.Run("fulltext index on text validates then fails as not implemented", func() {
+		_, err := s.db.Exec(`create fulltext index "idx_articles_body_fts" on "articles_index_method" (body) with (tokenizer = 'simple');`)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "index method is parsed but not implemented yet")
+		s.Contains(err.Error(), "fulltext indexes")
+	})
+
+	s.Run("fulltext index rejects non-text column before not implemented error", func() {
+		_, err := s.db.Exec(`create fulltext index "idx_articles_score_fts" on "articles_index_method" (score);`)
+		s.Require().Error(err)
+		s.Contains(err.Error(), `full-text index column "score" must be TEXT or VARCHAR`)
+	})
+
+	s.Run("fulltext index rejects unsupported tokenizer", func() {
+		_, err := s.db.Exec(`create fulltext index "idx_articles_body_porter" on "articles_index_method" (body) with (tokenizer = 'porter');`)
+		s.Require().Error(err)
+		s.Contains(err.Error(), `unsupported full-text tokenizer "porter"`)
+	})
+
+	s.Run("inverted index on JSON validates then fails as not implemented", func() {
+		_, err := s.db.Exec(`create inverted index "idx_events_payload_inv" on "events_index_method" (payload);`)
+		s.Require().Error(err)
+		s.Contains(err.Error(), "index method is parsed but not implemented yet")
+		s.Contains(err.Error(), "inverted indexes")
+	})
+
+	s.Run("inverted index rejects non-JSON column before not implemented error", func() {
+		_, err := s.db.Exec(`create inverted index "idx_events_name_inv" on "events_index_method" (name);`)
+		s.Require().Error(err)
+		s.Contains(err.Error(), `inverted index column "name" must be JSON`)
+	})
+}

--- a/internal/minisql/analyze.go
+++ b/internal/minisql/analyze.go
@@ -113,6 +113,9 @@ func (d *Database) Analyze(ctx context.Context, target string) error {
 
 		// 4. Analyze secondary indexes
 		for _, secondaryIdx := range table.SecondaryIndexes {
+			if !secondaryIdx.IsBTree() {
+				continue
+			}
 			if err := d.analyzeIndex(ctx, statsTable, tableName, secondaryIdx.Name, secondaryIdx.Index, false); err != nil {
 				return fmt.Errorf("analyze secondary index %s: %w", secondaryIdx.Name, err)
 			}
@@ -204,7 +207,7 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		}
 		if indexColumns == nil {
 			for _, idx := range table.SecondaryIndexes {
-				if idx.Name == indexName {
+				if idx.IsBTree() && idx.Name == indexName {
 					indexColumns = idx.Columns
 					break
 				}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -21,6 +21,7 @@ var (
 	errIndexDoesNotExist         = errors.New("index does not exist")
 	errIndexAlreadyExists        = errors.New("index already exists")
 	errIndexOnJSONColumn         = errors.New("b-tree index on JSON column is not supported")
+	errIndexMethodUnsupported    = errors.New("index method is parsed but not implemented yet")
 )
 
 // WALConfig bundles the Write-Ahead Log objects that NewDatabase needs.
@@ -844,6 +845,8 @@ func (d *Database) initSecondaryIndex(ctx context.Context, schema Schema) error 
 			WhereCond:     stmt.Conditions,
 			Expression:    stmt.IndexExpression,
 			ExpressionSQL: stmt.IndexExpressionSQL,
+			Tokenizer:     stmt.IndexTokenizer,
+			Method:        stmt.IndexMethod,
 		},
 	}
 
@@ -1358,6 +1361,10 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 		return errIndexAlreadyExists
 	}
 
+	if stmt.IndexMethod != IndexMethodBTree {
+		return fmt.Errorf("%w: %s indexes", errIndexMethodUnsupported, stmt.IndexMethod)
+	}
+
 	// Resolve index columns from the table schema, or build a synthetic column for expression indexes.
 	var indexColumns []Column
 	if stmt.IndexExpression != nil {
@@ -1399,6 +1406,8 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 			WhereCond:     stmt.Conditions,
 			Expression:    stmt.IndexExpression,
 			ExpressionSQL: stmt.IndexExpressionSQL,
+			Tokenizer:     stmt.IndexTokenizer,
+			Method:        stmt.IndexMethod,
 		},
 	}
 	createdIndex, err := d.createSecondaryIndex(ctx, stmt, table, secondaryIndex)

--- a/internal/minisql/integrity_check.go
+++ b/internal/minisql/integrity_check.go
@@ -60,7 +60,7 @@ func (d *Database) IntegrityCheck(ctx context.Context) (IntegrityReport, error) 
 			report = d.walkIndexPages(ctx, report, table.Name, index.Name, index.Columns, true, index.Index.GetRootPageIdx(), livePages)
 		}
 		for _, index := range table.SecondaryIndexes {
-			if index.Index == nil {
+			if !index.IsBTree() || index.Index == nil {
 				continue
 			}
 			report = d.walkIndexPages(ctx, report, table.Name, index.Name, index.Columns, false, index.Index.GetRootPageIdx(), livePages)
@@ -121,7 +121,7 @@ func (d *Database) QuickCheck(ctx context.Context) (IntegrityReport, error) {
 			}
 		}
 		for _, index := range table.SecondaryIndexes {
-			if index.Index != nil {
+			if index.IsBTree() && index.Index != nil {
 				rootPages[index.Index.GetRootPageIdx()] = fmt.Sprintf("index %s", index.Name)
 			}
 		}
@@ -699,7 +699,7 @@ func (d *Database) checkTableIndexConsistency(ctx context.Context, report Integr
 		})
 	}
 	for _, index := range table.SecondaryIndexes {
-		if index.Index == nil {
+		if !index.IsBTree() || index.Index == nil {
 			continue
 		}
 		report = checkIndexConsistency(ctx, report, table, indexConsistencyTarget{

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -337,6 +337,9 @@ func (t *Table) findBestEqualityIndexMatch(group Conditions) *indexMatch {
 		allIndexes = append(allIndexes, idx.IndexInfo)
 	}
 	for _, idx := range t.SecondaryIndexes {
+		if !idx.IsBTree() {
+			continue
+		}
 		allIndexes = append(allIndexes, idx.IndexInfo)
 	}
 

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -271,6 +271,9 @@ func (t *Table) findIndexOnColumns(columnNames []string) *IndexInfo {
 
 	// Check secondary indexes (skip partial indexes — they omit rows)
 	for name, idx := range t.SecondaryIndexes {
+		if !idx.IsBTree() {
+			continue
+		}
 		if idx.WhereClause != "" {
 			continue
 		}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -287,6 +287,41 @@ func (d Direction) String() string {
 	}
 }
 
+// IndexMethod identifies the access method used by a secondary index.
+type IndexMethod int
+
+const (
+	// IndexMethodBTree is the default scalar B+ tree index method.
+	IndexMethodBTree IndexMethod = iota
+	// IndexMethodFullText is reserved for future full-text inverted indexes.
+	IndexMethodFullText
+	// IndexMethodInverted is reserved for future JSON inverted indexes.
+	IndexMethodInverted
+)
+
+func (m IndexMethod) String() string {
+	switch m {
+	case IndexMethodBTree:
+		return "btree"
+	case IndexMethodFullText:
+		return "fulltext"
+	case IndexMethodInverted:
+		return "inverted"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// TextSearchTokenizerSimple is the only supported tokenizer in the initial
+	// full-text search implementation.
+	TextSearchTokenizerSimple = "simple"
+)
+
+func isSupportedIndexTokenizer(tokenizer string) bool {
+	return tokenizer == TextSearchTokenizerSimple
+}
+
 // OrderBy pairs a field with its sort direction for an ORDER BY clause.
 type OrderBy struct {
 	Field     Field
@@ -341,6 +376,7 @@ type Statement struct {
 	IndexName          string
 	IndexWhereClause   string // raw SQL of the partial index predicate (empty = full index)
 	IndexExpressionSQL string // raw SQL of the index expression (empty = column index)
+	IndexTokenizer     string // tokenizer option for full-text indexes
 	Target             string
 	PragmaName         string
 	PragmaValue        string
@@ -362,6 +398,7 @@ type Statement struct {
 	FromSubqueryAlias  string     // alias for the derived table (e.g. "t" in FROM (...) t)
 	CTEs               []CTE      // non-nil for WITH … SELECT statements
 	Kind               StatementKind
+	IndexMethod        IndexMethod
 	ConflictAction     ConflictAction
 	IfNotExists        bool
 	ExplainAnalyze     bool
@@ -450,6 +487,7 @@ func (s Statement) Clone() Statement {
 		IndexWhereClause:   s.IndexWhereClause,
 		IndexExpression:    s.IndexExpression,
 		IndexExpressionSQL: s.IndexExpressionSQL,
+		IndexTokenizer:     s.IndexTokenizer,
 		Target:             s.Target,
 		PragmaName:         s.PragmaName,
 		PragmaValue:        s.PragmaValue,
@@ -470,6 +508,7 @@ func (s Statement) Clone() Statement {
 		Offset:             s.Offset,
 		ReturningFields:    s.ReturningFields,
 		ExplainAnalyze:     s.ExplainAnalyze,
+		IndexMethod:        s.IndexMethod,
 		FromSubqueryAlias:  s.FromSubqueryAlias,
 		ForeignKeys:        s.ForeignKeys, // slice of value structs, safe to share
 	}
@@ -1254,7 +1293,7 @@ func (s Statement) validateCreateIndex(table *Table) error {
 		return errors.New("at least one column is required")
 	}
 
-	if table.HasIndexOnColumns(s.Columns) {
+	if s.IndexMethod == IndexMethodBTree && table.HasIndexOnColumns(s.Columns) {
 		return fmt.Errorf("columns %s can only have one index", columnNames(s.Columns))
 	}
 
@@ -1262,7 +1301,62 @@ func (s Statement) validateCreateIndex(table *Table) error {
 		return fmt.Errorf("index definition too long, maximum length is %d", maximumSchemaSQL)
 	}
 
+	if err := s.validateCreateIndexMethod(table); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (s Statement) validateCreateIndexMethod(table *Table) error {
+	switch s.IndexMethod {
+	case IndexMethodBTree:
+		if s.IndexTokenizer != "" {
+			return errors.New("btree indexes do not support tokenizer options")
+		}
+		return nil
+	case IndexMethodFullText:
+		if s.IndexExpression != nil {
+			return errors.New("full-text indexes do not support expression keys yet")
+		}
+		if len(s.Columns) != 1 {
+			return errors.New("full-text indexes require exactly one column")
+		}
+		if s.IndexTokenizer == "" {
+			return errors.New("full-text indexes require a tokenizer")
+		}
+		if !isSupportedIndexTokenizer(s.IndexTokenizer) {
+			return fmt.Errorf("unsupported full-text tokenizer %q", s.IndexTokenizer)
+		}
+		col, ok := table.ColumnByName(s.Columns[0].Name)
+		if !ok {
+			return fmt.Errorf("column %s does not exist on table %s", s.Columns[0].Name, s.TableName)
+		}
+		if col.Kind != Text && col.Kind != Varchar {
+			return fmt.Errorf("full-text index column %q must be TEXT or VARCHAR", col.Name)
+		}
+		return nil
+	case IndexMethodInverted:
+		if s.IndexExpression != nil {
+			return errors.New("inverted indexes do not support expression keys yet")
+		}
+		if s.IndexTokenizer != "" {
+			return errors.New("inverted indexes do not support tokenizer options")
+		}
+		if len(s.Columns) != 1 {
+			return errors.New("inverted indexes require exactly one column")
+		}
+		col, ok := table.ColumnByName(s.Columns[0].Name)
+		if !ok {
+			return fmt.Errorf("column %s does not exist on table %s", s.Columns[0].Name, s.TableName)
+		}
+		if col.Kind != JSON {
+			return fmt.Errorf("inverted index column %q must be JSON", col.Name)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown index method %s", s.IndexMethod)
+	}
 }
 
 func (s Statement) validateDropIndex() error {
@@ -1861,7 +1955,14 @@ func (s Statement) createTableDDL() string {
 
 func (s Statement) createIndexDDL() string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "create index \"%s\" on \"%s\" (\n", s.IndexName, s.TableName)
+	switch s.IndexMethod {
+	case IndexMethodFullText:
+		fmt.Fprintf(&sb, "create fulltext index \"%s\" on \"%s\" (\n", s.IndexName, s.TableName)
+	case IndexMethodInverted:
+		fmt.Fprintf(&sb, "create inverted index \"%s\" on \"%s\" (\n", s.IndexName, s.TableName)
+	default:
+		fmt.Fprintf(&sb, "create index \"%s\" on \"%s\" (\n", s.IndexName, s.TableName)
+	}
 
 	for i, col := range s.Columns {
 		if s.IndexExpression != nil && i == 0 {
@@ -1876,6 +1977,9 @@ func (s Statement) createIndexDDL() string {
 	}
 
 	sb.WriteString("\n)")
+	if s.IndexTokenizer != "" {
+		fmt.Fprintf(&sb, " with (tokenizer = '%s')", s.IndexTokenizer)
+	}
 	if s.IndexWhereClause != "" {
 		fmt.Fprintf(&sb, " where %s", s.IndexWhereClause)
 	}

--- a/internal/minisql/stmt_test.go
+++ b/internal/minisql/stmt_test.go
@@ -1779,6 +1779,45 @@ func TestStatement_DDL(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("create fulltext index with tokenizer", func(t *testing.T) {
+		stmt := Statement{
+			Kind:           CreateIndex,
+			IndexMethod:    IndexMethodFullText,
+			IndexName:      "idx_articles_body",
+			IndexTokenizer: TextSearchTokenizerSimple,
+			TableName:      "articles",
+			Columns: []Column{
+				{Name: "body"},
+			},
+		}
+
+		expected := `create fulltext index "idx_articles_body" on "articles" (
+	body
+) with (tokenizer = 'simple');`
+
+		actual := stmt.DDL()
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("create inverted index", func(t *testing.T) {
+		stmt := Statement{
+			Kind:        CreateIndex,
+			IndexMethod: IndexMethodInverted,
+			IndexName:   "idx_events_payload",
+			TableName:   "events",
+			Columns: []Column{
+				{Name: "payload"},
+			},
+		}
+
+		expected := `create inverted index "idx_events_payload" on "events" (
+	payload
+);`
+
+		actual := stmt.DDL()
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("create table with single foreign key (default restrict)", func(t *testing.T) {
 		columns := []Column{
 			{Kind: Int8, Size: 8, Name: "id"},

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -232,6 +232,9 @@ func (p *singleTableProvider) GetTable(ctx context.Context, name string) (*Table
 // updates the column-to-IndexInfo cache used by the query planner.
 func (t *Table) SetSecondaryIndex(si SecondaryIndex) {
 	t.SecondaryIndexes[si.Name] = si
+	if !si.IsBTree() {
+		return
+	}
 	if si.Expression != nil {
 		// Expression indexes are looked up by their SQL text, not by column name.
 		t.columnIndexInfoCache[si.ExpressionSQL] = si.IndexInfo
@@ -247,6 +250,10 @@ func (t *Table) RemoveSecondaryIndex(name string) {
 	if !ok {
 		return
 	}
+	if !si.IsBTree() {
+		delete(t.SecondaryIndexes, name)
+		return
+	}
 	if si.Expression != nil {
 		delete(t.columnIndexInfoCache, si.ExpressionSQL)
 	} else {
@@ -259,7 +266,7 @@ func (t *Table) RemoveSecondaryIndex(name string) {
 // structurally equal to expr, or (SecondaryIndex{}, false) if none exists.
 func (t *Table) FindExpressionIndex(expr *Expr) (SecondaryIndex, bool) {
 	for _, si := range t.SecondaryIndexes {
-		if si.Expression != nil && exprEqual(si.Expression, expr) {
+		if si.IsBTree() && si.Expression != nil && exprEqual(si.Expression, expr) {
 			return si, true
 		}
 	}
@@ -274,7 +281,15 @@ func (t *Table) GetRootPageIdx() PageIndex {
 // HasNoIndex reports whether the table has no indexes at all — no primary key,
 // no unique indexes, and no secondary indexes.
 func (t *Table) HasNoIndex() bool {
-	return !t.HasPrimaryKey() && len(t.UniqueIndexes) == 0 && len(t.SecondaryIndexes) == 0
+	if t.HasPrimaryKey() || len(t.UniqueIndexes) > 0 {
+		return false
+	}
+	for _, idx := range t.SecondaryIndexes {
+		if idx.IsBTree() {
+			return false
+		}
+	}
+	return true
 }
 
 // HasPrimaryKey reports whether a primary key index has been defined for the table.
@@ -349,6 +364,9 @@ func (t *Table) IndexByName(name string) (BTreeIndex, bool) {
 		return index.Index, true
 	}
 	if index, ok := t.SecondaryIndexes[name]; ok {
+		if !index.IsBTree() {
+			return nil, false
+		}
 		return index.Index, true
 	}
 	return nil, false

--- a/internal/minisql/table_primary_key.go
+++ b/internal/minisql/table_primary_key.go
@@ -17,9 +17,16 @@ type IndexInfo struct {
 	Expression    *Expr     // nil = column index; non-nil = expression index
 	WhereCond     OneOrMore // parsed DNF form of the partial index predicate (nil = full index)
 	Name          string
-	ExpressionSQL string   // raw SQL of the expression (empty = column index)
-	WhereClause   string   // raw SQL of the partial index predicate (empty = full index)
+	ExpressionSQL string // raw SQL of the expression (empty = column index)
+	WhereClause   string // raw SQL of the partial index predicate (empty = full index)
+	Tokenizer     string // tokenizer option for full-text indexes
 	Columns       []Column
+	Method        IndexMethod
+}
+
+// IsBTree reports whether this index uses the scalar B+ tree access method.
+func (ii IndexInfo) IsBTree() bool {
+	return ii.Method == IndexMethodBTree
 }
 
 // WhereCondColumns returns the names of columns referenced in the partial index WHERE predicate.

--- a/internal/parser/index.go
+++ b/internal/parser/index.go
@@ -84,6 +84,16 @@ func (p *parserItem) doParseCreateIndex() error {
 			p.step = stepCreateIndexColumn
 			return nil
 		}
+		p.step = stepCreateIndexWithOrWhereOrEnd
+	case stepCreateIndexWithOrWhereOrEnd:
+		token := strings.ToUpper(p.peek())
+		if token != "WITH" {
+			p.step = stepCreateIndexWhereOrEnd
+			return nil
+		}
+		if err := p.parseCreateIndexWithOptions(); err != nil {
+			return err
+		}
 		p.step = stepCreateIndexWhereOrEnd
 	case stepCreateIndexWhereOrEnd:
 		token := strings.ToUpper(p.peek())
@@ -102,6 +112,51 @@ func (p *parserItem) doParseCreateIndex() error {
 		p.step = stepStatementEnd
 	}
 	return nil
+}
+
+func (p *parserItem) parseCreateIndexWithOptions() error {
+	p.pop() // consume WITH
+	if p.peek() != "(" {
+		return p.errorf("at CREATE INDEX: expected opening parens after WITH")
+	}
+	p.pop()
+
+	for {
+		optionName := strings.ToUpper(p.peek())
+		if optionName == "" || optionName == ")" {
+			return p.errorf("at CREATE INDEX: expected WITH option name")
+		}
+		p.pop()
+
+		if p.peek() != "=" {
+			return p.errorf("at CREATE INDEX: expected '=' after WITH option name")
+		}
+		p.pop()
+
+		optionValue := p.peek()
+		if optionValue == "" {
+			return p.errorf("at CREATE INDEX: expected WITH option value")
+		}
+		p.pop()
+
+		switch optionName {
+		case "TOKENIZER":
+			p.IndexTokenizer = strings.ToLower(optionValue)
+		default:
+			return p.errorf("at CREATE INDEX: unknown WITH option %q", optionName)
+		}
+
+		switch p.peek() {
+		case ",":
+			p.pop()
+			continue
+		case ")":
+			p.pop()
+			return nil
+		default:
+			return p.errorf("at CREATE INDEX: expected comma or closing parens after WITH option")
+		}
+	}
 }
 
 func (p *parserItem) doParseDropIndex() error {

--- a/internal/parser/index_test.go
+++ b/internal/parser/index_test.go
@@ -42,9 +42,10 @@ func TestParse_CreateIndex(t *testing.T) {
 			"CREATE INDEX foo ON bar (qux);",
 			[]minisql.Statement{
 				{
-					Kind:      minisql.CreateIndex,
-					IndexName: "foo",
-					TableName: "bar",
+					Kind:        minisql.CreateIndex,
+					IndexMethod: minisql.IndexMethodBTree,
+					IndexName:   "foo",
+					TableName:   "bar",
 					Columns: []minisql.Column{
 						{
 							Name: "qux",
@@ -59,9 +60,10 @@ func TestParse_CreateIndex(t *testing.T) {
 			"CREATE INDEX IF NOT EXISTS foo ON bar (qux);",
 			[]minisql.Statement{
 				{
-					Kind:      minisql.CreateIndex,
-					IndexName: "foo",
-					TableName: "bar",
+					Kind:        minisql.CreateIndex,
+					IndexMethod: minisql.IndexMethodBTree,
+					IndexName:   "foo",
+					TableName:   "bar",
 					Columns: []minisql.Column{
 						{
 							Name: "qux",
@@ -77,9 +79,10 @@ func TestParse_CreateIndex(t *testing.T) {
 			"CREATE INDEX foo ON bar (qux, baz);",
 			[]minisql.Statement{
 				{
-					Kind:      minisql.CreateIndex,
-					IndexName: "foo",
-					TableName: "bar",
+					Kind:        minisql.CreateIndex,
+					IndexMethod: minisql.IndexMethodBTree,
+					IndexName:   "foo",
+					TableName:   "bar",
 					Columns: []minisql.Column{
 						{
 							Name: "qux",
@@ -98,6 +101,7 @@ func TestParse_CreateIndex(t *testing.T) {
 			[]minisql.Statement{
 				{
 					Kind:             minisql.CreateIndex,
+					IndexMethod:      minisql.IndexMethodBTree,
 					IndexName:        "idx_active",
 					TableName:        "orders",
 					IndexWhereClause: "status = 'active'",
@@ -122,10 +126,55 @@ func TestParse_CreateIndex(t *testing.T) {
 			"CREATE INDEX idx_all ON orders (amount);",
 			[]minisql.Statement{
 				{
-					Kind:      minisql.CreateIndex,
-					IndexName: "idx_all",
-					TableName: "orders",
-					Columns:   []minisql.Column{{Name: "amount"}},
+					Kind:        minisql.CreateIndex,
+					IndexMethod: minisql.IndexMethodBTree,
+					IndexName:   "idx_all",
+					TableName:   "orders",
+					Columns:     []minisql.Column{{Name: "amount"}},
+				},
+			},
+			nil,
+		},
+		{
+			"CREATE FULLTEXT INDEX works",
+			"CREATE FULLTEXT INDEX idx_body ON articles (body);",
+			[]minisql.Statement{
+				{
+					Kind:           minisql.CreateIndex,
+					IndexMethod:    minisql.IndexMethodFullText,
+					IndexTokenizer: minisql.TextSearchTokenizerSimple,
+					IndexName:      "idx_body",
+					TableName:      "articles",
+					Columns:        []minisql.Column{{Name: "body"}},
+				},
+			},
+			nil,
+		},
+		{
+			"CREATE FULLTEXT INDEX with tokenizer option works",
+			"CREATE FULLTEXT INDEX idx_body ON articles (body) WITH (tokenizer = 'simple');",
+			[]minisql.Statement{
+				{
+					Kind:           minisql.CreateIndex,
+					IndexMethod:    minisql.IndexMethodFullText,
+					IndexTokenizer: minisql.TextSearchTokenizerSimple,
+					IndexName:      "idx_body",
+					TableName:      "articles",
+					Columns:        []minisql.Column{{Name: "body"}},
+				},
+			},
+			nil,
+		},
+		{
+			"CREATE INVERTED INDEX works",
+			"CREATE INVERTED INDEX idx_payload ON events (payload);",
+			[]minisql.Statement{
+				{
+					Kind:        minisql.CreateIndex,
+					IndexMethod: minisql.IndexMethodInverted,
+					IndexName:   "idx_payload",
+					TableName:   "events",
+					Columns:     []minisql.Column{{Name: "payload"}},
 				},
 			},
 			nil,
@@ -244,6 +293,7 @@ func TestParse_CreateExpressionIndex(t *testing.T) {
 
 			stmt := stmts[0]
 			assert.Equal(t, minisql.CreateIndex, stmt.Kind)
+			assert.Equal(t, minisql.IndexMethodBTree, stmt.IndexMethod)
 			assert.Equal(t, tt.expressionSQL, stmt.IndexExpressionSQL)
 			require.NotNil(t, stmt.IndexExpression)
 			assert.Equal(t, []minisql.Column{{Name: "__expr__"}}, stmt.Columns)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,7 +37,7 @@ var reservedWords = []string{
 	"BOOLEAN", "INT4", "INT8", "REAL", "DOUBLE", "TEXT", "VARCHAR(", "TIMESTAMP", "JSON", "UUID",
 	// statement types
 	"EXPLAIN ANALYZE", "EXPLAIN",
-	"CREATE TABLE", "DROP TABLE", "CREATE INDEX", "DROP INDEX",
+	"CREATE TABLE", "DROP TABLE", "CREATE FULLTEXT INDEX", "CREATE INVERTED INDEX", "CREATE INDEX", "DROP INDEX",
 	"SELECT", "INSERT INTO", "VALUES", "UPDATE", "DELETE FROM",
 	// statement other
 	"*", "COUNT(*)", "SUM(", "AVG(", "MIN(", "MAX(", "GROUP BY", "HAVING", "ORDER BY", "LIMIT", "OFFSET",
@@ -100,6 +100,7 @@ const (
 	stepCreateIndexOpeningParens
 	stepCreateIndexColumn
 	stepCreateIndexCommaOrClosingParens
+	stepCreateIndexWithOrWhereOrEnd
 	stepCreateIndexWhereOrEnd
 	stepDropIndexName
 	stepInsertTable
@@ -202,6 +203,18 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 				p.step = stepDropTableName
 			case "CREATE INDEX":
 				p.Kind = minisql.CreateIndex
+				p.IndexMethod = minisql.IndexMethodBTree
+				p.pop()
+				p.step = stepCreateIndexIfNotExists
+			case "CREATE FULLTEXT INDEX":
+				p.Kind = minisql.CreateIndex
+				p.IndexMethod = minisql.IndexMethodFullText
+				p.IndexTokenizer = minisql.TextSearchTokenizerSimple
+				p.pop()
+				p.step = stepCreateIndexIfNotExists
+			case "CREATE INVERTED INDEX":
+				p.Kind = minisql.CreateIndex
+				p.IndexMethod = minisql.IndexMethodInverted
 				p.pop()
 				p.step = stepCreateIndexIfNotExists
 			case "DROP INDEX":
@@ -301,6 +314,7 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 			stepCreateIndexOpeningParens,
 			stepCreateIndexColumn,
 			stepCreateIndexCommaOrClosingParens,
+			stepCreateIndexWithOrWhereOrEnd,
 			stepCreateIndexWhereOrEnd:
 			if err := p.doParseCreateIndex(); err != nil {
 				return statements, err


### PR DESCRIPTION
- Added IndexMethod metadata: `btree`, `fulltext`, `inverted`.
- Added parser support for:
`CREATE FULLTEXT INDEX ...`
`CREATE INVERTED INDEX ...`
`WITH (tokenizer = 'simple')`
- Added tokenizer metadata on statements/index info, with only simple allowed for now.
- Added canonical DDL generation for fulltext/inverted indexes, keeping method/options in the stored SQL shape.
- Added semantic validation:
fulltext indexes require exactly one `TEXT` or `VARCHAR` column
inverted indexes require exactly one `JSON` column
unsupported tokenizers are rejected
tokenizer options are rejected for btree/inverted indexes
- Kept creation strict: valid non-btree index DDL now fails with index method is parsed but not implemented yet, so no fake/no-op index is persisted.
- Added planner/analyze/integrity/table guards so future non-btree secondary indexes won’t be treated as scalar B-tree indexes.