### PR TITLE
feat: support correlated scalar subqueries in UPDATE SET

### DIFF
--- a/e2e_tests/correlated_subquery_update_test.go
+++ b/e2e_tests/correlated_subquery_update_test.go
@@ -1,0 +1,156 @@
+package e2etests
+
+func (s *TestSuite) TestCorrelatedSubqueryUpdate() {
+	// Schema: departments and employees tables.
+	_, err := s.db.Exec(`create table "depts" (
+		id     int8 primary key autoincrement,
+		name   varchar(100) not null,
+		budget int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "emps" (
+		id      int8 primary key autoincrement,
+		name    varchar(100) not null,
+		dept_id int8 not null,
+		salary  int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	// Seed departments.
+	_, err = s.db.Exec(`insert into "depts" (name, budget) values ('Engineering', 100000)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "depts" (name, budget) values ('Sales', 60000)`)
+	s.Require().NoError(err)
+
+	// Seed employees.
+	_, err = s.db.Exec(`insert into "emps" (name, dept_id, salary) values ('Alice', 1, 0)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "emps" (name, dept_id, salary) values ('Bob', 2, 0)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "emps" (name, dept_id, salary) values ('Carol', 1, 0)`)
+	s.Require().NoError(err)
+
+	s.Run("correlated_set_from_dept_budget", func() {
+		// SET salary = (SELECT budget FROM depts WHERE id = e.dept_id)
+		_, err := s.db.Exec(`
+			update emps e
+			set salary = (select budget from depts where id = e.dept_id)
+		`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select name, salary from emps order by id`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type emp struct {
+			name   string
+			salary int64
+		}
+		var got []emp
+		for rows.Next() {
+			var e emp
+			s.Require().NoError(rows.Scan(&e.name, &e.salary))
+			got = append(got, e)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 3)
+		s.Equal("Alice", got[0].name)
+		s.Equal(int64(100000), got[0].salary, "Alice is in Engineering (budget 100000)")
+		s.Equal("Bob", got[1].name)
+		s.Equal(int64(60000), got[1].salary, "Bob is in Sales (budget 60000)")
+		s.Equal("Carol", got[2].name)
+		s.Equal(int64(100000), got[2].salary, "Carol is in Engineering (budget 100000)")
+	})
+
+	s.Run("correlated_set_with_where_filter", func() {
+		// Reset salaries.
+		_, err := s.db.Exec(`update emps set salary = 0`)
+		s.Require().NoError(err)
+
+		// Only update Engineering employees.
+		_, err = s.db.Exec(`
+			update emps e
+			set salary = (select budget from depts where id = e.dept_id)
+			where e.dept_id = 1
+		`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select name, salary from emps order by id`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type emp struct {
+			name   string
+			salary int64
+		}
+		var got []emp
+		for rows.Next() {
+			var e emp
+			s.Require().NoError(rows.Scan(&e.name, &e.salary))
+			got = append(got, e)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 3)
+		s.Equal(int64(100000), got[0].salary, "Alice updated (Engineering)")
+		s.Equal(int64(0), got[1].salary, "Bob not updated (Sales)")
+		s.Equal(int64(100000), got[2].salary, "Carol updated (Engineering)")
+	})
+
+	s.Run("non_correlated_set_subquery", func() {
+		// Reset salaries.
+		_, err := s.db.Exec(`update emps set salary = 0`)
+		s.Require().NoError(err)
+
+		// Set all salaries to the max budget (non-correlated).
+		_, err = s.db.Exec(`
+			update emps
+			set salary = (select max(budget) from depts)
+		`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select salary from emps order by id`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var salaries []int64
+		for rows.Next() {
+			var sal int64
+			s.Require().NoError(rows.Scan(&sal))
+			salaries = append(salaries, sal)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(salaries, 3)
+		for _, sal := range salaries {
+			s.Equal(int64(100000), sal, "all employees should get the max budget")
+		}
+	})
+
+	s.Run("correlated_set_subquery_no_match_yields_null", func() {
+		// dept_id=99 doesn't exist → subquery returns 0 rows → NULL.
+		_, err := s.db.Exec(`insert into "emps" (name, dept_id, salary) values ('Dave', 99, 9999)`)
+		s.Require().NoError(err)
+
+		_, err = s.db.Exec(`
+			update emps e
+			set salary = (select budget from depts where id = e.dept_id)
+			where e.name = 'Dave'
+		`)
+		s.Require().NoError(err)
+
+		var salary *int64
+		err = s.db.QueryRow(`select salary from emps where name = 'Dave'`).Scan(&salary)
+		s.Require().NoError(err)
+		s.Nil(salary, "unmatched correlated subquery should set column to NULL")
+	})
+
+	s.Run("correlated_subquery_more_than_one_row_errors", func() {
+		// All depts match "id > 0" → subquery returns multiple rows → error.
+		_, err := s.db.Exec(`
+			update emps e
+			set salary = (select budget from depts where id > 0)
+			where e.name = 'Alice'
+		`)
+		s.Require().Error(err, "multi-row scalar subquery in SET must error")
+	})
+}

--- a/internal/minisql/correlated_subquery.go
+++ b/internal/minisql/correlated_subquery.go
@@ -1,0 +1,282 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+)
+
+// ctxKeyCorrelatedSetUpdates is the context key for pre-computed per-row SET values.
+type ctxKeyCorrelatedSetUpdates struct{}
+
+// correlatedSetUpdates maps RowID → (column name → pre-computed value).
+// Built before the write lock is acquired and consumed inside Table.Update.
+type correlatedSetUpdates map[RowID]map[string]OptionalValue
+
+func contextWithCorrelatedSetUpdates(ctx context.Context, u correlatedSetUpdates) context.Context {
+	return context.WithValue(ctx, ctxKeyCorrelatedSetUpdates{}, u)
+}
+
+func correlatedSetUpdatesFromContext(ctx context.Context) (correlatedSetUpdates, bool) {
+	v, ok := ctx.Value(ctxKeyCorrelatedSetUpdates{}).(correlatedSetUpdates)
+	return v, ok
+}
+
+// resolveSetSubqueries inspects stmt.Updates for *Statement values (subqueries in
+// SET).  Non-correlated subqueries are executed once and replaced with their scalar
+// result.  Correlated subqueries (whose WHERE conditions reference outer-table
+// columns) require per-row execution: this function does a read scan of the target
+// table, executes each correlated subquery once per matching row, and stores the
+// results in the returned context so that Table.Update can consume them.
+//
+// Must be called BEFORE the write lock is acquired because subquery execution itself
+// calls ExecuteStatement → GetTable → RLock.
+func (d *Database) resolveSetSubqueries(ctx context.Context, stmt *Statement) (context.Context, error) {
+	// Fast path: no subquery values in SET.
+	hasSubquery := false
+	for _, val := range stmt.Updates {
+		if _, ok := val.Value.(*Statement); ok {
+			hasSubquery = true
+			break
+		}
+	}
+	if !hasSubquery {
+		return ctx, nil
+	}
+
+	targetTable, ok := d.tables[stmt.TableName]
+	if !ok {
+		// Table not found — will fail later with a proper error.
+		return ctx, nil
+	}
+
+	outerAlias := stmt.TableAlias
+	if outerAlias == "" {
+		outerAlias = stmt.TableName
+	}
+
+	type subEntry struct {
+		colName   string
+		inner     Statement
+		correlated bool
+	}
+	var entries []subEntry
+
+	for colName, val := range stmt.Updates {
+		inner, ok := val.Value.(*Statement)
+		if !ok {
+			continue
+		}
+		corr := isCorrelatedSetSubquery(*inner, targetTable.Columns, stmt.TableName, outerAlias)
+		entries = append(entries, subEntry{colName, *inner, corr})
+	}
+
+	// Handle non-correlated subqueries first: execute once and substitute.
+	for _, e := range entries {
+		if e.correlated {
+			continue
+		}
+		var val OptionalValue
+		if err := d.txManager.ExecuteReadOnlyTransaction(ctx, func(roCtx context.Context) error {
+			var err error
+			val, err = d.executeScalarSetSubquery(roCtx, e.inner)
+			return err
+		}); err != nil {
+			return ctx, fmt.Errorf("SET subquery for column %q: %w", e.colName, err)
+		}
+		stmt.Updates[e.colName] = val
+	}
+
+	// Collect correlated entries.
+	var corrEntries []subEntry
+	for _, e := range entries {
+		if e.correlated {
+			corrEntries = append(corrEntries, e)
+		}
+	}
+	if len(corrEntries) == 0 {
+		return ctx, nil
+	}
+
+	// Read scan: collect all target rows that match the WHERE clause.
+	// We re-use the same conditions as the UPDATE to avoid computing new values
+	// for rows that won't actually be updated.
+	scanStmt := Statement{
+		Kind:       Select,
+		TableName:  stmt.TableName,
+		TableAlias: outerAlias,
+		Columns:    targetTable.Columns,
+		Fields:     fieldsFromColumns(targetTable.Columns...),
+		Conditions: stmt.Conditions,
+	}
+
+	precomputed := make(correlatedSetUpdates)
+	scanErr := d.txManager.ExecuteReadOnlyTransaction(ctx, func(roCtx context.Context) error {
+		selectResult, err := targetTable.Select(roCtx, scanStmt)
+		if err != nil {
+			return fmt.Errorf("correlated SET subquery: scanning target table: %w", err)
+		}
+
+		for selectResult.Rows.Next(roCtx) {
+			outerRow := selectResult.Rows.Row()
+			rowUpdates := make(map[string]OptionalValue, len(corrEntries))
+			for _, e := range corrEntries {
+				bound := bindOuterRowToStatement(e.inner, outerRow, stmt.TableName, outerAlias)
+				val, err := d.executeScalarSetSubquery(roCtx, bound)
+				if err != nil {
+					return fmt.Errorf("correlated SET subquery for column %q: %w", e.colName, err)
+				}
+				rowUpdates[e.colName] = val
+			}
+			precomputed[outerRow.Key] = rowUpdates
+		}
+		return selectResult.Rows.Err()
+	})
+	if scanErr != nil {
+		return ctx, fmt.Errorf("correlated SET subquery: %w", scanErr)
+	}
+
+	// Leave *Statement placeholders in stmt.Updates so that validateUpdate does
+	// not see an empty Updates map.  Table.Update will overlay the pre-computed
+	// values before cursor.update is called; cursor.update guards against any
+	// *Statement that slips through.
+
+	return contextWithCorrelatedSetUpdates(ctx, precomputed), nil
+}
+
+// executeScalarSetSubquery runs stmt and returns the first column of the first row.
+// Zero rows → NULL; more than one row → error.
+func (d *Database) executeScalarSetSubquery(ctx context.Context, stmt Statement) (OptionalValue, error) {
+	result, err := d.ExecuteStatement(ctx, stmt)
+	if err != nil {
+		return OptionalValue{}, err
+	}
+	if len(result.Columns) != 1 {
+		return OptionalValue{}, fmt.Errorf("subquery used as expression must return exactly one column, got %d", len(result.Columns))
+	}
+	if !result.Rows.Next(ctx) {
+		if err := result.Rows.Err(); err != nil {
+			return OptionalValue{}, err
+		}
+		return OptionalValue{Valid: false}, nil // NULL
+	}
+	row := result.Rows.Row()
+	// Guard: more than one row is an error.
+	if result.Rows.Next(ctx) {
+		return OptionalValue{}, fmt.Errorf("more than one row returned by a subquery used as an expression")
+	}
+	if err := result.Rows.Err(); err != nil {
+		return OptionalValue{}, err
+	}
+	if len(row.Values) == 0 || !row.Values[0].Valid {
+		return OptionalValue{Valid: false}, nil
+	}
+	return row.Values[0], nil
+}
+
+// isCorrelatedSetSubquery reports whether inner's WHERE conditions contain any
+// reference to an outer-table column, identified by outerTableName or outerAlias
+// as an AliasPrefix, or as an unqualified name matching a column in outerCols.
+func isCorrelatedSetSubquery(inner Statement, outerCols []Column, outerTableName, outerAlias string) bool {
+	outerColSet := make(map[string]bool, len(outerCols))
+	for _, col := range outerCols {
+		outerColSet[col.Name] = true
+	}
+	return conditionsHaveOuterRef(inner.Conditions, outerColSet, outerTableName, outerAlias)
+}
+
+func conditionsHaveOuterRef(conds OneOrMore, outerColSet map[string]bool, outerTableName, outerAlias string) bool {
+	for _, group := range conds {
+		for _, cond := range group {
+			for _, op := range [2]Operand{cond.Operand1, cond.Operand2} {
+				if op.Type != OperandField {
+					continue
+				}
+				f, ok := op.Value.(Field)
+				if !ok {
+					continue
+				}
+				if f.AliasPrefix == outerTableName || (outerAlias != outerTableName && f.AliasPrefix == outerAlias) {
+					return true
+				}
+				// Unqualified name that matches an outer column.
+				if f.AliasPrefix == "" && outerColSet[f.Name] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// bindOuterRowToStatement returns a copy of inner with all outer-table column
+// references in the WHERE conditions replaced by the concrete values from outerRow.
+func bindOuterRowToStatement(inner Statement, outerRow Row, outerTableName, outerAlias string) Statement {
+	bound := inner
+	bound.Conditions = bindOuterRowToConditions(inner.Conditions, outerRow, outerTableName, outerAlias)
+	return bound
+}
+
+func bindOuterRowToConditions(conds OneOrMore, outerRow Row, outerTableName, outerAlias string) OneOrMore {
+	result := make(OneOrMore, len(conds))
+	for gi, group := range conds {
+		newGroup := make([]Condition, len(group))
+		for ci, cond := range group {
+			newCond := cond
+			newCond.Operand1 = bindOuterOperand(cond.Operand1, outerRow, outerTableName, outerAlias)
+			newCond.Operand2 = bindOuterOperand(cond.Operand2, outerRow, outerTableName, outerAlias)
+			newGroup[ci] = newCond
+		}
+		result[gi] = newGroup
+	}
+	return result
+}
+
+func bindOuterOperand(op Operand, outerRow Row, outerTableName, outerAlias string) Operand {
+	if op.Type != OperandField {
+		return op
+	}
+	f, ok := op.Value.(Field)
+	if !ok {
+		return op
+	}
+
+	isOuterRef := f.AliasPrefix == outerTableName ||
+		(outerAlias != outerTableName && f.AliasPrefix == outerAlias)
+
+	if !isOuterRef {
+		return op
+	}
+
+	val, ok := outerRow.GetValue(f.Name)
+	if !ok {
+		return op
+	}
+	return operandFromOptionalValue(val)
+}
+
+// operandFromOptionalValue converts a concrete row value to the matching Operand.
+func operandFromOptionalValue(val OptionalValue) Operand {
+	if !val.Valid {
+		return Operand{Type: OperandNull}
+	}
+	switch v := val.Value.(type) {
+	case int64:
+		return Operand{Type: OperandInteger, Value: v}
+	case int32:
+		return Operand{Type: OperandInteger, Value: int64(v)}
+	case float64:
+		return Operand{Type: OperandFloat, Value: v}
+	case float32:
+		return Operand{Type: OperandFloat, Value: float64(v)}
+	case bool:
+		return Operand{Type: OperandBoolean, Value: v}
+	case TextPointer:
+		return Operand{Type: OperandQuotedString, Value: string(v.Data)}
+	case string:
+		return Operand{Type: OperandQuotedString, Value: v}
+	case TimestampMicros:
+		return Operand{Type: OperandQuotedString, Value: v}
+	default:
+		return Operand{Type: OperandNull}
+	}
+}

--- a/internal/minisql/correlated_subquery_test.go
+++ b/internal/minisql/correlated_subquery_test.go
@@ -1,0 +1,389 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── DB-backed tests for resolveSetSubqueries / executeScalarSetSubquery ──────
+
+// corrSubqueryDB returns the same two-table DB as updateFromTestDB so that the
+// correlated-subquery unit tests don't duplicate the setup code.
+func corrSubqueryDB(t *testing.T) *Database {
+	t.Helper()
+	return updateFromTestDB(t)
+}
+
+func TestResolveSetSubqueries_NoSubqueries(t *testing.T) {
+	// Fast path: no *Statement in Updates → context returned unchanged.
+	db := corrSubqueryDB(t)
+	stmt := &Statement{
+		Kind:      Update,
+		TableName: "employees",
+		Updates: map[string]OptionalValue{
+			"dept_id": {Valid: true, Value: int64(1)},
+		},
+	}
+	ctx := context.Background()
+	newCtx, err := db.resolveSetSubqueries(ctx, stmt)
+	require.NoError(t, err)
+	_, ok := correlatedSetUpdatesFromContext(newCtx)
+	assert.False(t, ok, "no correlatedSetUpdates should be in context when there are no subqueries")
+	assert.Equal(t, int64(1), stmt.Updates["dept_id"].Value, "literal value must be unchanged")
+}
+
+func TestResolveSetSubqueries_TableNotFound(t *testing.T) {
+	// Target table not in DB → function returns ctx unchanged without error.
+	db := corrSubqueryDB(t)
+	inner := &Statement{Kind: Select, TableName: "departments", Fields: []Field{{Name: "id"}}}
+	stmt := &Statement{
+		Kind:      Update,
+		TableName: "no_such_table",
+		Updates:   map[string]OptionalValue{"dept_id": {Valid: true, Value: inner}},
+	}
+	ctx := context.Background()
+	newCtx, err := db.resolveSetSubqueries(ctx, stmt)
+	require.NoError(t, err)
+	_, ok := correlatedSetUpdatesFromContext(newCtx)
+	assert.False(t, ok)
+}
+
+func TestResolveSetSubqueries_NonCorrelated_OneRow(t *testing.T) {
+	// Non-correlated subquery returning exactly one row → value substituted into stmt.Updates.
+	db := corrSubqueryDB(t)
+	// SELECT id FROM departments WHERE departments.id = 1  (qualified → no outer-table reference)
+	// Using AliasPrefix "departments" prevents conditionsHaveOuterRef from treating the
+	// unqualified "id" as an outer-table column match.
+	inner := &Statement{
+		Kind:      Select,
+		TableName: "departments",
+		Fields:    []Field{{Name: "id"}},
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id", AliasPrefix: "departments"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+				},
+			},
+		},
+	}
+	stmt := &Statement{
+		Kind:      Update,
+		TableName: "employees",
+		Updates:   map[string]OptionalValue{"dept_id": {Valid: true, Value: inner}},
+	}
+	ctx := context.Background()
+	newCtx, err := db.resolveSetSubqueries(ctx, stmt)
+	require.NoError(t, err)
+	// The *Statement placeholder must be replaced with the scalar result (int64(1)).
+	assert.Equal(t, int64(1), stmt.Updates["dept_id"].Value)
+	assert.True(t, stmt.Updates["dept_id"].Valid)
+	// Non-correlated path does not populate the context map.
+	_, ok := correlatedSetUpdatesFromContext(newCtx)
+	assert.False(t, ok)
+}
+
+func TestResolveSetSubqueries_NonCorrelated_NoRows(t *testing.T) {
+	// Non-correlated subquery returning zero rows → NULL substituted.
+	db := corrSubqueryDB(t)
+	inner := &Statement{
+		Kind:      Select,
+		TableName: "departments",
+		Fields:    []Field{{Name: "id"}},
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id", AliasPrefix: "departments"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandInteger, Value: int64(999)},
+				},
+			},
+		},
+	}
+	stmt := &Statement{
+		Kind:      Update,
+		TableName: "employees",
+		Updates:   map[string]OptionalValue{"dept_id": {Valid: true, Value: inner}},
+	}
+	ctx := context.Background()
+	_, err := db.resolveSetSubqueries(ctx, stmt)
+	require.NoError(t, err)
+	assert.False(t, stmt.Updates["dept_id"].Valid, "zero-row subquery should produce NULL")
+}
+
+func TestResolveSetSubqueries_NonCorrelated_MultipleRows(t *testing.T) {
+	// Non-correlated subquery returning multiple rows → error.
+	db := corrSubqueryDB(t)
+	// SELECT id FROM departments (no WHERE → returns all 2 rows)
+	inner := &Statement{
+		Kind:      Select,
+		TableName: "departments",
+		Fields:    []Field{{Name: "id"}},
+	}
+	stmt := &Statement{
+		Kind:      Update,
+		TableName: "employees",
+		Updates:   map[string]OptionalValue{"dept_id": {Valid: true, Value: inner}},
+	}
+	ctx := context.Background()
+	_, err := db.resolveSetSubqueries(ctx, stmt)
+	require.Error(t, err, "multi-row scalar subquery must produce an error")
+	assert.Contains(t, err.Error(), "more than one row")
+}
+
+func TestResolveSetSubqueries_Correlated(t *testing.T) {
+	// Correlated subquery: per-row values pre-computed and stored in context.
+	db := corrSubqueryDB(t)
+	// inner: SELECT id FROM departments WHERE id = e.dept_id
+	inner := &Statement{
+		Kind:      Select,
+		TableName: "departments",
+		Fields:    []Field{{Name: "id"}},
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+					Operator: Eq,
+					// e.dept_id — qualified reference to outer employees alias.
+					Operand2: Operand{Type: OperandField, Value: Field{Name: "dept_id", AliasPrefix: "e"}},
+				},
+			},
+		},
+	}
+	stmt := &Statement{
+		Kind:       Update,
+		TableName:  "employees",
+		TableAlias: "e",
+		Updates:    map[string]OptionalValue{"dept_id": {Valid: true, Value: inner}},
+	}
+	ctx := context.Background()
+	newCtx, err := db.resolveSetSubqueries(ctx, stmt)
+	require.NoError(t, err)
+
+	// correlatedSetUpdates must be in context.
+	updates, ok := correlatedSetUpdatesFromContext(newCtx)
+	require.True(t, ok)
+	// One entry per employee row (2 employees in the test DB).
+	assert.Len(t, updates, 2)
+
+	// The *Statement placeholder must remain in stmt.Updates so that validateUpdate
+	// can verify there is at least one field to update.
+	_, isStmt := stmt.Updates["dept_id"].Value.(*Statement)
+	assert.True(t, isStmt, "*Statement placeholder must not be removed from stmt.Updates")
+
+	// Verify per-row results: Alice has dept_id=0 (no match → NULL),
+	// Bob has dept_id=2 (matches dept id=2 → int64(2)).
+	var nullCount, matchCount int
+	for _, rowUpdates := range updates {
+		v, exists := rowUpdates["dept_id"]
+		if !exists {
+			continue
+		}
+		if !v.Valid {
+			nullCount++
+		} else {
+			matchCount++
+			assert.Equal(t, int64(2), v.Value, "matched dept id must be 2")
+		}
+	}
+	assert.Equal(t, 1, nullCount, "Alice (dept_id=0) should have NULL result")
+	assert.Equal(t, 1, matchCount, "Bob (dept_id=2) should have a matched result")
+}
+
+// ── pure helper tests ──────────────────────────────────────────────────────
+
+func TestIsCorrelatedSetSubquery_Qualified(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "id", Kind: Int8}, {Name: "dept_id", Kind: Int8}}
+
+	inner := Statement{
+		Kind:      Select,
+		TableName: "depts",
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id", AliasPrefix: "depts"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandField, Value: Field{Name: "dept_id", AliasPrefix: "e"}},
+				},
+			},
+		},
+	}
+
+	assert.True(t, isCorrelatedSetSubquery(inner, outerCols, "employees", "e"))
+}
+
+func TestIsCorrelatedSetSubquery_Unqualified(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "dept_id", Kind: Int8}}
+
+	inner := Statement{
+		Kind:      Select,
+		TableName: "depts",
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandField, Value: Field{Name: "dept_id"}},
+				},
+			},
+		},
+	}
+
+	assert.True(t, isCorrelatedSetSubquery(inner, outerCols, "employees", "employees"))
+}
+
+func TestIsCorrelatedSetSubquery_NonCorrelated(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "id", Kind: Int8}}
+
+	inner := Statement{
+		Kind:      Select,
+		TableName: "depts",
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "active", AliasPrefix: "depts"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandBoolean, Value: true},
+				},
+			},
+		},
+	}
+
+	assert.False(t, isCorrelatedSetSubquery(inner, outerCols, "employees", "employees"))
+}
+
+func TestIsCorrelatedSetSubquery_EmptyConditions(t *testing.T) {
+	t.Parallel()
+	outerCols := []Column{{Name: "id", Kind: Int8}}
+	inner := Statement{Kind: Select, TableName: "depts"}
+	assert.False(t, isCorrelatedSetSubquery(inner, outerCols, "employees", "employees"))
+}
+
+func TestBindOuterOperand_QualifiedRef(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "dept_id", Kind: Int8}}
+	outerRow := NewRowWithValues(outerCols, []OptionalValue{{Valid: true, Value: int64(42)}})
+
+	op := Operand{Type: OperandField, Value: Field{Name: "dept_id", AliasPrefix: "e"}}
+	bound := bindOuterOperand(op, outerRow, "employees", "e")
+
+	assert.Equal(t, OperandInteger, bound.Type)
+	assert.Equal(t, int64(42), bound.Value)
+}
+
+func TestBindOuterOperand_NonOuterRef(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "dept_id", Kind: Int8}}
+	outerRow := NewRowWithValues(outerCols, []OptionalValue{{Valid: true, Value: int64(42)}})
+
+	// AliasPrefix is "depts" — refers to inner table, not outer.
+	op := Operand{Type: OperandField, Value: Field{Name: "id", AliasPrefix: "depts"}}
+	bound := bindOuterOperand(op, outerRow, "employees", "e")
+
+	// Unchanged.
+	assert.Equal(t, op, bound)
+}
+
+func TestBindOuterOperand_NullValue(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "x", Kind: Int8}}
+	outerRow := NewRowWithValues(outerCols, []OptionalValue{{Valid: false}})
+
+	op := Operand{Type: OperandField, Value: Field{Name: "x", AliasPrefix: "t"}}
+	bound := bindOuterOperand(op, outerRow, "tbl", "t")
+
+	assert.Equal(t, OperandNull, bound.Type)
+}
+
+func TestBindOuterRowToStatement(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{{Name: "dept_id", Kind: Int8}}
+	outerRow := NewRowWithValues(outerCols, []OptionalValue{{Valid: true, Value: int64(7)}})
+
+	inner := Statement{
+		Kind:      Select,
+		TableName: "depts",
+		Conditions: OneOrMore{
+			{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+					Operator: Eq,
+					Operand2: Operand{Type: OperandField, Value: Field{Name: "dept_id", AliasPrefix: "e"}},
+				},
+			},
+		},
+	}
+
+	bound := bindOuterRowToStatement(inner, outerRow, "employees", "e")
+
+	// Operand2 should now be the concrete value 7, not a field ref.
+	cond := bound.Conditions[0][0]
+	assert.Equal(t, OperandInteger, cond.Operand2.Type)
+	assert.Equal(t, int64(7), cond.Operand2.Value)
+
+	// Original must not be mutated.
+	assert.Equal(t, OperandField, inner.Conditions[0][0].Operand2.Type)
+}
+
+func TestOperandFromOptionalValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    OptionalValue
+		wantType OperandType
+		wantVal  any
+	}{
+		{"null", OptionalValue{Valid: false}, OperandNull, nil},
+		{"int64", OptionalValue{Valid: true, Value: int64(5)}, OperandInteger, int64(5)},
+		{"int32", OptionalValue{Valid: true, Value: int32(3)}, OperandInteger, int64(3)},
+		{"float64", OptionalValue{Valid: true, Value: float64(1.5)}, OperandFloat, float64(1.5)},
+		{"float32", OptionalValue{Valid: true, Value: float32(2.5)}, OperandFloat, float64(float32(2.5))},
+		{"bool", OptionalValue{Valid: true, Value: true}, OperandBoolean, true},
+		{"TextPointer", OptionalValue{Valid: true, Value: NewTextPointer([]byte("hi"))}, OperandQuotedString, "hi"},
+		{"string", OptionalValue{Valid: true, Value: "hello"}, OperandQuotedString, "hello"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := operandFromOptionalValue(tc.input)
+			assert.Equal(t, tc.wantType, got.Type)
+			if tc.wantVal != nil {
+				assert.Equal(t, tc.wantVal, got.Value)
+			}
+		})
+	}
+}
+
+func TestContextWithCorrelatedSetUpdates(t *testing.T) {
+	t.Parallel()
+
+	updates := correlatedSetUpdates{
+		RowID(1): {"salary": {Valid: true, Value: int64(5000)}},
+	}
+	ctx := contextWithCorrelatedSetUpdates(context.Background(), updates)
+	got, ok := correlatedSetUpdatesFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, int64(5000), got[RowID(1)]["salary"].Value)
+}
+
+func TestCorrelatedSetUpdatesFromContext_Missing(t *testing.T) {
+	t.Parallel()
+	_, ok := correlatedSetUpdatesFromContext(context.Background())
+	assert.False(t, ok)
+}
+

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -255,6 +255,12 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		changedValues = map[string]Column{}
 	)
 	for name, value := range stmt.Updates {
+		// Correlated subquery placeholders must have been resolved by
+		// resolveSetSubqueries before reaching here; if one slips through it
+		// indicates a programming error.
+		if _, isSub := value.Value.(*Statement); isSub {
+			return false, fmt.Errorf("internal error: unresolved correlated subquery for column %q in cursor.update", name)
+		}
 		// Evaluate arithmetic expressions against the current row before applying.
 		if expr, ok := value.Value.(*Expr); ok {
 			result, err := expr.Eval(row)

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -501,6 +501,16 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 			ctx = contextWithUpdateFromRows(ctx, fromRows)
 		}
 
+		// Correlated SET subqueries: pre-compute per-row values before acquiring
+		// the write lock for the same re-entrancy reason as UPDATE FROM above.
+		if stmt.Kind == Update {
+			var err error
+			ctx, err = d.resolveSetSubqueries(ctx, &stmt)
+			if err != nil {
+				return StatementResult{}, err
+			}
+		}
+
 		table, ok := d.GetTable(ctx, stmt.TableName)
 		if !ok {
 			return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.TableName)

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -1488,8 +1488,12 @@ func (s Statement) validateUpdate(table *Table) error {
 			return fmt.Errorf("unknown field %q in table %q", field.Name, table.Name)
 		}
 		updateVal := s.Updates[field.Name]
-		// Arithmetic expressions are evaluated at execution time — skip static type validation.
+		// Arithmetic expressions and correlated subqueries are evaluated at execution
+		// time — skip static type validation for both.
 		if _, isExpr := updateVal.Value.(*Expr); isExpr {
+			continue
+		}
+		if _, isSub := updateVal.Value.(*Statement); isSub {
 			continue
 		}
 		if err := s.validateColumnValue(table, col, updateVal); err != nil {

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -34,23 +34,59 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 	// affects indexed columns. If not, and the row size does not increase, we update
 	// rows in-place as we encounter them. Otherwise we collect all rows first and
 	// update them afterwards to avoid conflicts with B-tree structural changes.
+	type pendingRow struct {
+		row  Row
+		stmt Statement // may carry per-row correlated SET values
+	}
 	var (
-		cantUpdateInPlace []Row
+		cantUpdateInPlace []pendingRow
 		updatedKeys       []RowID // tracked only when RETURNING is requested
 	)
 
+	// Pre-computed correlated SET subquery values (built in resolveSetSubqueries).
+	corrUpdates, hasCorrUpdates := correlatedSetUpdatesFromContext(ctx)
+
+	// mergeCorrelatedUpdates returns a statement with per-row correlated SET values
+	// merged in.  If there are none, it returns stmt unchanged.
+	mergeCorrelatedUpdates := func(row Row) Statement {
+		if !hasCorrUpdates {
+			return stmt
+		}
+		rowMap, ok := corrUpdates[row.Key]
+		if !ok || len(rowMap) == 0 {
+			return stmt
+		}
+		merged := make(map[string]OptionalValue, len(stmt.Updates)+len(rowMap))
+		for k, v := range stmt.Updates {
+			merged[k] = v
+		}
+		for k, v := range rowMap {
+			merged[k] = v
+		}
+		s := stmt
+		s.Updates = merged
+		return s
+	}
+
 	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+		rowStmt := mergeCorrelatedUpdates(row)
+
 		size := row.Size()
 		newSize := size
 
 		indexChanges := false
-		for colName, newValue := range stmt.Updates {
-			col, _ := stmt.ColumnByName(colName)
+		for colName, newValue := range rowStmt.Updates {
+			col, _ := rowStmt.ColumnByName(colName)
 			oldValue, _ := row.GetValue(colName)
 
-			// Expression values are evaluated at execution time — their actual value
-			// and size are unknown statically, so we must use the full update path.
+			// Expression values and correlated subquery placeholders are resolved at
+			// execution time — their actual value and size are unknown statically,
+			// so we must use the full update path.
 			if _, isExpr := newValue.Value.(*Expr); isExpr {
+				indexChanges = true
+				break
+			}
+			if _, isSub := newValue.Value.(*Statement); isSub {
 				indexChanges = true
 				break
 			}
@@ -85,7 +121,7 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 			if err != nil {
 				return err
 			}
-			changed, err := cursor.update(ctx, stmt, row)
+			changed, err := cursor.update(ctx, rowStmt, row)
 			if err != nil {
 				return err
 			}
@@ -99,20 +135,20 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 
 		// Cannot update in place — collect and defer.
-		cantUpdateInPlace = append(cantUpdateInPlace, row)
+		cantUpdateInPlace = append(cantUpdateInPlace, pendingRow{row: row, stmt: rowStmt})
 		return nil
 	}); err != nil {
 		return result, err
 	}
 
 	// Apply deferred updates for rows that couldn't be updated in place.
-	for _, row := range cantUpdateInPlace {
-		cursor, err := t.Seek(ctx, row.Key)
+	for _, pending := range cantUpdateInPlace {
+		cursor, err := t.Seek(ctx, pending.row.Key)
 		if err != nil {
 			return result, err
 		}
 
-		changed, err := cursor.update(ctx, stmt, row)
+		changed, err := cursor.update(ctx, pending.stmt, pending.row)
 		if err != nil {
 			return result, err
 		}
@@ -120,7 +156,7 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		if changed {
 			result.RowsAffected += 1
 			if len(stmt.ReturningFields) > 0 {
-				updatedKeys = append(updatedKeys, row.Key)
+				updatedKeys = append(updatedKeys, pending.row.Key)
 			}
 		}
 	}

--- a/internal/parser/correlated_subquery_test.go
+++ b/internal/parser/correlated_subquery_test.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_UpdateSetSubquery_NonCorrelated(t *testing.T) {
+	t.Parallel()
+
+	sql := `UPDATE products SET price = (SELECT AVG(price) FROM products)`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Update, stmt.Kind)
+	assert.Equal(t, "products", stmt.TableName)
+
+	val, ok := stmt.Updates["price"]
+	require.True(t, ok, "price must be in Updates")
+	inner, ok := val.Value.(*minisql.Statement)
+	require.True(t, ok, "SET value must be *Statement (subquery)")
+	assert.Equal(t, minisql.Select, inner.Kind)
+	assert.Equal(t, "products", inner.TableName)
+}
+
+func TestParse_UpdateSetSubquery_Correlated(t *testing.T) {
+	t.Parallel()
+
+	sql := `UPDATE employees e SET salary = (SELECT avg_salary FROM depts WHERE id = e.dept_id) WHERE e.active = true`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Update, stmt.Kind)
+	assert.Equal(t, "employees", stmt.TableName)
+	assert.Equal(t, "e", stmt.TableAlias)
+
+	val, ok := stmt.Updates["salary"]
+	require.True(t, ok, "salary must be in Updates")
+	inner, ok := val.Value.(*minisql.Statement)
+	require.True(t, ok, "SET value must be *Statement (subquery)")
+	assert.Equal(t, minisql.Select, inner.Kind)
+	assert.Equal(t, "depts", inner.TableName)
+	require.NotEmpty(t, inner.Conditions)
+}
+
+func TestParse_UpdateSetSubquery_MultipleColumns(t *testing.T) {
+	t.Parallel()
+
+	sql := `UPDATE employees e SET salary = (SELECT avg_salary FROM depts WHERE id = e.dept_id), bonus = (SELECT avg_bonus FROM depts WHERE id = e.dept_id)`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Update, stmt.Kind)
+
+	salaryVal, ok := stmt.Updates["salary"]
+	require.True(t, ok)
+	_, ok = salaryVal.Value.(*minisql.Statement)
+	require.True(t, ok, "salary SET value must be *Statement")
+
+	bonusVal, ok := stmt.Updates["bonus"]
+	require.True(t, ok)
+	_, ok = bonusVal.Value.(*minisql.Statement)
+	require.True(t, ok, "bonus SET value must be *Statement")
+}
+
+func TestParse_UpdateSetSubquery_MixedWithLiteral(t *testing.T) {
+	t.Parallel()
+
+	sql := `UPDATE employees e SET salary = (SELECT avg_salary FROM depts WHERE id = e.dept_id), active = true`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	_, isSubquery := stmt.Updates["salary"].Value.(*minisql.Statement)
+	assert.True(t, isSubquery, "salary must be subquery")
+	assert.Equal(t, true, stmt.Updates["active"].Value, "active must be bool literal")
+}
+
+func TestParse_UpdateSetSubquery_WithoutWhere(t *testing.T) {
+	t.Parallel()
+
+	sql := `UPDATE products SET price = (SELECT AVG(price) FROM products)`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	assert.Empty(t, stmt.Conditions, "no WHERE clause should produce empty conditions")
+}

