### PR TITLE
feat: add full text posting codec for delta encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ ON articles (body)
 WITH (tokenizer = 'simple');
 ```
 
-The v1 index stores one B+ tree entry per unique token, with each token pointing at ordered positional postings `(row ID, token position)`. It does not compress postings, rank from index statistics, or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting posting rows for all query tokens; quoted phrases such as `MATCH(body, '"database pages"')` additionally require adjacent token positions. Dynamic query expressions fall back to the sequential semantics.
+The v1 index stores one B+ tree entry per unique token, with each token pointing at ordered positional postings `(row ID, token position)`. The current on-disk format stores packed positional postings in the generic B+ tree posting slots; a delta/varint posting-list codec exists internally as preparation for a future dedicated inverted-index payload format. It does not rank from index statistics or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting posting rows for all query tokens; quoted phrases such as `MATCH(body, '"database pages"')` additionally require adjacent token positions. Dynamic query expressions fall back to the sequential semantics.
 
 | Function | Description |
 |----------|-------------|

--- a/internal/minisql/full_text_posting.go
+++ b/internal/minisql/full_text_posting.go
@@ -1,0 +1,144 @@
+package minisql
+
+import (
+	"encoding/binary"
+	"fmt"
+	"slices"
+)
+
+const (
+	fullTextPostingPositionBits = 32
+	maxFullTextPostingComponent = uint64(^uint32(0))
+)
+
+type fullTextPosting struct {
+	RowID    RowID
+	Position uint32
+}
+
+// encodeFullTextPosting packs one positional posting into a RowID-sized value.
+// The current v1 full-text index stores this packed value in the existing
+// non-unique B+ tree posting slots.
+func encodeFullTextPosting(posting fullTextPosting) (RowID, error) {
+	if uint64(posting.RowID) > maxFullTextPostingComponent {
+		return 0, fmt.Errorf("full-text row id %d exceeds positional posting limit", posting.RowID)
+	}
+	return RowID(uint64(posting.RowID)<<fullTextPostingPositionBits | uint64(posting.Position)), nil
+}
+
+// decodeFullTextPosting unpacks the RowID-sized value stored by the v1 full-text
+// index back into its logical row ID and token position.
+func decodeFullTextPosting(posting RowID) fullTextPosting {
+	return fullTextPosting{
+		RowID:    RowID(uint64(posting) >> fullTextPostingPositionBits),
+		Position: uint32(posting),
+	}
+}
+
+// encodeFullTextPostingList serializes postings as sorted row/position deltas
+// encoded with unsigned varints. This is preparation for a future dedicated
+// inverted-index payload format; the current on-disk index still uses
+// encodeFullTextPosting for each individual posting.
+func encodeFullTextPostingList(postings []fullTextPosting) ([]byte, error) {
+	if len(postings) == 0 {
+		return nil, nil
+	}
+
+	sorted := append([]fullTextPosting(nil), postings...)
+	slices.SortFunc(sorted, compareFullTextPostings)
+
+	// PutUvarint writes into tmp below; this output buffer is only the append
+	// destination. Pre-size for the worst case so encoding does not repeatedly grow it.
+	buf := make([]byte, 0, len(sorted)*2*binary.MaxVarintLen64)
+	var (
+		prevRowID    RowID
+		prevPosition uint32
+		tmp          [binary.MaxVarintLen64]byte
+	)
+	for i, posting := range sorted {
+		if uint64(posting.RowID) > maxFullTextPostingComponent {
+			return nil, fmt.Errorf("full-text row id %d exceeds positional posting limit", posting.RowID)
+		}
+
+		var (
+			rowDelta      = uint64(posting.RowID)
+			positionDelta = uint64(posting.Position)
+		)
+		if i > 0 {
+			rowDelta = uint64(posting.RowID - prevRowID)
+			if posting.RowID == prevRowID {
+				positionDelta = uint64(posting.Position - prevPosition)
+			}
+		}
+
+		n := binary.PutUvarint(tmp[:], rowDelta)
+		buf = append(buf, tmp[:n]...)
+		n = binary.PutUvarint(tmp[:], positionDelta)
+		buf = append(buf, tmp[:n]...)
+
+		prevRowID = posting.RowID
+		prevPosition = posting.Position
+	}
+	return buf, nil
+}
+
+// decodeFullTextPostingList reverses encodeFullTextPostingList and reconstructs
+// the sorted positional postings from row/position deltas.
+func decodeFullTextPostingList(encoded []byte) ([]fullTextPosting, error) {
+	if len(encoded) == 0 {
+		return nil, nil
+	}
+
+	postings := make([]fullTextPosting, 0)
+	var (
+		prevRowID    RowID
+		prevPosition uint32
+		offset       int
+	)
+	for offset < len(encoded) {
+		rowDelta, n := binary.Uvarint(encoded[offset:])
+		if n <= 0 {
+			return nil, fmt.Errorf("decode full-text posting row delta at byte %d", offset)
+		}
+		offset += n
+
+		positionDelta, n := binary.Uvarint(encoded[offset:])
+		if n <= 0 {
+			return nil, fmt.Errorf("decode full-text posting position delta at byte %d", offset)
+		}
+		offset += n
+
+		rowID := RowID(rowDelta)
+		position := uint32(positionDelta)
+		if len(postings) > 0 {
+			rowID = prevRowID + RowID(rowDelta)
+			if rowID == prevRowID {
+				position = prevPosition + uint32(positionDelta)
+			}
+		}
+
+		posting := fullTextPosting{RowID: rowID, Position: position}
+		postings = append(postings, posting)
+		prevRowID = posting.RowID
+		prevPosition = posting.Position
+	}
+	return postings, nil
+}
+
+// compareFullTextPostings orders postings by row ID first and token position
+// second. Keeping a single canonical order makes delta encoding deterministic.
+func compareFullTextPostings(a, b fullTextPosting) int {
+	if a.RowID < b.RowID {
+		return -1
+	}
+	if a.RowID > b.RowID {
+		return 1
+	}
+	if a.Position < b.Position {
+		return -1
+	}
+	if a.Position > b.Position {
+		return 1
+	}
+	return 0
+}

--- a/internal/minisql/full_text_posting_test.go
+++ b/internal/minisql/full_text_posting_test.go
@@ -1,0 +1,66 @@
+package minisql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullTextPostingPackedEncoding(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := encodeFullTextPosting(fullTextPosting{RowID: 42, Position: 7})
+	require.NoError(t, err)
+	assert.Equal(t, fullTextPosting{RowID: 42, Position: 7}, decodeFullTextPosting(encoded))
+
+	_, err = encodeFullTextPosting(fullTextPosting{RowID: RowID(maxFullTextPostingComponent + 1)})
+	require.ErrorContains(t, err, "exceeds positional posting limit")
+}
+
+func TestFullTextPostingListDeltaEncoding(t *testing.T) {
+	t.Parallel()
+
+	postings := []fullTextPosting{
+		{RowID: 10, Position: 5},
+		{RowID: 1, Position: 2},
+		{RowID: 1, Position: 0},
+		{RowID: 10, Position: 9},
+	}
+	encoded, err := encodeFullTextPostingList(postings)
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+
+	decoded, err := decodeFullTextPostingList(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, []fullTextPosting{
+		{RowID: 1, Position: 0},
+		{RowID: 1, Position: 2},
+		{RowID: 10, Position: 5},
+		{RowID: 10, Position: 9},
+	}, decoded)
+}
+
+func TestFullTextPostingListEmptyAndInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := encodeFullTextPostingList(nil)
+	require.NoError(t, err)
+	assert.Nil(t, encoded)
+
+	decoded, err := decodeFullTextPostingList(nil)
+	require.NoError(t, err)
+	assert.Nil(t, decoded)
+
+	_, err = decodeFullTextPostingList([]byte{0x80})
+	require.ErrorContains(t, err, "row delta")
+}
+
+func TestCompareFullTextPostings(t *testing.T) {
+	t.Parallel()
+
+	assert.Negative(t, compareFullTextPostings(fullTextPosting{RowID: 1, Position: 9}, fullTextPosting{RowID: 2, Position: 0}))
+	assert.Negative(t, compareFullTextPostings(fullTextPosting{RowID: 1, Position: 1}, fullTextPosting{RowID: 1, Position: 2}))
+	assert.Zero(t, compareFullTextPostings(fullTextPosting{RowID: 1, Position: 1}, fullTextPosting{RowID: 1, Position: 1}))
+	assert.Positive(t, compareFullTextPostings(fullTextPosting{RowID: 2, Position: 0}, fullTextPosting{RowID: 1, Position: 9}))
+}

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1114,8 +1114,8 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 		}
 		rows := make(map[RowID][]uint32)
 		for _, posting := range postings {
-			rowID, position := decodeFullTextPosting(posting)
-			rows[rowID] = append(rows[rowID], position)
+			decoded := decodeFullTextPosting(posting)
+			rows[decoded.RowID] = append(rows[decoded.RowID], decoded.Position)
 		}
 		postingsByTerm[term] = rows
 	}

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -231,7 +231,7 @@ func (t *Table) insertFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 		return err
 	}
 	for _, token := range tokens {
-		posting, err := encodeFullTextPosting(rowID, token.Position)
+		posting, err := encodeFullTextPosting(fullTextPosting{RowID: rowID, Position: token.Position})
 		if err != nil {
 			return err
 		}
@@ -266,7 +266,7 @@ func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 		return err
 	}
 	for _, token := range tokens {
-		posting, err := encodeFullTextPosting(rowID, token.Position)
+		posting, err := encodeFullTextPosting(fullTextPosting{RowID: rowID, Position: token.Position})
 		if err != nil {
 			return err
 		}

--- a/internal/minisql/text_search.go
+++ b/internal/minisql/text_search.go
@@ -1,7 +1,6 @@
 package minisql
 
 import (
-	"fmt"
 	"math"
 	"unicode"
 )
@@ -11,11 +10,6 @@ var textSearchStopWords = map[string]struct{}{
 	"for": {}, "from": {}, "in": {}, "is": {}, "it": {}, "of": {}, "on": {}, "or": {},
 	"that": {}, "the": {}, "to": {}, "was": {}, "with": {},
 }
-
-const (
-	fullTextPostingPositionBits = 32
-	maxFullTextPostingComponent = uint64(^uint32(0))
-)
 
 type textSearchTokenPosition struct {
 	Term     string
@@ -27,6 +21,8 @@ type textSearchQuery struct {
 	Phrases [][]string
 }
 
+// textSearchTokens returns the normalized token terms from input, without
+// positions. It is used by ranking and callers that only need term presence.
 func textSearchTokens(input string) []string {
 	positions := textSearchTokenPositions(input)
 	tokens := make([]string, len(positions))
@@ -36,6 +32,8 @@ func textSearchTokens(input string) []string {
 	return tokens
 }
 
+// textSearchTokenPositions lowercases input, splits on non-letter/non-digit
+// boundaries, removes stop words, and assigns dense positions to emitted tokens.
 func textSearchTokenPositions(input string) []textSearchTokenPosition {
 	tokens := make([]textSearchTokenPosition, 0)
 	current := make([]rune, 0, 16)
@@ -69,6 +67,8 @@ func textSearchTokenPositions(input string) []textSearchTokenPosition {
 	return tokens
 }
 
+// uniqueTextSearchTokens returns de-duplicated indexable tokens in first-seen
+// order. Tokens too large for the current B+ tree key format are skipped.
 func uniqueTextSearchTokens(input string) []string {
 	tokens := textSearchTokens(input)
 	seen := make(map[string]struct{}, len(tokens))
@@ -86,6 +86,8 @@ func uniqueTextSearchTokens(input string) []string {
 	return unique
 }
 
+// parseTextSearchQuery splits a MATCH query into plain terms and double-quoted
+// phrases. Plain terms and phrases are combined with implicit AND semantics.
 func parseTextSearchQuery(input string) (textSearchQuery, bool) {
 	var (
 		query       textSearchQuery
@@ -137,6 +139,8 @@ func parseTextSearchQuery(input string) (textSearchQuery, bool) {
 	return query, true
 }
 
+// appendUniqueTextSearchTerms appends terms that are not already present,
+// preserving the order of their first occurrence.
 func appendUniqueTextSearchTerms(existing []string, terms ...string) []string {
 	seen := make(map[string]struct{}, len(existing)+len(terms))
 	for _, term := range existing {
@@ -155,6 +159,8 @@ func appendUniqueTextSearchTerms(existing []string, terms ...string) []string {
 	return existing
 }
 
+// allUniqueTokens returns every distinct token needed to evaluate the query,
+// including tokens that came from phrases.
 func (q textSearchQuery) allUniqueTokens() []string {
 	tokens := appendUniqueTextSearchTerms(nil, q.Terms...)
 	for _, phrase := range q.Phrases {
@@ -163,6 +169,8 @@ func (q textSearchQuery) allUniqueTokens() []string {
 	return tokens
 }
 
+// textSearchMatch evaluates MATCH semantics in memory. Plain query terms must
+// all be present, and every quoted phrase must appear at adjacent token positions.
 func textSearchMatch(document, query string) bool {
 	parsedQuery, ok := parseTextSearchQuery(query)
 	if !ok {
@@ -191,6 +199,8 @@ func textSearchMatch(document, query string) bool {
 	return true
 }
 
+// textSearchRank returns a simple log-scaled term-frequency score for the query
+// tokens. Phrase proximity does not affect ranking yet.
 func textSearchRank(document, query string) float64 {
 	parsedQuery, ok := parseTextSearchQuery(query)
 	if !ok {
@@ -218,6 +228,8 @@ func textSearchRank(document, query string) float64 {
 	return score / float64(len(queryTokens))
 }
 
+// textSearchPhraseMatches reports whether all tokens in phrase appear at
+// consecutive positions in the already-tokenized document position map.
 func textSearchPhraseMatches(positions map[string][]uint32, phrase []string) bool {
 	if len(phrase) == 0 {
 		return false
@@ -249,15 +261,4 @@ func textSearchPhraseMatches(positions map[string][]uint32, phrase []string) boo
 		}
 	}
 	return false
-}
-
-func encodeFullTextPosting(rowID RowID, position uint32) (RowID, error) {
-	if uint64(rowID) > maxFullTextPostingComponent {
-		return 0, fmt.Errorf("full-text row id %d exceeds positional posting limit", rowID)
-	}
-	return RowID(uint64(rowID)<<fullTextPostingPositionBits | uint64(position)), nil
-}
-
-func decodeFullTextPosting(posting RowID) (RowID, uint32) {
-	return RowID(uint64(posting) >> fullTextPostingPositionBits), uint32(posting)
 }

--- a/internal/minisql/text_search_test.go
+++ b/internal/minisql/text_search_test.go
@@ -146,19 +146,6 @@ func TestTextSearchMatch(t *testing.T) {
 	}
 }
 
-func TestFullTextPostingEncoding(t *testing.T) {
-	t.Parallel()
-
-	posting, err := encodeFullTextPosting(42, 7)
-	assert.NoError(t, err)
-	rowID, position := decodeFullTextPosting(posting)
-	assert.Equal(t, RowID(42), rowID)
-	assert.Equal(t, uint32(7), position)
-
-	_, err = encodeFullTextPosting(RowID(maxFullTextPostingComponent+1), 0)
-	assert.ErrorContains(t, err, "exceeds positional posting limit")
-}
-
 func TestTextSearchRank(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implemented the bounded storage-prep.

What changed:
- Added full_text_posting.go with a typed fullTextPosting { RowID, Position }.
- Moved packed posting encode/decode behind that typed codec.
- Added delta + unsigned-varint posting-list encode/decode helpers for future dedicated inverted-index payloads.
- Current full-text index still stores packed positional postings in the existing generic B+ tree posting slots.
- Added focused codec tests in full_text_posting_test.go.
- README now documents that delta/varint codec exists internally as future storage prep, not as the current on-disk posting-list format.