### PR TITLE
feat: implement v1 of full text inverted indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ rows.Scan(&owner)
 | String functions | `UPPER(s)`, `LOWER(s)` — case conversion; `TRIM(s[, chars])`, `LTRIM(s[, chars])`, `RTRIM(s[, chars])` — strip whitespace or custom characters; `LENGTH(s)` — byte length; `SUBSTR(s, start[, len])` — 1-based substring; `REPLACE(s, from, to)` — replace all occurrences; `CONCAT(a, b, ...)` — concatenate (NULLs skipped). All usable in `SELECT`, `UPDATE SET`, and composable with each other and arithmetic |
 | Numeric functions | `ABS(n)` — absolute value (preserves input type); `FLOOR(n)`, `CEIL(n)` — floor/ceiling; `ROUND(n[, d])` — round to `d` decimal places (default 0); `MOD(a, b)` — modulo (integer or float). All usable in `SELECT`, `UPDATE SET`, composable with each other and arithmetic |
 | Date/time functions | `NOW()` — current UTC timestamp; `DATE_TRUNC('unit', ts)` — truncate to `year`/`month`/`week`/`day`/`hour`/`minute`/`second`; `EXTRACT('field', ts)` / `DATE_PART('field', ts)` — extract numeric field (`year`, `month`, `day`, `hour`, `minute`, `second`, `dow`); `TO_TIMESTAMP('str')` — parse timestamp string into a TIMESTAMP value. All usable in `SELECT`, `UPDATE SET`, composable with other expressions |
-| Full-text search functions | `MATCH(doc, query)` and `TS_RANK(doc, query)` provide initial full-text semantics via sequential scans. No full-text index is used yet. |
+| Full-text search functions | `MATCH(doc, query)` and `TS_RANK(doc, query)` provide initial full-text semantics. `CREATE FULLTEXT INDEX` can accelerate literal `MATCH` predicates on one `TEXT`/`VARCHAR` column. |
 | `CASE WHEN` | Searched form: `CASE WHEN cond THEN result … ELSE default END`; simple form: `CASE expr WHEN val THEN result … ELSE default END`. Multiple WHEN clauses, optional ELSE (omitting returns NULL). Usable in `SELECT` (including nested in arithmetic), `UPDATE SET`, supports `IS NULL` / `IS NOT NULL` / all comparison operators in conditions |
 | `UNION` / `UNION ALL` | Combine results of two or more `SELECT` statements. `UNION ALL` concatenates all rows (duplicates kept); `UNION` deduplicates the combined result. Chains of three or more branches supported (e.g. `SELECT … UNION ALL SELECT … UNION SELECT …`). Each branch may have its own `WHERE` clause. |
 | `CAST(expr AS type)` | Standard SQL type coercion. Supported target types: `BOOLEAN`, `INT4`, `INT8`, `REAL`, `DOUBLE`, `TEXT`, `VARCHAR(n)`, `TIMESTAMP`, `JSON`, `UUID`. Follows SQLite semantics: float→int truncates toward zero; text→int/float parses leading digits (non-numeric input → 0). `CAST(x AS JSON)` validates and compacts the value. `CAST(x AS UUID)` parses a UUID string and stores it in binary form. `CAST(uuid_col AS TEXT)` formats the 16-byte value back to a hyphenated lowercase string. NULL propagates. Usable anywhere an expression is valid (e.g. `SELECT CAST(price AS INT8)`, `SELECT CAST(n AS TEXT) AS label`, `SELECT CAST(id AS TEXT) FROM widgets`). |
@@ -628,7 +628,15 @@ rows.Scan(&owner)
 
 #### Full-Text Search Functions
 
-MiniSQL currently supports initial full-text search semantics without a full-text index. Queries using `MATCH` scan candidate rows, tokenize the document and query in memory, and evaluate the match during the normal `WHERE` filter.
+MiniSQL supports initial full-text search semantics with an optional v1 full-text index. Without an index, `MATCH` scans candidate rows, tokenizes the document and query in memory, and evaluates the match during the normal `WHERE` filter.
+
+```sql
+CREATE FULLTEXT INDEX idx_articles_body
+ON articles (body)
+WITH (tokenizer = 'simple');
+```
+
+The v1 index stores one B+ tree entry per unique token, with each token pointing at an ordered posting list of row IDs. It does not store token positions, compress postings, rank from index statistics, or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting the posting lists for all query tokens; dynamic query expressions fall back to the sequential semantics.
 
 | Function | Description |
 |----------|-------------|

--- a/e2e_tests/full_text_test.go
+++ b/e2e_tests/full_text_test.go
@@ -63,3 +63,119 @@ func (s *TestSuite) TestFullTextSearch_SequentialMatchAndRank() {
 		s.Contains(rows[0].Detail, "table=articles")
 	})
 }