--- a/internal/parser/update.go
+++ b/internal/parser/update.go
@@ -60,6 +60,31 @@ func (p *parserItem) doParseUpdate() error {
 		p.pop()
 		p.step = stepUpdateValue
 	case stepUpdateValue:
+		// Subquery in SET: SET col = (SELECT …)
+		if p.peek() == "(" {
+			rest := strings.TrimSpace(p.sql[p.i+1:])
+			if strings.HasPrefix(strings.ToUpper(rest), "SELECT") {
+				p.pop() // consume "("
+				subStmt, err := p.parseSubquery()
+				if err != nil {
+					return err
+				}
+				p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: subStmt, Valid: true})
+				p.nextUpdateField = ""
+				maybeNext := strings.ToUpper(p.peek())
+				if maybeNext == "WHERE" {
+					p.step = stepWhere
+					return nil
+				}
+				if maybeNext == "FROM" {
+					p.pop()
+					p.step = stepUpdateFrom
+					return nil
+				}
+				p.step = stepUpdateComma
+				return nil
+			}
+		}
 		specialValue := strings.ToUpper(p.peek())
 		switch specialValue {
 		case "?":


### PR DESCRIPTION
Support correlated scalar subqueries in UPDATE SET, e.g.:

```sql
UPDATE employees SET salary = (SELECT avg_salary FROM depts WHERE id = employees.dept_id) 
```