### PR TITLE
feat: full text search  ranking improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ FROM events
 WHERE JSON_CONTAINS(payload, '{"type":"click","tags":["web"]}');
 ```
 
-The v1 index stores generated JSON terms in a non-unique B+ tree. Terms include key existence (`k:user.id`) and scalar key/value entries (`kv:type:s:"click"`, `kv:tags[]:s:"web"`). The planner uses those terms as a prefilter for literal `JSON_CONTAINS(column, 'json')` queries, then rechecks the full predicate against the row for correctness. It does not support posting trees, compression, path-specific operators, or dynamic query expressions yet.
+The v1 index stores generated JSON terms in a non-unique B+ tree. Terms include key existence (`k:user.id`) and scalar key/value entries (`kv:type:s:"click"`, `kv:tags[]:s:"web"`). Generated terms longer than the current 255-byte index-key limit are skipped; indexed queries are always rechecked against the full row, and queries that cannot produce any indexable terms fall back to sequential evaluation. It does not support posting trees, compression, path-specific operators, or dynamic query expressions yet.
 
 ### CAST AS JSON
 
@@ -656,12 +656,12 @@ ON articles (body)
 WITH (tokenizer = 'simple');
 ```
 
-The v1 index stores one B+ tree entry per unique token, with each token pointing at ordered positional postings `(row ID, token position)`. The current on-disk format stores packed positional postings in the generic B+ tree posting slots; a delta/varint posting-list codec exists internally as preparation for a future dedicated inverted-index payload format. It does not rank from index statistics or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting posting rows for all query tokens; quoted phrases such as `MATCH(body, '"database pages"')` additionally require adjacent token positions. Dynamic query expressions fall back to the sequential semantics.
+The v1 index stores one B+ tree entry per unique token, with each token pointing at ordered positional postings `(row ID, token position)`. The current on-disk format stores packed positional postings in the generic B+ tree posting slots; a delta/varint posting-list codec exists internally as preparation for a future dedicated inverted-index payload format. It does not rank from index statistics or use posting trees yet. Literal `MATCH(body, 'mini database')` predicates can use the index by intersecting posting rows for all query tokens; quoted phrases such as `MATCH(body, '"database pages"')` additionally require adjacent token positions. Dynamic query expressions and queries containing tokens longer than the current 255-byte index-key limit fall back to the sequential semantics.
 
 | Function | Description |
 |----------|-------------|
 | `MATCH(doc, query)` | Returns `true` when every non-stop-word query token appears in `doc`. Double-quoted phrases require adjacent indexed token positions, e.g. `WHERE MATCH(body, '"mini database"')`. |
-| `TS_RANK(doc, query)` | Returns a simple relevance score using log-scaled term frequency: `sum(log(1 + term_frequency)) / query_terms`. |
+| `TS_RANK(doc, query)` | Returns a relevance score that combines saturated term frequency, query coverage, mild document-length normalization, exact phrase boosts, and token-proximity boosts. |
 
 Tokenizer v1 lowercases text, splits on non-letter/non-digit boundaries, removes a small built-in English stop-word list, and does not perform stemming. For example, `database` and `databases` are different tokens.
 

--- a/internal/minisql/expr_test.go
+++ b/internal/minisql/expr_test.go
@@ -475,12 +475,12 @@ func TestExpr_Eval_TextSearch(t *testing.T) {
 		assert.Equal(t, true, v)
 	})
 