+
+func (s *TestSuite) TestFullTextSearch_FullTextIndex() {
+	_, err := s.db.Exec(`create table "articles_fts" (
+		id    int8 primary key autoincrement,
+		title varchar(100) not null,
+		body  text not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "articles_fts" (title, body) values
+		('MiniSQL', 'MiniSQL is a tiny embedded database. MiniSQL stores rows in B tree pages and database pages.'),
+		('Postgres', 'Postgres has a generalized inverted index for full text search.'),
+		('SQLite', 'SQLite has FTS5 tables for full text search.'),
+		('Storage', 'A small database stores data in pages.');`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create fulltext index "idx_articles_fts_body" on "articles_fts" (body) with (tokenizer = 'simple');`)
+	s.Require().NoError(err)
+
+	s.Run("EXPLAIN uses full-text index for literal MATCH query", func() {
+		rows := s.collectExplain(`EXPLAIN SELECT title FROM "articles_fts" WHERE MATCH(body, 'database pages');`)
+		s.Require().NotEmpty(rows)
+		s.Equal("fulltext", rows[0].Operation)
+		s.Contains(rows[0].Detail, "index=idx_articles_fts_body")
+		s.Contains(rows[0].Detail, "keys=[database pages]")
+	})
+
+	s.Run("EXPLAIN ANALYZE executes full-text index scan", func() {
+		rows := s.collectExplain(`EXPLAIN ANALYZE SELECT title FROM "articles_fts" WHERE MATCH(body, 'database pages');`)
+		s.Require().Len(rows, 1)
+		s.Equal("fulltext", rows[0].Operation)
+		s.Contains(rows[0].Detail, "index=idx_articles_fts_body")
+		s.True(rows[0].RowsActual.Valid)
+		s.Equal(int64(2), rows[0].RowsActual.Int64)
+		s.True(rows[0].DurationUS.Valid)
+	})
+
+	s.Run("MATCH results come from posting list intersection", func() {
+		rows, err := s.db.Query(`select title from "articles_fts" where MATCH(body, 'database pages') order by title;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var titles []string
+		for rows.Next() {
+			var title string
+			s.Require().NoError(rows.Scan(&title))
+			titles = append(titles, title)
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal([]string{"MiniSQL", "Storage"}, titles)
+	})
+
+	s.Run("index reloads and passes integrity checks", func() {
+		s.Require().NoError(s.db.Close())
+		s.db = s.reopenDB()
+
+		rows := s.collectExplain(`EXPLAIN SELECT title FROM "articles_fts" WHERE MATCH(body, 'database pages');`)
+		s.Require().NotEmpty(rows)
+		s.Equal("fulltext", rows[0].Operation)
+		s.Contains(rows[0].Detail, "index=idx_articles_fts_body")
+
+		checkRows, err := s.db.Query(`PRAGMA integrity_check;`)
+		s.Require().NoError(err)
+		defer checkRows.Close()
+		s.Require().True(checkRows.Next())
+		var checkName string
+		var status string
+		var tableName, indexName any
+		var message string
+		s.Require().NoError(checkRows.Scan(&checkName, &status, &tableName, &indexName, &message))
+		s.Equal("integrity_check", checkName)
+		s.Equal("ok", status)
+		s.Equal("ok", message)
+		s.Require().NoError(checkRows.Err())
+	})
+
+	s.Run("index maintenance tracks insert update and delete", func() {
+		_, err := s.db.Exec(`insert into "articles_fts" (title, body) values ('New', 'A database search article with fresh tokens.');`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select title from "articles_fts" where MATCH(body, 'fresh tokens');`)
+		s.Require().NoError(err)
+		s.Require().True(rows.Next())
+		var title string
+		s.Require().NoError(rows.Scan(&title))
+		s.Equal("New", title)
+		s.Require().NoError(rows.Err())
+		s.Require().NoError(rows.Close())
+
+		_, err = s.db.Exec(`update "articles_fts" set body = 'Updated document mentions index maintenance.' where title = 'New';`)
+		s.Require().NoError(err)
+
+		rows, err = s.db.Query(`select title from "articles_fts" where MATCH(body, 'fresh tokens');`)
+		s.Require().NoError(err)
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+		s.Require().NoError(rows.Close())
+
+		rows, err = s.db.Query(`select title from "articles_fts" where MATCH(body, 'index maintenance');`)
+		s.Require().NoError(err)
+		s.Require().True(rows.Next())
+		s.Require().NoError(rows.Scan(&title))
+		s.Equal("New", title)
+		s.Require().NoError(rows.Err())
+		s.Require().NoError(rows.Close())
+
+		_, err = s.db.Exec(`delete from "articles_fts" where title = 'New';`)
+		s.Require().NoError(err)
+
+		rows, err = s.db.Query(`select title from "articles_fts" where MATCH(body, 'index maintenance');`)
+		s.Require().NoError(err)
+		defer rows.Close()
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+}

--- a/e2e_tests/index_method_test.go
+++ b/e2e_tests/index_method_test.go
@@ -16,11 +16,9 @@ func (s *TestSuite) TestIndexMethods_StrictScaffold() {
 	);`)
 	s.Require().NoError(err)
 
-	s.Run("fulltext index on text validates then fails as not implemented", func() {
+	s.Run("fulltext index on text is created", func() {
 		_, err := s.db.Exec(`create fulltext index "idx_articles_body_fts" on "articles_index_method" (body) with (tokenizer = 'simple');`)
-		s.Require().Error(err)
-		s.Contains(err.Error(), "index method is parsed but not implemented yet")
-		s.Contains(err.Error(), "fulltext indexes")
+		s.Require().NoError(err)
 	})
 
 	s.Run("fulltext index rejects non-text column before not implemented error", func() {

--- a/internal/minisql/covering_index.go
+++ b/internal/minisql/covering_index.go
@@ -12,7 +12,7 @@ func (p *QueryPlan) markCoveringIndexes(stmt Statement) {
 		return
 	}
 	for i, scan := range p.Scans {
-		if scan.Type == ScanTypeSequential || scan.Type == ScanTypeIndexIntersect {
+		if scan.Type == ScanTypeSequential || scan.Type == ScanTypeIndexIntersect || scan.Type == ScanTypeFullText {
 			continue
 		}
 		if coveringIndexEligible(stmt, scan.IndexColumns) {

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -647,6 +647,18 @@ func (c *Cursor) deleteSecondaryIndexKeys(ctx context.Context, row Row) error {
 	}
 
 	for _, secondaryIndex := range c.Table.SecondaryIndexes {
+		if secondaryIndex.Method == IndexMethodFullText {
+			if ok, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
+				return fmt.Errorf("partial full-text index %s where check: %w", secondaryIndex.Name, err)
+			} else if !ok {
+				continue
+			}
+			if err := c.Table.deleteFullTextIndexKeys(ctx, secondaryIndex, row.Key, row); err != nil {
+				return err
+			}
+			continue
+		}
+
 		// Partial index: row was not in the index if it didn't satisfy the WHERE predicate.
 		if ok, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
 			return fmt.Errorf("partial index %s where check: %w", secondaryIndex.Name, err)

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -850,14 +850,16 @@ func (d *Database) initSecondaryIndex(ctx context.Context, schema Schema) error 
 		},
 	}
 
+	storageColumns := secondaryIndexStorageColumns(secondaryIndex)
+
 	// Create and set BTree index instance
 	tp := NewTransactionalPager(
-		d.factory.ForIndex(secondaryIndex.Columns, false),
+		d.factory.ForIndex(storageColumns, false),
 		d.txManager,
 		table.Name,
 		schema.Name,
 	)
-	btreeIndex, err := table.newBTreeIndex(tp, schema.RootPage, secondaryIndex.Columns, secondaryIndex.Name, false)
+	btreeIndex, err := table.newBTreeIndex(tp, schema.RootPage, storageColumns, secondaryIndex.Name, false)
 	if err != nil {
 		return err
 	}
@@ -1327,7 +1329,7 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 	for _, secondaryIndex := range tableToDelete.SecondaryIndexes {
 
 		txPager := NewTransactionalPager(
-			d.factory.ForIndex(secondaryIndex.Columns, false),
+			d.factory.ForIndex(secondaryIndexStorageColumns(secondaryIndex), false),
 			d.txManager,
 			tableToDelete.Name,
 			secondaryIndex.Name,
@@ -1361,7 +1363,7 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 		return errIndexAlreadyExists
 	}
 
-	if stmt.IndexMethod != IndexMethodBTree {
+	if stmt.IndexMethod == IndexMethodInverted {
 		return fmt.Errorf("%w: %s indexes", errIndexMethodUnsupported, stmt.IndexMethod)
 	}
 
@@ -1380,7 +1382,7 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 			if !ok {
 				return fmt.Errorf("column %s does not exist on table %s", stmtCol.Name, stmt.TableName)
 			}
-			if col.Kind == JSON {
+			if stmt.IndexMethod == IndexMethodBTree && col.Kind == JSON {
 				return fmt.Errorf("%w: column %q on table %q", errIndexOnJSONColumn, col.Name, stmt.TableName)
 			}
 			indexColumns = append(indexColumns, col)
@@ -1450,6 +1452,10 @@ func (d *Database) populateIndex(ctx context.Context, table *Table, secondaryInd
 		}
 
 		switch {
+		case secondaryIndex.Method == IndexMethodFullText:
+			if err := table.insertFullTextIndexKeys(ctx, secondaryIndex, row.Key, row); err != nil {
+				return err
+			}
 		case secondaryIndex.Expression != nil:
 			// Expression index: evaluate expression against the row.
 			key, ok, err := evalExprIndexKey(secondaryIndex.Expression, secondaryIndex.Columns[0], row)
@@ -1553,24 +1559,32 @@ func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {
 		indexColumns = append(indexColumns, indexColumn)
 	}
 
+	secondaryIndex := SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Name:          schema.Name,
+			Columns:       indexColumns,
+			WhereClause:   stmts[0].IndexWhereClause,
+			WhereCond:     stmts[0].Conditions,
+			Expression:    stmts[0].IndexExpression,
+			ExpressionSQL: stmts[0].IndexExpressionSQL,
+			Tokenizer:     stmts[0].IndexTokenizer,
+			Method:        stmts[0].IndexMethod,
+		},
+	}
+	storageColumns := secondaryIndexStorageColumns(secondaryIndex)
+
 	txPager := NewTransactionalPager(
-		d.factory.ForIndex(indexColumns, true),
+		d.factory.ForIndex(storageColumns, false),
 		d.txManager,
 		table.Name,
 		schema.Name,
 	)
 
-	btreeIndex, err := table.newBTreeIndex(txPager, schema.RootPage, indexColumns, schema.Name, false)
+	btreeIndex, err := table.newBTreeIndex(txPager, schema.RootPage, storageColumns, schema.Name, false)
 	if err != nil {
 		return err
 	}
-	secondaryIndex := SecondaryIndex{
-		IndexInfo: IndexInfo{
-			Name:    schema.Name,
-			Columns: indexColumns,
-		},
-		Index: btreeIndex,
-	}
+	secondaryIndex.Index = btreeIndex
 
 	if err := d.deleteSchema(ctx, schema.Type, schema.Name); err != nil {
 		return err
@@ -1660,8 +1674,9 @@ func (d *Database) createUniqueIndex(ctx context.Context, table *Table, uniqueIn
 func (d *Database) createSecondaryIndex(ctx context.Context, stmt Statement, table *Table, secondaryIndex SecondaryIndex) (BTreeIndex, error) {
 	d.logger.Sugar().With("column", secondaryIndex.Columns[0].Name).Debug("creating secondary index")
 
+	storageColumns := secondaryIndexStorageColumns(secondaryIndex)
 	txPager := NewTransactionalPager(
-		d.factory.ForIndex(secondaryIndex.Columns, false),
+		d.factory.ForIndex(storageColumns, false),
 		d.txManager,
 		table.Name,
 		secondaryIndex.Name,
@@ -1672,7 +1687,7 @@ func (d *Database) createSecondaryIndex(ctx context.Context, stmt Statement, tab
 		return nil, err
 	}
 
-	createdIndex, err := table.createBTreeIndex(txPager, freePage, secondaryIndex.Columns, secondaryIndex.Name, false)
+	createdIndex, err := table.createBTreeIndex(txPager, freePage, storageColumns, secondaryIndex.Name, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -428,6 +428,8 @@ func (t *Table) executeExplainScan(ctx context.Context, plan QueryPlan, scan Sca
 		return t.sequentialScan(ctx, scan, selectedFields, out)
 	case ScanTypeIndexIntersect:
 		return t.indexIntersectScan(ctx, scan, selectedFields, out)
+	case ScanTypeFullText:
+		return t.fullTextIndexScan(ctx, scan, selectedFields, out)
 	default:
 		return fmt.Errorf("unhandled scan type in EXPLAIN ANALYZE: %d", scan.Type)
 	}
@@ -622,6 +624,10 @@ func estimateScanRows(table *Table, scan Scan) OptionalValue {
 			if estimated >= 0 {
 				return OptionalValue{Valid: true, Value: estimated}
 			}
+		}
+	case ScanTypeFullText:
+		if len(scan.IndexKeys) > 0 {
+			return OptionalValue{Valid: true, Value: int64(len(scan.IndexKeys))}
 		}
 	case ScanTypeIndexIntersect:
 		// Estimate as the minimum across sub-scans (intersection can only shrink the result).

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -1,0 +1,482 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTable_FullTextIndexScanAndMaintenance(t *testing.T) {
+	pager, dbFile := initTest(t)
+	ctx := context.Background()
+	mockParser := new(MockParser)
+	database, err := NewDatabase(ctx, testLogger, dbFile.Name(), mockParser, pager, pager, nil)
+	require.NoError(t, err)
+
+	const tableName = "articles"
+	columns := []Column{
+		{Kind: Int8, Size: 8, Name: "id"},
+		{Kind: Varchar, Size: MaxInlineVarchar, Name: "title"},
+		{Kind: Text, Size: 0, Name: "body"},
+	}
+	createStmt := Statement{
+		Kind:      CreateTable,
+		TableName: tableName,
+		Columns:   columns,
+	}
+	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := database.ExecuteStatement(ctx, createStmt)
+		return err
+	}))
+
+	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		for _, row := range [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("MiniSQL"))}, {Valid: true, Value: NewTextPointer([]byte("MiniSQL stores rows in B tree pages and database pages."))}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("Postgres"))}, {Valid: true, Value: NewTextPointer([]byte("Postgres has generalized inverted indexes."))}},
+			{{Valid: true, Value: int64(3)}, {Valid: true, Value: NewTextPointer([]byte("Storage"))}, {Valid: true, Value: NewTextPointer([]byte("A small database stores data in pages."))}},
+		} {
+			_, err := database.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: tableName,
+				Columns:   columns,
+				Fields:    fieldsFromColumns(columns...),
+				Inserts:   [][]OptionalValue{row},
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	fullTextIndexStmt := Statement{
+		Kind:           CreateIndex,
+		TableName:      tableName,
+		IndexName:      "idx_articles_body_fts",
+		Columns:        []Column{{Name: "body"}},
+		IndexMethod:    IndexMethodFullText,
+		IndexTokenizer: TextSearchTokenizerSimple,
+	}
+	mockParser.On("Parse", mock.Anything, createStmt.DDL()).Return([]Statement{createStmt}, nil).Once()
+	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := database.ExecuteStatement(ctx, fullTextIndexStmt)
+		return err
+	}))
+
+	table, ok := database.GetTable(ctx, tableName)
+	require.True(t, ok)
+
+	matchDatabasePages := fullTextMatchCondition("body", "database pages")
+	plan, err := table.PlanQuery(ctx, Statement{
+		Kind:       Select,
+		TableName:  tableName,
+		Columns:    columns,
+		Fields:     []Field{{Name: "title"}},
+		Conditions: OneOrMore{{matchDatabasePages}},
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Scans, 1)
+	assert.Equal(t, ScanTypeFullText, plan.Scans[0].Type)
+	assert.Equal(t, []any{"database", "pages"}, plan.Scans[0].IndexKeys)
+
+	titles := selectTitlesWithCondition(t, ctx, database, table, matchDatabasePages)
+	assert.Equal(t, []string{"MiniSQL", "Storage"}, titles)
+
+	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := table.Update(ctx, Statement{
+			Kind:    Update,
+			Columns: columns,
+			Updates: map[string]OptionalValue{
+				"body": {Valid: true, Value: NewTextPointer([]byte("Fresh token document about index maintenance."))},
+			},
+			Conditions: OneOrMore{{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "title"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandQuotedString, Value: NewTextPointer([]byte("Postgres"))},
+				},
+			}},
+		})
+		return err
+	}))
+
+	assert.Equal(t, []string{"Postgres"}, selectTitlesWithCondition(t, ctx, database, table, fullTextMatchCondition("body", "fresh token")))
+	assert.Empty(t, selectTitlesWithCondition(t, ctx, database, table, fullTextMatchCondition("body", "generalized inverted")))
+
+	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := table.Delete(ctx, Statement{
+			Kind:       Delete,
+			Columns:    columns,
+			Conditions: OneOrMore{{fullTextMatchCondition("body", "fresh token")}},
+		})
+		return err
+	}))
+	assert.Empty(t, selectTitlesWithCondition(t, ctx, database, table, fullTextMatchCondition("body", "fresh token")))
+
+	mockParser.AssertExpectations(t)
+}
+
+func TestFullTextIndexHelpers(t *testing.T) {
+	t.Parallel()
+
+	sourceColumn := Column{Name: "body", Kind: Text}
+	storageColumns := secondaryIndexStorageColumns(SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Method:  IndexMethodFullText,
+			Columns: []Column{sourceColumn},
+		},
+	})
+	require.Len(t, storageColumns, 1)
+	assert.Equal(t, "__fts_token__", storageColumns[0].Name)
+	assert.Equal(t, Varchar, storageColumns[0].Kind)
+
+	plainColumns := []Column{{Name: "title", Kind: Varchar, Size: MaxInlineVarchar}}
+	assert.Equal(t, plainColumns, secondaryIndexStorageColumns(SecondaryIndex{
+		IndexInfo: IndexInfo{Method: IndexMethodBTree, Columns: plainColumns},
+	}))
+
+	row := Row{
+		Columns: []Column{sourceColumn},
+		Values:  []OptionalValue{{Valid: true, Value: NewTextPointer([]byte("MiniSQL minisql database and pages"))}},
+	}
+	tokens, err := fullTextTokensForRow(SecondaryIndex{
+		IndexInfo: IndexInfo{Name: "idx_body", Columns: []Column{sourceColumn}},
+	}, row)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"minisql", "database", "pages"}, tokens)
+
+	_, err = fullTextTokensForRow(SecondaryIndex{
+		IndexInfo: IndexInfo{Name: "idx_bad", Columns: []Column{sourceColumn, {Name: "title", Kind: Varchar}}},
+	}, row)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires exactly one source column")
+}
+
+func TestFullTextIndexKeyMaintenanceHelpers(t *testing.T) {
+	t.Parallel()
+
+	bodyColumn := Column{Name: "body", Kind: Text}
+	index := &fakeFullTextIndex{rowIDs: make(map[any][]RowID)}
+	secondaryIndex := SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Name:    "idx_body_fts",
+			Method:  IndexMethodFullText,
+			Columns: []Column{bodyColumn},
+		},
+		Index: index,
+	}
+	table := NewTable(testLogger, nil, nil, "articles", []Column{bodyColumn}, 0, nil)
+	ctx := context.Background()
+
+	oldRow := Row{
+		Key:     7,
+		Columns: []Column{bodyColumn},
+		Values:  []OptionalValue{{Valid: true, Value: NewTextPointer([]byte("old token value"))}},
+	}
+	newRow := Row{
+		Key:     7,
+		Columns: []Column{bodyColumn},
+		Values:  []OptionalValue{{Valid: true, Value: NewTextPointer([]byte("new token value"))}},
+	}
+
+	require.NoError(t, table.insertFullTextIndexKeys(ctx, secondaryIndex, newRow.Key, newRow))
+	assert.Contains(t, index.inserted, "new")
+	assert.Contains(t, index.inserted, "token")
+	assert.Contains(t, index.inserted, "value")
+
+	require.NoError(t, table.updateFullTextIndexKeys(ctx, secondaryIndex, oldRow, newRow))
+	assert.Contains(t, index.deleted, "old")
+	assert.Contains(t, index.inserted, "new")
+
+	require.NoError(t, table.deleteFullTextIndexKeys(ctx, secondaryIndex, newRow.Key, newRow))
+	assert.Contains(t, index.deleted, "new")
+}
+
+func TestFullTextIndexScanMissingIndex(t *testing.T) {
+	t.Parallel()
+
+	table := NewTable(testLogger, nil, nil, "articles", []Column{{Name: "body", Kind: Text}}, 0, nil)
+	err := table.fullTextIndexScan(context.Background(), Scan{
+		Type:      ScanTypeFullText,
+		IndexName: "missing",
+		IndexKeys: []any{"database"},
+	}, nil, func(Row) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no index found for full-text scan")
+}
+
+func TestIndexMethodStringAndTokenizer(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "btree", IndexMethodBTree.String())
+	assert.Equal(t, "fulltext", IndexMethodFullText.String())
+	assert.Equal(t, "inverted", IndexMethodInverted.String())
+	assert.Equal(t, "unknown", IndexMethod(99).String())
+	assert.True(t, isSupportedIndexTokenizer(TextSearchTokenizerSimple))
+	assert.False(t, isSupportedIndexTokenizer("porter"))
+}
+
+func TestStatement_ValidateCreateIndexMethods(t *testing.T) {
+	t.Parallel()
+
+	table := NewTable(testLogger, nil, nil, "docs", []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "body", Kind: Text},
+		{Name: "title", Kind: Varchar, Size: MaxInlineVarchar},
+		{Name: "payload", Kind: JSON},
+	}, 0, nil)
+
+	cases := []struct {
+		stmt    Statement
+		name    string
+		wantErr string
+	}{
+		{
+			name: "btree rejects tokenizer",
+			stmt: Statement{
+				IndexMethod:    IndexMethodBTree,
+				Columns:        []Column{{Name: "title"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+			},
+			wantErr: "btree indexes do not support tokenizer options",
+		},
+		{
+			name: "fulltext rejects expression",
+			stmt: Statement{
+				IndexMethod:    IndexMethodFullText,
+				Columns:        []Column{{Name: "body"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+				IndexExpression: &Expr{
+					Column: "body",
+				},
+			},
+			wantErr: "full-text indexes do not support expression keys yet",
+		},
+		{
+			name: "fulltext rejects multiple columns",
+			stmt: Statement{
+				IndexMethod:    IndexMethodFullText,
+				Columns:        []Column{{Name: "body"}, {Name: "title"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+			},
+			wantErr: "full-text indexes require exactly one column",
+		},
+		{
+			name: "fulltext requires tokenizer",
+			stmt: Statement{
+				IndexMethod: IndexMethodFullText,
+				Columns:     []Column{{Name: "body"}},
+			},
+			wantErr: "full-text indexes require a tokenizer",
+		},
+		{
+			name: "fulltext rejects unsupported tokenizer",
+			stmt: Statement{
+				IndexMethod:    IndexMethodFullText,
+				Columns:        []Column{{Name: "body"}},
+				IndexTokenizer: "porter",
+			},
+			wantErr: `unsupported full-text tokenizer "porter"`,
+		},
+		{
+			name: "fulltext rejects missing column",
+			stmt: Statement{
+				IndexMethod:    IndexMethodFullText,
+				Columns:        []Column{{Name: "missing"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+				TableName:      "docs",
+			},
+			wantErr: "column missing does not exist on table docs",
+		},
+		{
+			name: "fulltext rejects non text column",
+			stmt: Statement{
+				IndexMethod:    IndexMethodFullText,
+				Columns:        []Column{{Name: "id"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+			},
+			wantErr: `full-text index column "id" must be TEXT or VARCHAR`,
+		},
+		{
+			name: "inverted rejects expression",
+			stmt: Statement{
+				IndexMethod:     IndexMethodInverted,
+				Columns:         []Column{{Name: "payload"}},
+				IndexExpression: &Expr{Column: "payload"},
+			},
+			wantErr: "inverted indexes do not support expression keys yet",
+		},
+		{
+			name: "inverted rejects tokenizer",
+			stmt: Statement{
+				IndexMethod:    IndexMethodInverted,
+				Columns:        []Column{{Name: "payload"}},
+				IndexTokenizer: TextSearchTokenizerSimple,
+			},
+			wantErr: "inverted indexes do not support tokenizer options",
+		},
+		{
+			name: "inverted rejects multiple columns",
+			stmt: Statement{
+				IndexMethod: IndexMethodInverted,
+				Columns:     []Column{{Name: "payload"}, {Name: "title"}},
+			},
+			wantErr: "inverted indexes require exactly one column",
+		},
+		{
+			name: "inverted rejects missing column",
+			stmt: Statement{
+				IndexMethod: IndexMethodInverted,
+				Columns:     []Column{{Name: "missing"}},
+				TableName:   "docs",
+			},
+			wantErr: "column missing does not exist on table docs",
+		},
+		{
+			name: "inverted rejects non json column",
+			stmt: Statement{
+				IndexMethod: IndexMethodInverted,
+				Columns:     []Column{{Name: "title"}},
+			},
+			wantErr: `inverted index column "title" must be JSON`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.stmt.validateCreateIndexMethod(table)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	require.NoError(t, (Statement{
+		IndexMethod:    IndexMethodFullText,
+		Columns:        []Column{{Name: "body"}},
+		IndexTokenizer: TextSearchTokenizerSimple,
+	}).validateCreateIndexMethod(table))
+	require.NoError(t, (Statement{
+		IndexMethod: IndexMethodInverted,
+		Columns:     []Column{{Name: "payload"}},
+	}).validateCreateIndexMethod(table))
+}
+
+func selectTitlesWithCondition(t *testing.T, ctx context.Context, database *Database, table *Table, cond Condition) []string {
+	t.Helper()
+
+	var titles []string
+	err := database.txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		result, err := table.Select(ctx, Statement{
+			Kind:       Select,
+			TableName:  table.Name,
+			Columns:    table.Columns,
+			Fields:     []Field{{Name: "title"}},
+			Conditions: OneOrMore{{cond}},
+		})
+		if err != nil {
+			return err
+		}
+		for result.Rows.Next(ctx) {
+			row := result.Rows.Row()
+			value, ok := row.GetValue("title")
+			if !ok || !value.Valid {
+				continue
+			}
+			title, ok := toStringVal(value.Value)
+			if ok {
+				titles = append(titles, title)
+			}
+		}
+		return result.Rows.Err()
+	})
+	require.NoError(t, err)
+	return titles
+}
+
+func fullTextMatchCondition(columnName, query string) Condition {
+	return Condition{
+		Operand1: Operand{
+			Type: OperandExpr,
+			Value: &Expr{
+				FuncName: "MATCH",
+				Args: []*Expr{
+					{Column: columnName},
+					{Literal: NewTextPointer([]byte(query))},
+				},
+			},
+		},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandBoolean, Value: true},
+	}
+}
+
+type fakeFullTextIndex struct {
+	rowIDs   map[any][]RowID
+	inserted []string
+	deleted  []string
+}
+
+func (f *fakeFullTextIndex) GetRootPageIdx() PageIndex {
+	return 0
+}
+
+func (f *fakeFullTextIndex) FindRowIDs(_ context.Context, key any) ([]RowID, error) {
+	ids, ok := f.rowIDs[key]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return ids, nil
+}
+
+func (f *fakeFullTextIndex) VisitRowIDs(_ context.Context, key any, fn func(RowID) error) error {
+	ids, ok := f.rowIDs[key]
+	if !ok {
+		return ErrNotFound
+	}
+	for _, id := range ids {
+		if err := fn(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeFullTextIndex) SeekLastKey(context.Context, PageIndex) (any, error) {
+	return nil, ErrNotFound
+}
+
+func (f *fakeFullTextIndex) Insert(_ context.Context, key any, rowID RowID) error {
+	f.inserted = append(f.inserted, key.(string))
+	f.rowIDs[key] = append(f.rowIDs[key], rowID)
+	return nil
+}
+
+func (f *fakeFullTextIndex) Delete(_ context.Context, key any, rowID RowID) error {
+	f.deleted = append(f.deleted, key.(string))
+	ids := f.rowIDs[key]
+	for i, id := range ids {
+		if id == rowID {
+			f.rowIDs[key] = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeFullTextIndex) ScanAll(context.Context, bool, indexScanner) error {
+	return nil
+}
+
+func (f *fakeFullTextIndex) ScanRange(context.Context, RangeCondition, bool, indexScanner) error {
+	return nil
+}
+
+func (f *fakeFullTextIndex) BFS(context.Context, indexCallback) error {
+	return nil
+}

--- a/internal/minisql/integrity_check.go
+++ b/internal/minisql/integrity_check.go
@@ -60,10 +60,10 @@ func (d *Database) IntegrityCheck(ctx context.Context) (IntegrityReport, error) 
 			report = d.walkIndexPages(ctx, report, table.Name, index.Name, index.Columns, true, index.Index.GetRootPageIdx(), livePages)
 		}
 		for _, index := range table.SecondaryIndexes {
-			if !index.IsBTree() || index.Index == nil {
+			if index.Index == nil {
 				continue
 			}
-			report = d.walkIndexPages(ctx, report, table.Name, index.Name, index.Columns, false, index.Index.GetRootPageIdx(), livePages)
+			report = d.walkIndexPages(ctx, report, table.Name, index.Name, secondaryIndexStorageColumns(index), false, index.Index.GetRootPageIdx(), livePages)
 		}
 	}
 
@@ -121,7 +121,7 @@ func (d *Database) QuickCheck(ctx context.Context) (IntegrityReport, error) {
 			}
 		}
 		for _, index := range table.SecondaryIndexes {
-			if index.IsBTree() && index.Index != nil {
+			if index.Index != nil {
 				rootPages[index.Index.GetRootPageIdx()] = fmt.Sprintf("index %s", index.Name)
 			}
 		}

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -27,6 +27,8 @@ const (
 	// memory, then fetches only the surviving rows.  Used for AND conditions where two or
 	// more independent indexes are available.
 	ScanTypeIndexIntersect
+	// ScanTypeFullText runs an inverted full-text index lookup for MATCH predicates.
+	ScanTypeFullText
 )
 
 func (st ScanType) String() string {
@@ -45,6 +47,8 @@ func (st ScanType) String() string {
 		return "index_last"
 	case ScanTypeIndexIntersect:
 		return "index_intersect"
+	case ScanTypeFullText:
+		return "fulltext"
 	default:
 		return "unknown"
 	}
@@ -233,6 +237,13 @@ func (t *Table) PlanQuery(ctx context.Context, stmt Statement) (QueryPlan, error
 		return plan.optimizeOrdering(t, stmt.Conditions), nil
 	}
 
+	if fullTextScan, ok := t.tryFullTextIndexScan(stmt.Conditions); ok {
+		plan.Scans = []Scan{fullTextScan}
+		result := plan.optimizeOrdering(t, stmt.Conditions)
+		result.markCoveringIndexes(stmt)
+		return result, nil
+	}
+
 	// Check if we can do an index scans
 	if err := plan.setIndexScans(t, stmt.Conditions); err != nil {
 		return QueryPlan{}, err
@@ -409,6 +420,98 @@ func (t *Table) findBestEqualityIndexMatch(group Conditions) *indexMatch {
 	}
 
 	return bestMatch
+}
+
+func (t *Table) tryFullTextIndexScan(filters OneOrMore) (Scan, bool) {
+	if len(filters) != 1 {
+		return Scan{}, false
+	}
+
+	var matchCondIdx = -1
+	var matchExpr *Expr
+	for i, cond := range filters[0] {
+		if cond.Operator != Eq || cond.Operand2.Type != OperandBoolean || cond.Operand2.Value != true {
+			continue
+		}
+		if cond.Operand1.Type != OperandExpr {
+			continue
+		}
+		expr, ok := cond.Operand1.Value.(*Expr)
+		if !ok || expr.FuncName != "MATCH" || len(expr.Args) != 2 {
+			continue
+		}
+		matchCondIdx = i
+		matchExpr = expr
+		break
+	}
+	if matchExpr == nil {
+		return Scan{}, false
+	}
+
+	columnName := matchExpr.Args[0].Column
+	if columnName == "" {
+		return Scan{}, false
+	}
+	query, ok := literalText(matchExpr.Args[1])
+	if !ok {
+		return Scan{}, false
+	}
+	tokens := uniqueTextSearchTokens(query)
+	if len(tokens) == 0 {
+		return Scan{}, false
+	}
+
+	var matchedIndex SecondaryIndex
+	foundIndex := false
+	for _, idx := range t.SecondaryIndexes {
+		if idx.Method != IndexMethodFullText || len(idx.Columns) != 1 {
+			continue
+		}
+		if idx.Columns[0].Name == columnName {
+			matchedIndex = idx
+			foundIndex = true
+			break
+		}
+	}
+	if !foundIndex || !partialIndexImplied(matchedIndex.WhereCond, filters[0]) {
+		return Scan{}, false
+	}
+
+	remaining := make(Conditions, 0, len(filters[0]))
+	for i, cond := range filters[0] {
+		if i == matchCondIdx {
+			continue
+		}
+		remaining = append(remaining, cond)
+	}
+	scanFilters := OneOrMore{remaining}
+	if len(remaining) == 0 {
+		scanFilters = nil
+	}
+
+	indexKeys := make([]any, len(tokens))
+	for i, token := range tokens {
+		indexKeys[i] = token
+	}
+	return Scan{
+		TableName:    t.Name,
+		Type:         ScanTypeFullText,
+		IndexName:    matchedIndex.Name,
+		IndexColumns: []Column{fullTextTokenColumn()},
+		IndexKeys:    indexKeys,
+		Filters:      scanFilters,
+	}, true
+}
+
+func literalText(expr *Expr) (string, bool) {
+	if expr == nil {
+		return "", false
+	}
+	tp, ok := expr.Literal.(TextPointer)
+	if !ok {
+		return "", false
+	}
+	return tp.String(), true
 }
 
 // tryMatchIndex attempts to match an index against the conditions in a group.
@@ -1208,6 +1311,8 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, true)
 		case ScanTypeIndexIntersect:
 			return t.indexIntersectScan(ctx, p.Scans[0], selectedFields, out)
+		case ScanTypeFullText:
+			return t.fullTextIndexScan(ctx, p.Scans[0], selectedFields, out)
 		case ScanTypeSequential:
 			return t.sequentialScan(ctx, p.Scans[0], selectedFields, out)
 		default:
@@ -1231,6 +1336,10 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 			}
 		case ScanTypeIndexIntersect:
 			if err := t.indexIntersectScan(ctx, scan, selectedFields, out); err != nil {
+				return err
+			}
+		case ScanTypeFullText:
+			if err := t.fullTextIndexScan(ctx, scan, selectedFields, out); err != nil {
 				return err
 			}
 		default:

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1073,6 +1073,71 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 	return nil
 }
 
+func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
+	idx, ok := t.IndexByName(scan.IndexName)
+	if !ok {
+		return fmt.Errorf("no index found for full-text scan: %s", scan.IndexName)
+	}
+	if len(scan.IndexKeys) == 0 {
+		return nil
+	}
+
+	sets := make([][]RowID, 0, len(scan.IndexKeys))
+	for _, key := range scan.IndexKeys {
+		ids, err := idx.FindRowIDs(ctx, key)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil
+			}
+			return fmt.Errorf("full-text lookup failed: %w", err)
+		}
+		sets = append(sets, ids)
+	}
+
+	surviving := intersectSortedRowIDs(sets)
+	if len(surviving) == 0 {
+		return nil
+	}
+
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	for _, rowID := range surviving {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var row Row
+		if len(selectedFields) == 0 {
+			row = NewRowWithValues(t.Columns, nil)
+			row.Key = rowID
+		} else {
+			cursor, err := t.Seek(ctx, rowID)
+			if err != nil {
+				return fmt.Errorf("full-text seek: %w", err)
+			}
+			row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+			if err != nil {
+				return fmt.Errorf("full-text fetch: %w", err)
+			}
+		}
+
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		if err := out(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // errStopScan is a sentinel returned by an index scan callback to stop iteration after the
 // first row has been delivered.  It is never surfaced to callers.
 var errStopScan = errors.New("stop scan")

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -293,7 +293,7 @@ type IndexMethod int
 const (
 	// IndexMethodBTree is the default scalar B+ tree index method.
 	IndexMethodBTree IndexMethod = iota
-	// IndexMethodFullText is reserved for future full-text inverted indexes.
+	// IndexMethodFullText indexes text tokens for MATCH predicates.
 	IndexMethodFullText
 	// IndexMethodInverted is reserved for future JSON inverted indexes.
 	IndexMethodInverted

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -60,91 +60,6 @@ type Table struct {
 	maximumICells      uint32
 }
 
-// TableOption is a functional option applied to a Table during construction via NewTable.
-type TableOption func(*Table)
-
-// WithPrimaryKey sets the primary key index on the table being constructed.
-func WithPrimaryKey(pk PrimaryKey) TableOption {
-	return func(t *Table) {
-		t.PrimaryKey = pk
-	}
-}
-
-// WithUniqueIndex registers a unique index on the table being constructed.
-func WithUniqueIndex(index UniqueIndex) TableOption {
-	return func(t *Table) {
-		t.UniqueIndexes[index.Name] = index
-	}
-}
-
-// WithSecondaryIndex registers a secondary (non-unique) index on the table being constructed.
-func WithSecondaryIndex(index SecondaryIndex) TableOption {
-	return func(t *Table) {
-		t.SecondaryIndexes[index.Name] = index
-	}
-}
-
-// WithParallelScan enables or disables concurrent leaf-page scanning for this table.
-func WithParallelScan(enabled bool) TableOption {
-	return func(t *Table) {
-		t.parallelScan = enabled
-	}
-}
-
-// WithForeignKeys sets the outgoing FK constraints on the table.
-func WithForeignKeys(fks []ForeignKey) TableOption {
-	return func(t *Table) {
-		t.ForeignKeys = fks
-		t.fkColumnSet = make(map[string]bool)
-		for _, fk := range fks {
-			for _, col := range fk.Columns {
-				t.fkColumnSet[col] = true
-			}
-		}
-	}
-}
-
-// WithChildFKChecker wires up a callback that checks outgoing FK constraints.
-// Called by *Database; must only be invoked while d.dbLock is held (write).
-func WithChildFKChecker(fn func(context.Context, Row) error) TableOption {
-	return func(t *Table) { t.checkChildFK = fn }
-}
-
-// WithParentFKChecker wires up a callback that enforces inbound FK constraints on DELETE.
-// Called by *Database; must only be invoked while d.dbLock is held (write).
-func WithParentFKChecker(fn func(context.Context, Row) error) TableOption {
-	return func(t *Table) { t.checkParentFK = fn }
-}
-
-// WithParentFKUpdateEnforcer wires up a callback that enforces inbound FK constraints on UPDATE.
-// Called by *Database; must only be invoked while d.dbLock is held (write).
-func WithParentFKUpdateEnforcer(fn func(context.Context, Row, Row) error) TableOption {
-	return func(t *Table) { t.enforceParentFKOnUpdate = fn }
-}
-
-// WithReferencedColumns marks which columns of this table are FK targets in other tables.
-func WithReferencedColumns(cols map[string]bool) TableOption {
-	return func(t *Table) { t.referencedColumns = cols }
-}
-
-// estimatedRowCount returns the tracked row count, or -1 if no row-count
-// accessor has been wired up (e.g. in unit tests that build tables directly).
-func (t *Table) estimatedRowCount() int64 {
-	if t.getRowCount == nil {
-		return -1
-	}
-	return t.getRowCount()
-}
-
-// WithRowCountGetter sets an O(1) row-count accessor on the table.
-// When set, COUNT(*) with no WHERE clause returns the value directly
-// instead of performing a leaf-page walk.
-func WithRowCountGetter(fn func() int64) TableOption {
-	return func(t *Table) {
-		t.getRowCount = fn
-	}
-}
-
 // NewTable constructs a Table and applies the given options (primary key, unique
 // and secondary indexes, FK callbacks, etc.). If provider is nil a simple
 // single-table provider is created, which is sufficient for unit tests.
@@ -285,7 +200,7 @@ func (t *Table) HasNoIndex() bool {
 		return false
 	}
 	for _, idx := range t.SecondaryIndexes {
-		if idx.IsBTree() {
+		if idx.IsBTree() || idx.Method == IndexMethodFullText {
 			return false
 		}
 	}
@@ -364,7 +279,7 @@ func (t *Table) IndexByName(name string) (BTreeIndex, bool) {
 		return index.Index, true
 	}
 	if index, ok := t.SecondaryIndexes[name]; ok {
-		if !index.IsBTree() {
+		if !index.IsBTree() && index.Method != IndexMethodFullText {
 			return nil, false
 		}
 		return index.Index, true
@@ -1562,4 +1477,13 @@ func (t *Table) newBTreeIndex(pager *TransactionalPager, rootPageIdx PageIndex, 
 	default:
 		return nil, fmt.Errorf("unsupported BTree index column type %v for index %s", columns[0].Kind, indexName)
 	}
+}
+
+// estimatedRowCount returns the tracked row count, or -1 if no row-count
+// accessor has been wired up (e.g. in unit tests that build tables directly).
+func (t *Table) estimatedRowCount() int64 {
+	if t.getRowCount == nil {
+		return -1
+	}
+	return t.getRowCount()
 }

--- a/internal/minisql/table_options.go
+++ b/internal/minisql/table_options.go
@@ -1,0 +1,81 @@
+package minisql
+
+import (
+	"context"
+)
+
+// TableOption is a functional option applied to a Table during construction via NewTable.
+type TableOption func(*Table)
+
+// WithPrimaryKey sets the primary key index on the table being constructed.
+func WithPrimaryKey(pk PrimaryKey) TableOption {
+	return func(t *Table) {
+		t.PrimaryKey = pk
+	}
+}
+
+// WithUniqueIndex registers a unique index on the table being constructed.
+func WithUniqueIndex(index UniqueIndex) TableOption {
+	return func(t *Table) {
+		t.UniqueIndexes[index.Name] = index
+	}
+}
+
+// WithSecondaryIndex registers a secondary (non-unique) index on the table being constructed.
+func WithSecondaryIndex(index SecondaryIndex) TableOption {
+	return func(t *Table) {
+		t.SecondaryIndexes[index.Name] = index
+	}
+}
+
+// WithParallelScan enables or disables concurrent leaf-page scanning for this table.
+func WithParallelScan(enabled bool) TableOption {
+	return func(t *Table) {
+		t.parallelScan = enabled
+	}
+}
+
+// WithForeignKeys sets the outgoing FK constraints on the table.
+func WithForeignKeys(fks []ForeignKey) TableOption {
+	return func(t *Table) {
+		t.ForeignKeys = fks
+		t.fkColumnSet = make(map[string]bool)
+		for _, fk := range fks {
+			for _, col := range fk.Columns {
+				t.fkColumnSet[col] = true
+			}
+		}
+	}
+}
+
+// WithChildFKChecker wires up a callback that checks outgoing FK constraints.
+// Called by *Database; must only be invoked while d.dbLock is held (write).
+func WithChildFKChecker(fn func(context.Context, Row) error) TableOption {
+	return func(t *Table) { t.checkChildFK = fn }
+}
+
+// WithParentFKChecker wires up a callback that enforces inbound FK constraints on DELETE.
+// Called by *Database; must only be invoked while d.dbLock is held (write).
+func WithParentFKChecker(fn func(context.Context, Row) error) TableOption {
+	return func(t *Table) { t.checkParentFK = fn }
+}
+
+// WithParentFKUpdateEnforcer wires up a callback that enforces inbound FK constraints on UPDATE.
+// Called by *Database; must only be invoked while d.dbLock is held (write).
+func WithParentFKUpdateEnforcer(fn func(context.Context, Row, Row) error) TableOption {
+	return func(t *Table) { t.enforceParentFKOnUpdate = fn }
+}
+
+// WithReferencedColumns marks which columns of this table are FK targets in other tables.
+func WithReferencedColumns(cols map[string]bool) TableOption {
+	return func(t *Table) { t.referencedColumns = cols }
+}
+
+// WithRowCountGetter sets an O(1) row-count accessor on the table.
+// When set, COUNT(*) with no WHERE clause returns the value directly
+// instead of performing a leaf-page walk.
+func WithRowCountGetter(fn func() int64) TableOption {
+	return func(t *Table) {
+		t.getRowCount = fn
+	}
+}

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -15,6 +15,17 @@ type SecondaryIndex struct {
 	IndexInfo
 }
 
+func fullTextTokenColumn() Column {
+	return Column{Name: "__fts_token__", Kind: Varchar, Size: MaxIndexKeySize}
+}
+
+func secondaryIndexStorageColumns(secondaryIndex SecondaryIndex) []Column {
+	if secondaryIndex.Method == IndexMethodFullText {
+		return []Column{fullTextTokenColumn()}
+	}
+	return secondaryIndex.Columns
+}
+
 // rowSatisfiesWhereCond returns true when the row satisfies the partial index predicate,
 // or always true for a full (non-partial) index.
 func (si SecondaryIndex) rowSatisfiesWhereCond(row Row) (bool, error) {
@@ -27,6 +38,10 @@ func (si SecondaryIndex) rowSatisfiesWhereCond(row Row) (bool, error) {
 func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex SecondaryIndex, keys []OptionalValue, rowID RowID, row Row) error {
 	if secondaryIndex.Index == nil {
 		return fmt.Errorf("table %s has secondary index %s but no Btree index instance", t.Name, secondaryIndex.Name)
+	}
+
+	if secondaryIndex.Method == IndexMethodFullText {
+		return t.insertFullTextIndexKeys(ctx, secondaryIndex, rowID, row)
 	}
 
 	// Partial index: skip rows that don't satisfy the WHERE predicate.
@@ -106,6 +121,10 @@ func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 func (t *Table) updateSecondaryIndexKey(ctx context.Context, secondaryIndex SecondaryIndex, oldKeyParts []OptionalValue, oldRow, row Row) error {
 	if secondaryIndex.Index == nil {
 		return fmt.Errorf("table %s has secondary index %s but no Btree index instance", t.Name, secondaryIndex.Name)
+	}
+
+	if secondaryIndex.Method == IndexMethodFullText {
+		return t.updateFullTextIndexKeys(ctx, secondaryIndex, oldRow, row)
 	}
 
 	// Expression index: evaluate expression against old and new rows.
@@ -198,6 +217,71 @@ func (t *Table) updateSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 	}
 
 	return nil
+}
+
+func (t *Table) insertFullTextIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, rowID RowID, row Row) error {
+	if ok, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
+		return fmt.Errorf("partial full-text index %s where check: %w", secondaryIndex.Name, err)
+	} else if !ok {
+		return nil
+	}
+
+	tokens, err := fullTextTokensForRow(secondaryIndex, row)
+	if err != nil {
+		return err
+	}
+	for _, token := range tokens {
+		if err := secondaryIndex.Index.Insert(ctx, token, rowID); err != nil {
+			return fmt.Errorf("failed to insert token for full-text index %s: %w", secondaryIndex.Name, err)
+		}
+	}
+	return nil
+}
+
+func (t *Table) updateFullTextIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, oldRow, row Row) error {
+	rowID := row.Key
+	if oldInIndex, err := secondaryIndex.rowSatisfiesWhereCond(oldRow); err != nil {
+		return fmt.Errorf("partial full-text index %s where check (old row): %w", secondaryIndex.Name, err)
+	} else if oldInIndex {
+		if err := t.deleteFullTextIndexKeys(ctx, secondaryIndex, rowID, oldRow); err != nil {
+			return err
+		}
+	}
+
+	if newInIndex, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
+		return fmt.Errorf("partial full-text index %s where check (new row): %w", secondaryIndex.Name, err)
+	} else if newInIndex {
+		return t.insertFullTextIndexKeys(ctx, secondaryIndex, rowID, row)
+	}
+	return nil
+}
+
+func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, rowID RowID, row Row) error {
+	tokens, err := fullTextTokensForRow(secondaryIndex, row)
+	if err != nil {
+		return err
+	}
+	for _, token := range tokens {
+		if err := secondaryIndex.Index.Delete(ctx, token, rowID); err != nil {
+			return fmt.Errorf("failed to delete token for full-text index %s: %w", secondaryIndex.Name, err)
+		}
+	}
+	return nil
+}
+
+func fullTextTokensForRow(secondaryIndex SecondaryIndex, row Row) ([]string, error) {
+	if len(secondaryIndex.Columns) != 1 {
+		return nil, fmt.Errorf("full-text index %s requires exactly one source column", secondaryIndex.Name)
+	}
+	value, ok := row.GetValue(secondaryIndex.Columns[0].Name)
+	if !ok || !value.Valid {
+		return nil, nil
+	}
+	doc, ok := toStringVal(value.Value)
+	if !ok {
+		return nil, fmt.Errorf("full-text index %s column %q must be text", secondaryIndex.Name, secondaryIndex.Columns[0].Name)
+	}
+	return uniqueTextSearchTokens(doc), nil
 }
 
 func (t *Table) updateCompositeSecondaryIndexKey(ctx context.Context, secondaryIndex SecondaryIndex, oldKeyParts []OptionalValue, oldRow, row Row) error {

--- a/internal/minisql/text_search.go
+++ b/internal/minisql/text_search.go
@@ -44,6 +44,9 @@ func uniqueTextSearchTokens(input string) []string {
 	seen := make(map[string]struct{}, len(tokens))
 	unique := make([]string, 0, len(tokens))
 	for _, token := range tokens {
+		if len([]byte(token)) > MaxIndexKeySize {
+			continue
+		}
 		if _, ok := seen[token]; ok {
 			continue
 		}


### PR DESCRIPTION
Implemented v1 full-text inverted indexing with simple ordered posting lists, no positions and no delta compression yet.

What changed:

- `CREATE FULLTEXT INDEX ... WITH (tokenizer = 'simple')` now creates a working index.
- Full-text index storage uses the existing non-unique B+ tree as a v1 entry tree: token -> rowIDs.
- `MATCH(body, 'literal query')` can now plan as fulltext and intersect posting lists for all query tokens.
- Insert/update/delete maintain full-text index entries.
- Reopen/init/drop/integrity paths understand that full-text indexes store synthetic token keys, not the source `TEXT` column.
- README now documents the v1 full-text index behavior and limitations.