### PR TITLE
feat: implement positional full text postings and phrase queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,11 +636,11 @@ ON articles (body)
 WITH (tokenizer = 'simple');
 ```
 
-The v1 index stores one B+ tree entry per unique token, with each token pointing at an ordered posting list of row IDs. It does not store token positions, compress postings, rank from index statistics, or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting the posting lists for all query tokens; dynamic query expressions fall back to the sequential semantics.
+The v1 index stores one B+ tree entry per unique token, with each token pointing at ordered positional postings `(row ID, token position)`. It does not compress postings, rank from index statistics, or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting posting rows for all query tokens; quoted phrases such as `MATCH(body, '"database pages"')` additionally require adjacent token positions. Dynamic query expressions fall back to the sequential semantics.
 
 | Function | Description |
 |----------|-------------|
-| `MATCH(doc, query)` | Returns `true` when every non-stop-word query token appears in `doc`. Usable directly as `WHERE MATCH(body, 'mini database')`. |
+| `MATCH(doc, query)` | Returns `true` when every non-stop-word query token appears in `doc`. Double-quoted phrases require adjacent indexed token positions, e.g. `WHERE MATCH(body, '"mini database"')`. |
 | `TS_RANK(doc, query)` | Returns a simple relevance score using log-scaled term frequency: `sum(log(1 + term_frequency)) / query_terms`. |
 
 Tokenizer v1 lowercases text, splits on non-letter/non-digit boundaries, removes a small built-in English stop-word list, and does not perform stemming. For example, `database` and `databases` are different tokens.
@@ -650,6 +650,10 @@ SELECT id, TS_RANK(body, 'mini database') AS score
 FROM articles
 WHERE MATCH(body, 'mini database')
 ORDER BY score DESC;
+
+SELECT id
+FROM articles
+WHERE MATCH(body, 'mini "database pages"');
 ```
 
 ### Operators Reference

--- a/e2e_tests/full_text_test.go
+++ b/e2e_tests/full_text_test.go
@@ -115,6 +115,19 @@ func (s *TestSuite) TestFullTextSearch_FullTextIndex() {
 		s.Equal([]string{"MiniSQL", "Storage"}, titles)
 	})
 