-	t.Run("TS_RANK uses log-scaled term frequency", func(t *testing.T) {
+	t.Run("TS_RANK returns a positive relevance score", func(t *testing.T) {
 		t.Parallel()
 		e := &Expr{FuncName: "TS_RANK", Args: []*Expr{{Column: "body"}, textExpr("minisql database")}}
 		v, err := e.Eval(row)
 		require.NoError(t, err)
-		assert.InDelta(t, 0.8958, v.(float64), 0.0001)
+		assert.Greater(t, v.(float64), float64(0))
 	})
 
 	t.Run("null arguments produce false match and zero rank", func(t *testing.T) {

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -209,6 +210,30 @@ func TestFullTextIndexScanMissingIndex(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no index found for full-text scan")
+}
+
+func TestPlanQuery_FullTextIndexSkipsOverlongQueryToken(t *testing.T) {
+	t.Parallel()
+
+	bodyColumn := Column{Name: "body", Kind: Text}
+	table := NewTable(testLogger, nil, nil, "articles", []Column{bodyColumn}, 0, nil, WithSecondaryIndex(SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Name:    "idx_body_fts",
+			Method:  IndexMethodFullText,
+			Columns: []Column{bodyColumn},
+		},
+	}))
+
+	plan, err := table.PlanQuery(context.Background(), Statement{
+		Kind:       Select,
+		TableName:  "articles",
+		Columns:    table.Columns,
+		Fields:     []Field{{Name: "body"}},
+		Conditions: OneOrMore{{fullTextMatchCondition("body", "database "+strings.Repeat("x", MaxIndexKeySize+1))}},
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Scans, 1)
+	assert.Equal(t, ScanTypeSequential, plan.Scans[0].Type)
 }
 
 func TestIndexMethodStringAndTokenizer(t *testing.T) {

--- a/internal/minisql/full_text_search.go
+++ b/internal/minisql/full_text_search.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"math"
+	"slices"
 	"unicode"
 )
 
@@ -144,16 +145,15 @@ func parseTextSearchQuery(input string) (textSearchQuery, bool) {
 }
 
 // appendUniqueTextSearchTerms appends terms that are not already present,
-// preserving the order of their first occurrence.
+// preserving the order of their first occurrence. It intentionally does not
+// enforce index key limits so sequential MATCH semantics can still handle long
+// terms; index planning checks key sizes separately.
 func appendUniqueTextSearchTerms(existing []string, terms ...string) []string {
 	seen := make(map[string]struct{}, len(existing)+len(terms))
 	for _, term := range existing {
 		seen[term] = struct{}{}
 	}
 	for _, term := range terms {
-		if len([]byte(term)) > MaxIndexKeySize {
-			continue
-		}
 		if _, ok := seen[term]; ok {
 			continue
 		}
@@ -171,6 +171,24 @@ func (q textSearchQuery) allUniqueTokens() []string {
 		tokens = appendUniqueTextSearchTerms(tokens, phrase...)
 	}
 	return tokens
+}
+
+// hasOverlongToken reports whether any parsed query token cannot be represented
+// as a key in the current full-text B+ tree index.
+func (q textSearchQuery) hasOverlongToken() bool {
+	for _, term := range q.Terms {
+		if len([]byte(term)) > MaxIndexKeySize {
+			return true
+		}
+	}
+	for _, phrase := range q.Phrases {
+		for _, term := range phrase {
+			if len([]byte(term)) > MaxIndexKeySize {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // textSearchMatch evaluates MATCH semantics in memory. Plain query terms must
@@ -203,8 +221,9 @@ func textSearchMatch(document, query string) bool {
 	return true
 }
 
-// textSearchRank returns a simple log-scaled term-frequency score for the query
-// tokens. Phrase proximity does not affect ranking yet.
+// textSearchRank returns a relevance score for the query tokens. It combines
+// saturated term frequency, query coverage, mild document-length normalization,
+// phrase boosts, and proximity boosts from token positions.
 func textSearchRank(document, query string) float64 {
 	parsedQuery, ok := parseTextSearchQuery(query)
 	if !ok {
@@ -215,21 +234,138 @@ func textSearchRank(document, query string) float64 {
 		return 0
 	}
 
-	docTokens := textSearchTokens(document)
+	docTokens := textSearchTokenPositions(document)
 	if len(docTokens) == 0 {
 		return 0
 	}
+	return textSearchRankPositions(docTokens, parsedQuery)
+}
 
+func textSearchRankPositions(docTokens []textSearchTokenPosition, query textSearchQuery) float64 {
+	queryTokens := query.allUniqueTokens()
+	if len(queryTokens) == 0 || len(docTokens) == 0 {
+		return 0
+	}
+
+	positions := make(map[string][]uint32, len(docTokens))
 	frequencies := make(map[string]int, len(docTokens))
 	for _, token := range docTokens {
-		frequencies[token] += 1
+		frequencies[token.Term] += 1
+		positions[token.Term] = append(positions[token.Term], token.Position)
 	}
 
-	var score float64
+	var (
+		frequencyScore float64
+		matchedTerms   int
+	)
 	for _, token := range queryTokens {
-		score += math.Log1p(float64(frequencies[token]))
+		frequency := frequencies[token]
+		if frequency == 0 {
+			continue
+		}
+		matchedTerms += 1
+		frequencyScore += saturatedTermFrequency(frequency)
 	}
-	return score / float64(len(queryTokens))
+
+	if matchedTerms == 0 {
+		return 0
+	}
+
+	coverage := float64(matchedTerms) / float64(len(queryTokens))
+	base := (frequencyScore / float64(len(queryTokens))) * (0.5 + 0.5*coverage)
+	base *= textSearchLengthNormalization(len(docTokens), len(queryTokens))
+
+	return base + textSearchPhraseBoost(positions, query, len(queryTokens)) + textSearchProximityBoost(docTokens, queryTokens, coverage)
+}
+
+func saturatedTermFrequency(frequency int) float64 {
+	if frequency <= 0 {
+		return 0
+	}
+	raw := math.Log1p(float64(frequency))
+	return raw / (1 + raw)
+}
+
+func textSearchLengthNormalization(documentTokens, queryTokens int) float64 {
+	if documentTokens <= 0 || queryTokens <= 0 {
+		return 0
+	}
+	extraTokens := max(documentTokens-queryTokens, 0)
+	return 1 / math.Sqrt(1+float64(extraTokens)/20)
+}
+
+func textSearchPhraseBoost(positions map[string][]uint32, query textSearchQuery, queryTokenCount int) float64 {
+	if queryTokenCount == 0 {
+		return 0
+	}
+	var boost float64
+	for _, phrase := range query.Phrases {
+		if textSearchPhraseMatches(positions, phrase) {
+			boost += 0.25 * (float64(len(phrase)) / float64(queryTokenCount))
+		}
+	}
+	return boost
+}
+
+func textSearchProximityBoost(docTokens []textSearchTokenPosition, queryTokens []string, coverage float64) float64 {
+	if len(queryTokens) < 2 || coverage == 0 {
+		return 0
+	}
+	span, ok := textSearchMinCoverSpan(docTokens, queryTokens)
+	if !ok || span == 0 {
+		return 0
+	}
+	density := float64(len(queryTokens)) / float64(span)
+	return 0.20 * density * coverage
+}
+
+func textSearchMinCoverSpan(docTokens []textSearchTokenPosition, queryTokens []string) (uint32, bool) {
+	querySet := make(map[string]struct{}, len(queryTokens))
+	for _, token := range queryTokens {
+		querySet[token] = struct{}{}
+	}
+	hits := make([]textSearchTokenPosition, 0, len(docTokens))
+	for _, token := range docTokens {
+		if _, ok := querySet[token.Term]; ok {
+			hits = append(hits, token)
+		}
+	}
+	if len(hits) == 0 {
+		return 0, false
+	}
+	slices.SortFunc(hits, func(a, b textSearchTokenPosition) int {
+		return int(a.Position) - int(b.Position)
+	})
+
+	counts := make(map[string]int, len(queryTokens))
+	var (
+		have     int
+		left     int
+		bestSpan uint32
+		found    bool
+	)
+	for right, hit := range hits {
+		if counts[hit.Term] == 0 {
+			have += 1
+		}
+		counts[hit.Term] += 1
+
+		for have == len(queryTokens) {
+			span := hits[right].Position - hits[left].Position + 1
+			if !found || span < bestSpan {
+				bestSpan = span
+				found = true
+			}
+			leftTerm := hits[left].Term
+			counts[leftTerm] -= 1
+			if counts[leftTerm] == 0 {
+				have -= 1
+			}
+			left += 1
+		}
+	}
+
+	return bestSpan, found
 }
 
 // textSearchPhraseMatches reports whether all tokens in phrase appear at

--- a/internal/minisql/full_text_search_test.go
+++ b/internal/minisql/full_text_search_test.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,10 @@ func TestUniqueTextSearchTokens(t *testing.T) {
 
 	got := uniqueTextSearchTokens("MiniSQL minisql database MiniSQL")
 	assert.Equal(t, []string{"minisql", "database"}, got)
+
+	overlong := strings.Repeat("x", MaxIndexKeySize+1)
+	got = uniqueTextSearchTokens("database " + overlong)
+	assert.Equal(t, []string{"database"}, got)
 }
 
 func TestTextSearchTokenPositions(t *testing.T) {
@@ -74,6 +79,11 @@ func TestParseTextSearchQuery(t *testing.T) {
 	assert.Equal(t, []string{"mini"}, query.Terms)
 	assert.Equal(t, [][]string{{"database", "pages"}}, query.Phrases)
 	assert.Equal(t, []string{"mini", "database", "pages"}, query.allUniqueTokens())
+	assert.False(t, query.hasOverlongToken())
+
+	query, ok = parseTextSearchQuery("database " + strings.Repeat("x", MaxIndexKeySize+1))
+	assert.True(t, ok)
+	assert.True(t, query.hasOverlongToken())
 
 	_, ok = parseTextSearchQuery(`"unterminated phrase`)
 	assert.False(t, ok)
@@ -149,48 +159,69 @@ func TestTextSearchMatch(t *testing.T) {
 func TestTextSearchRank(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name     string
-		document string
-		query    string
-		want     float64
-	}{
-		{
-			name:     "log-scaled average term frequency",
-			document: "MiniSQL database database",
-			query:    "minisql database",
-			want:     0.8958797346140275,
-		},
-		{
-			name:     "missing query term contributes zero",
-			document: "MiniSQL database",
-			query:    "minisql postgres",
-			want:     0.34657359027997264,
-		},
-		{
-			name:     "duplicate query tokens are counted once",
-			document: "MiniSQL MiniSQL database",
-			query:    "minisql minisql database",
-			want:     0.8958797346140275,
-		},
-		{
-			name:     "stop-word-only query has zero rank",
-			document: "MiniSQL database",
-			query:    "the and of",
-			want:     0,
-		},
-		{
-			name:     "empty document has zero rank",
-			document: "",
-			query:    "minisql",
-			want:     0,
-		},
-	}
+	t.Run("scores term frequency with saturation", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.InDelta(t, tt.want, textSearchRank(tt.document, tt.query), 0.0000000001)
-		})
-	}
+		oneHit := textSearchRank("MiniSQL database", "minisql database")
+		twoHits := textSearchRank("MiniSQL database database", "minisql database")
+		manyHits := textSearchRank("MiniSQL database "+strings.Repeat("database ", 20), "minisql database")
+
+		assert.Greater(t, twoHits, oneHit)
+		assert.Less(t, manyHits-twoHits, twoHits-oneHit)
+	})
+
+	t.Run("missing query term lowers rank through coverage", func(t *testing.T) {
+		t.Parallel()
+
+		fullMatch := textSearchRank("MiniSQL database", "minisql database")
+		partialMatch := textSearchRank("MiniSQL database", "minisql postgres")
+
+		assert.Greater(t, fullMatch, partialMatch)
+		assert.Greater(t, partialMatch, float64(0))
+	})
+
+	t.Run("duplicate query tokens are counted once", func(t *testing.T) {
+		t.Parallel()
+
+		assert.InDelta(t,
+			textSearchRank("MiniSQL MiniSQL database", "minisql database"),
+			textSearchRank("MiniSQL MiniSQL database", "minisql minisql database"),
+			0.0000000001,
+		)
+	})
+
+	t.Run("phrase match outranks separated terms", func(t *testing.T) {
+		t.Parallel()
+
+		phrase := textSearchRank("MiniSQL stores database pages together", `"database pages"`)
+		separated := textSearchRank("MiniSQL stores database values across many pages", `"database pages"`)
+
+		assert.Greater(t, phrase, separated)
+	})
+
+	t.Run("dense cluster outranks scattered terms", func(t *testing.T) {
+		t.Parallel()
+
+		dense := textSearchRank("mini database pages are nearby", "mini database pages")
+		scattered := textSearchRank("mini "+strings.Repeat("noise ", 20)+"database "+strings.Repeat("noise ", 20)+"pages", "mini database pages")
+
+		assert.Greater(t, dense, scattered)
+	})
+
+	t.Run("short focused document outranks long noisy document", func(t *testing.T) {
+		t.Parallel()
+
+		short := textSearchRank("mini database", "mini database")
+		long := textSearchRank("mini database "+strings.Repeat("noise ", 80), "mini database")
+
+		assert.Greater(t, short, long)
+	})
+
+	t.Run("empty inputs and stop-word-only queries have zero rank", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, float64(0), textSearchRank("MiniSQL database", "the and of"))
+		assert.Equal(t, float64(0), textSearchRank("", "minisql"))
+		assert.Equal(t, float64(0), textSearchRank("MiniSQL database", `"unterminated phrase`))
+	})
 }

--- a/internal/minisql/json_inverted_test.go
+++ b/internal/minisql/json_inverted_test.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,17 @@ func TestJSONInvertedTermsForDocument(t *testing.T) {
 		"kv:type:s:\"click\"",
 		"kv:user.id:s:\"u1\"",
 	}, terms)
+}
+
+func TestJSONInvertedTermsSkipOverlongGeneratedTerms(t *testing.T) {
+	t.Parallel()
+
+	terms, err := jsonInvertedTermsForDocument(`{"short":"ok","long":"` + strings.Repeat("x", MaxIndexKeySize+1) + `"}`)
+	require.NoError(t, err)
+
+	assert.Contains(t, terms, "k:long")
+	assert.Contains(t, terms, `kv:short:s:"ok"`)
+	assert.NotContains(t, terms, `kv:long:s:"`+strings.Repeat("x", MaxIndexKeySize+1)+`"`)
 }
 
 func TestJSONContains(t *testing.T) {

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -473,6 +473,9 @@ func (t *Table) tryFullTextIndexScan(filters OneOrMore) (Scan, bool) {
 	if !ok {
 		return Scan{}, false
 	}
+	if parsedQuery.hasOverlongToken() {
+		return Scan{}, false
+	}
 	tokens := parsedQuery.allUniqueTokens()
 	if len(tokens) == 0 {
 		return Scan{}, false


### PR DESCRIPTION
Implemented step 7 ranking improvements.

`TS_RANK` now combines:

- saturated term frequency
- query coverage
- mild document-length normalization
- exact phrase boosts
- proximity boosts from token positions

In addition, fixed the overlong full-text token edge case: full-text index storage skips terms over MaxIndexKeySize, and the planner now falls back to sequential 1MATCH1 when a query contains an overlong token so we don’t accidentally evaluate only part of the predicate from the index.

For the key-size behavior:

- Full-text document tokens over 255 bytes are skipped in the index.
- Full-text queries containing overlong tokens fall back to sequential evaluation.
- JSON inverted generated terms over 255 bytes are skipped.
- JSON inverted scans keep the full `JSON_CONTAINS` recheck, so skipped terms do not cause incorrect results; if no indexable query terms exist, planning falls back to sequential evaluation.