+	s.Run("quoted phrases require adjacent indexed positions", func() {
+		rows, err := s.db.Query(`select title from "articles_fts" where MATCH(body, '"database pages"');`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var title string
+		s.Require().NoError(rows.Scan(&title))
+		s.Equal("MiniSQL", title)
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
 	s.Run("index reloads and passes integrity checks", func() {
 		s.Require().NoError(s.db.Close())
 		s.db = s.reopenDB()

--- a/internal/minisql/expr_test.go
+++ b/internal/minisql/expr_test.go
@@ -467,6 +467,14 @@ func TestExpr_Eval_TextSearch(t *testing.T) {
 		assert.Equal(t, false, v)
 	})
 
+	t.Run("MATCH supports quoted phrases", func(t *testing.T) {
+		t.Parallel()
+		e := &Expr{FuncName: "MATCH", Args: []*Expr{{Column: "body"}, textExpr(`"embedded database"`)}}
+		v, err := e.Eval(row)
+		require.NoError(t, err)
+		assert.Equal(t, true, v)
+	})
+
 	t.Run("TS_RANK uses log-scaled term frequency", func(t *testing.T) {
 		t.Parallel()
 		e := &Expr{FuncName: "TS_RANK", Args: []*Expr{{Column: "body"}, textExpr("minisql database")}}

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -84,6 +84,7 @@ func TestTable_FullTextIndexScanAndMaintenance(t *testing.T) {
 
 	titles := selectTitlesWithCondition(t, ctx, database, table, matchDatabasePages)
 	assert.Equal(t, []string{"MiniSQL", "Storage"}, titles)
+	assert.Equal(t, []string{"MiniSQL"}, selectTitlesWithCondition(t, ctx, database, table, fullTextMatchCondition("body", `"database pages"`)))
 
 	require.NoError(t, database.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		_, err := table.Update(ctx, Statement{

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -122,6 +122,7 @@ type QueryPlan struct {
 // relevant to that scan type.
 type Scan struct {
 	RangeCondition RangeCondition
+	FullTextQuery  *textSearchQuery
 	TableName      string
 	TableAlias     string
 	IndexName      string
@@ -427,8 +428,10 @@ func (t *Table) tryFullTextIndexScan(filters OneOrMore) (Scan, bool) {
 		return Scan{}, false
 	}
 
-	var matchCondIdx = -1
-	var matchExpr *Expr
+	var (
+		matchCondIdx = -1
+		matchExpr    *Expr
+	)
 	for i, cond := range filters[0] {
 		if cond.Operator != Eq || cond.Operand2.Type != OperandBoolean || cond.Operand2.Value != true {
 			continue
@@ -456,13 +459,19 @@ func (t *Table) tryFullTextIndexScan(filters OneOrMore) (Scan, bool) {
 	if !ok {
 		return Scan{}, false
 	}
-	tokens := uniqueTextSearchTokens(query)
+	parsedQuery, ok := parseTextSearchQuery(query)
+	if !ok {
+		return Scan{}, false
+	}
+	tokens := parsedQuery.allUniqueTokens()
 	if len(tokens) == 0 {
 		return Scan{}, false
 	}
 
-	var matchedIndex SecondaryIndex
-	foundIndex := false
+	var (
+		matchedIndex SecondaryIndex
+		foundIndex   = false
+	)
 	for _, idx := range t.SecondaryIndexes {
 		if idx.Method != IndexMethodFullText || len(idx.Columns) != 1 {
 			continue
@@ -494,12 +503,13 @@ func (t *Table) tryFullTextIndexScan(filters OneOrMore) (Scan, bool) {
 		indexKeys[i] = token
 	}
 	return Scan{
-		TableName:    t.Name,
-		Type:         ScanTypeFullText,
-		IndexName:    matchedIndex.Name,
-		IndexColumns: []Column{fullTextTokenColumn()},
-		IndexKeys:    indexKeys,
-		Filters:      scanFilters,
+		TableName:     t.Name,
+		Type:          ScanTypeFullText,
+		FullTextQuery: &parsedQuery,
+		IndexName:     matchedIndex.Name,
+		IndexColumns:  []Column{fullTextTokenColumn()},
+		IndexKeys:     indexKeys,
+		Filters:       scanFilters,
 	}, true
 }
 

--- a/internal/minisql/query_plan_test.go
+++ b/internal/minisql/query_plan_test.go
@@ -601,6 +601,8 @@ func TestScanType_String(t *testing.T) {
 		{want: "index_range", st: ScanTypeIndexRange},
 		{want: "index_first", st: ScanTypeIndexFirst},
 		{want: "index_last", st: ScanTypeIndexLast},
+		{want: "index_intersect", st: ScanTypeIndexIntersect},
+		{want: "fulltext", st: ScanTypeFullText},
 		{want: "unknown", st: ScanType(99)},
 	}
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1082,19 +1082,71 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 		return nil
 	}
 
-	sets := make([][]RowID, 0, len(scan.IndexKeys))
+	query := scan.FullTextQuery
+	if query == nil {
+		terms := make([]string, 0, len(scan.IndexKeys))
+		for _, key := range scan.IndexKeys {
+			term, ok := key.(string)
+			if !ok {
+				continue
+			}
+			terms = appendUniqueTextSearchTerms(terms, term)
+		}
+		query = &textSearchQuery{Terms: terms}
+	}
+	queryTokens := query.allUniqueTokens()
+	if len(queryTokens) == 0 {
+		return nil
+	}
+
+	postingsByTerm := make(map[string]map[RowID][]uint32, len(queryTokens))
 	for _, key := range scan.IndexKeys {
-		ids, err := idx.FindRowIDs(ctx, key)
+		term, ok := key.(string)
+		if !ok {
+			continue
+		}
+		postings, err := idx.FindRowIDs(ctx, key)
 		if err != nil {
 			if errors.Is(err, ErrNotFound) {
 				return nil
 			}
 			return fmt.Errorf("full-text lookup failed: %w", err)
 		}
-		sets = append(sets, ids)
+		rows := make(map[RowID][]uint32)
+		for _, posting := range postings {
+			rowID, position := decodeFullTextPosting(posting)
+			rows[rowID] = append(rows[rowID], position)
+		}
+		postingsByTerm[term] = rows
 	}
 
-	surviving := intersectSortedRowIDs(sets)
+	firstRows := postingsByTerm[queryTokens[0]]
+	surviving := make([]RowID, 0, len(firstRows))
+	for rowID := range firstRows {
+		positions := make(map[string][]uint32, len(queryTokens))
+		matches := true
+		for _, term := range queryTokens {
+			termPositions := postingsByTerm[term][rowID]
+			if len(termPositions) == 0 {
+				matches = false
+				break
+			}
+			positions[term] = termPositions
+		}
+		if !matches {
+			continue
+		}
+		for _, phrase := range query.Phrases {
+			if !textSearchPhraseMatches(positions, phrase) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			surviving = append(surviving, rowID)
+		}
+	}
+	sortRowIDs(surviving)
 	if len(surviving) == 0 {
 		return nil
 	}

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -226,12 +226,16 @@ func (t *Table) insertFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 		return nil
 	}
 
-	tokens, err := fullTextTokensForRow(secondaryIndex, row)
+	tokens, err := fullTextTokenPositionsForRow(secondaryIndex, row)
 	if err != nil {
 		return err
 	}
 	for _, token := range tokens {
-		if err := secondaryIndex.Index.Insert(ctx, token, rowID); err != nil {
+		posting, err := encodeFullTextPosting(rowID, token.Position)
+		if err != nil {
+			return err
+		}
+		if err := secondaryIndex.Index.Insert(ctx, token.Term, posting); err != nil {
 			return fmt.Errorf("failed to insert token for full-text index %s: %w", secondaryIndex.Name, err)
 		}
 	}
@@ -257,12 +261,16 @@ func (t *Table) updateFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 }
 
 func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, rowID RowID, row Row) error {
-	tokens, err := fullTextTokensForRow(secondaryIndex, row)
+	tokens, err := fullTextTokenPositionsForRow(secondaryIndex, row)
 	if err != nil {
 		return err
 	}
 	for _, token := range tokens {
-		if err := secondaryIndex.Index.Delete(ctx, token, rowID); err != nil {
+		posting, err := encodeFullTextPosting(rowID, token.Position)
+		if err != nil {
+			return err
+		}
+		if err := secondaryIndex.Index.Delete(ctx, token.Term, posting); err != nil {
 			return fmt.Errorf("failed to delete token for full-text index %s: %w", secondaryIndex.Name, err)
 		}
 	}
@@ -270,6 +278,18 @@ func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 }
 
 func fullTextTokensForRow(secondaryIndex SecondaryIndex, row Row) ([]string, error) {
+	positions, err := fullTextTokenPositionsForRow(secondaryIndex, row)
+	if err != nil {
+		return nil, err
+	}
+	tokens := make([]string, 0, len(positions))
+	for _, token := range positions {
+		tokens = appendUniqueTextSearchTerms(tokens, token.Term)
+	}
+	return tokens, nil
+}
+
+func fullTextTokenPositionsForRow(secondaryIndex SecondaryIndex, row Row) ([]textSearchTokenPosition, error) {
 	if len(secondaryIndex.Columns) != 1 {
 		return nil, fmt.Errorf("full-text index %s requires exactly one source column", secondaryIndex.Name)
 	}
@@ -281,7 +301,15 @@ func fullTextTokensForRow(secondaryIndex SecondaryIndex, row Row) ([]string, err
 	if !ok {
 		return nil, fmt.Errorf("full-text index %s column %q must be text", secondaryIndex.Name, secondaryIndex.Columns[0].Name)
 	}
-	return uniqueTextSearchTokens(doc), nil
+	positions := textSearchTokenPositions(doc)
+	indexable := make([]textSearchTokenPosition, 0, len(positions))
+	for _, token := range positions {
+		if len([]byte(token.Term)) > MaxIndexKeySize {
+			continue
+		}
+		indexable = append(indexable, token)
+	}
+	return indexable, nil
 }
 
 func (t *Table) updateCompositeSecondaryIndexKey(ctx context.Context, secondaryIndex SecondaryIndex, oldKeyParts []OptionalValue, oldRow, row Row) error {

--- a/internal/minisql/text_search.go
+++ b/internal/minisql/text_search.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"fmt"
 	"math"
 	"unicode"
 )
@@ -11,9 +12,34 @@ var textSearchStopWords = map[string]struct{}{
 	"that": {}, "the": {}, "to": {}, "was": {}, "with": {},
 }
 
+const (
+	fullTextPostingPositionBits = 32
+	maxFullTextPostingComponent = uint64(^uint32(0))
+)
+
+type textSearchTokenPosition struct {
+	Term     string
+	Position uint32
+}
+
+type textSearchQuery struct {
+	Terms   []string
+	Phrases [][]string
+}
+
 func textSearchTokens(input string) []string {
-	tokens := make([]string, 0)
+	positions := textSearchTokenPositions(input)
+	tokens := make([]string, len(positions))
+	for i, positioned := range positions {
+		tokens[i] = positioned.Term
+	}
+	return tokens
+}
+
+func textSearchTokenPositions(input string) []textSearchTokenPosition {
+	tokens := make([]textSearchTokenPosition, 0)
 	current := make([]rune, 0, 16)
+	var position uint64
 
 	flush := func() {
 		if len(current) == 0 {
@@ -24,7 +50,11 @@ func textSearchTokens(input string) []string {
 		if _, stop := textSearchStopWords[token]; stop {
 			return
 		}
-		tokens = append(tokens, token)
+		if position > maxFullTextPostingComponent {
+			return
+		}
+		tokens = append(tokens, textSearchTokenPosition{Term: token, Position: uint32(position)})
+		position += 1
 	}
 
 	for _, r := range input {
@@ -56,23 +86,105 @@ func uniqueTextSearchTokens(input string) []string {
 	return unique
 }
 
+func parseTextSearchQuery(input string) (textSearchQuery, bool) {
+	var (
+		query       textSearchQuery
+		outside     []rune
+		phrase      []rune
+		insideQuote bool
+	)
+
+	appendTerms := func(input string) {
+		query.Terms = appendUniqueTextSearchTerms(query.Terms, textSearchTokens(input)...)
+	}
+	appendPhrase := func(input string) {
+		tokens := textSearchTokens(input)
+		if len(tokens) > 0 {
+			query.Phrases = append(query.Phrases, tokens)
+		}
+	}
+
+	for _, r := range input {
+		if r != '"' {
+			if insideQuote {
+				phrase = append(phrase, r)
+			} else {
+				outside = append(outside, r)
+			}
+			continue
+		}
+
+		if insideQuote {
+			appendPhrase(string(phrase))
+			phrase = phrase[:0]
+			insideQuote = false
+			continue
+		}
+
+		appendTerms(string(outside))
+		outside = outside[:0]
+		insideQuote = true
+	}
+
+	if insideQuote {
+		return textSearchQuery{}, false
+	}
+	appendTerms(string(outside))
+
+	if len(query.Terms) == 0 && len(query.Phrases) == 0 {
+		return textSearchQuery{}, false
+	}
+	return query, true
+}
+
+func appendUniqueTextSearchTerms(existing []string, terms ...string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(terms))
+	for _, term := range existing {
+		seen[term] = struct{}{}
+	}
+	for _, term := range terms {
+		if len([]byte(term)) > MaxIndexKeySize {
+			continue
+		}
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		existing = append(existing, term)
+	}
+	return existing
+}
+
+func (q textSearchQuery) allUniqueTokens() []string {
+	tokens := appendUniqueTextSearchTerms(nil, q.Terms...)
+	for _, phrase := range q.Phrases {
+		tokens = appendUniqueTextSearchTerms(tokens, phrase...)
+	}
+	return tokens
+}
+
 func textSearchMatch(document, query string) bool {
-	queryTokens := uniqueTextSearchTokens(query)
-	if len(queryTokens) == 0 {
+	parsedQuery, ok := parseTextSearchQuery(query)
+	if !ok {
 		return false
 	}
 
-	docTokens := textSearchTokens(document)
+	docTokens := textSearchTokenPositions(document)
 	if len(docTokens) == 0 {
 		return false
 	}
 
-	docSet := make(map[string]struct{}, len(docTokens))
+	positions := make(map[string][]uint32, len(docTokens))
 	for _, token := range docTokens {
-		docSet[token] = struct{}{}
+		positions[token.Term] = append(positions[token.Term], token.Position)
 	}
-	for _, token := range queryTokens {
-		if _, ok := docSet[token]; !ok {
+	for _, token := range parsedQuery.Terms {
+		if len(positions[token]) == 0 {
+			return false
+		}
+	}
+	for _, phrase := range parsedQuery.Phrases {
+		if !textSearchPhraseMatches(positions, phrase) {
 			return false
 		}
 	}
@@ -80,7 +192,11 @@ func textSearchMatch(document, query string) bool {
 }
 
 func textSearchRank(document, query string) float64 {
-	queryTokens := uniqueTextSearchTokens(query)
+	parsedQuery, ok := parseTextSearchQuery(query)
+	if !ok {
+		return 0
+	}
+	queryTokens := parsedQuery.allUniqueTokens()
 	if len(queryTokens) == 0 {
 		return 0
 	}
@@ -100,4 +216,48 @@ func textSearchRank(document, query string) float64 {
 		score += math.Log1p(float64(frequencies[token]))
 	}
 	return score / float64(len(queryTokens))
+}
+
+func textSearchPhraseMatches(positions map[string][]uint32, phrase []string) bool {
+	if len(phrase) == 0 {
+		return false
+	}
+	starts := positions[phrase[0]]
+	if len(starts) == 0 {
+		return false
+	}
+	positionSets := make([]map[uint32]struct{}, len(phrase))
+	for i, term := range phrase {
+		if len(positions[term]) == 0 {
+			return false
+		}
+		positionSets[i] = make(map[uint32]struct{}, len(positions[term]))
+		for _, position := range positions[term] {
+			positionSets[i][position] = struct{}{}
+		}
+	}
+	for _, start := range starts {
+		matches := true
+		for offset := 1; offset < len(phrase); offset++ {
+			if _, ok := positionSets[offset][start+uint32(offset)]; !ok {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeFullTextPosting(rowID RowID, position uint32) (RowID, error) {
+	if uint64(rowID) > maxFullTextPostingComponent {
+		return 0, fmt.Errorf("full-text row id %d exceeds positional posting limit", rowID)
+	}
+	return RowID(uint64(rowID)<<fullTextPostingPositionBits | uint64(position)), nil
+}
+
+func decodeFullTextPosting(posting RowID) (RowID, uint32) {
+	return RowID(uint64(posting) >> fullTextPostingPositionBits), uint32(posting)
 }

--- a/internal/minisql/text_search_test.go
+++ b/internal/minisql/text_search_test.go
@@ -56,6 +56,29 @@ func TestUniqueTextSearchTokens(t *testing.T) {
 	assert.Equal(t, []string{"minisql", "database"}, got)
 }
 
+func TestTextSearchTokenPositions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []textSearchTokenPosition{
+		{Term: "mini", Position: 0},
+		{Term: "embedded", Position: 1},
+		{Term: "database", Position: 2},
+	}, textSearchTokenPositions("The mini embedded database"))
+}
+
+func TestParseTextSearchQuery(t *testing.T) {
+	t.Parallel()
+
+	query, ok := parseTextSearchQuery(`mini "database pages"`)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"mini"}, query.Terms)
+	assert.Equal(t, [][]string{{"database", "pages"}}, query.Phrases)
+	assert.Equal(t, []string{"mini", "database", "pages"}, query.allUniqueTokens())
+
+	_, ok = parseTextSearchQuery(`"unterminated phrase`)
+	assert.False(t, ok)
+}
+
 func TestTextSearchMatch(t *testing.T) {
 	t.Parallel()
 
@@ -95,6 +118,24 @@ func TestTextSearchMatch(t *testing.T) {
 			query:    "minisql",
 			want:     false,
 		},
+		{
+			name:     "quoted phrase requires adjacent tokens",
+			document: "MiniSQL stores database pages together",
+			query:    `"database pages"`,
+			want:     true,
+		},
+		{
+			name:     "quoted phrase rejects scattered tokens",
+			document: "MiniSQL stores database values across many pages",
+			query:    `"database pages"`,
+			want:     false,
+		},
+		{
+			name:     "plain terms and phrase combine with AND",
+			document: "MiniSQL stores database pages",
+			query:    `minisql "database pages"`,
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,6 +144,19 @@ func TestTextSearchMatch(t *testing.T) {
 			assert.Equal(t, tt.want, textSearchMatch(tt.document, tt.query))
 		})
 	}
+}
+
+func TestFullTextPostingEncoding(t *testing.T) {
+	t.Parallel()
+
+	posting, err := encodeFullTextPosting(42, 7)
+	assert.NoError(t, err)
+	rowID, position := decodeFullTextPosting(posting)
+	assert.Equal(t, RowID(42), rowID)
+	assert.Equal(t, uint32(7), position)
+
+	_, err = encodeFullTextPosting(RowID(maxFullTextPostingComponent+1), 0)
+	assert.ErrorContains(t, err, "exceeds positional posting limit")
 }
 
 func TestTextSearchRank(t *testing.T) {


### PR DESCRIPTION
Implemented positional full-text postings and phrase queries.

What changed:

- `MATCH()` now parses double-quoted phrases, e.g. `MATCH(body, '"database pages"')`.
- Sequential `MATCH()` supports phrase adjacency.
- Full-text index postings now encode (rowID, token position) into the existing posting slot.
- Indexed full-text scans decode positions and enforce phrase adjacency.
- Full-text insert/update/delete maintenance now writes/removes positional postings.
- README documents phrase syntax and positional posting behavior.
- Added unit and e2e coverage for tokenizer positions, phrase parsing, phrase matching, positional posting encoding, indexed phrase lookup, and scan type strings.