### PR TITLE
feat: implemented the first inverted-index benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test-output.txt
 .claude/worktrees/
 .vscode/
 benchmarks/raw.txt
+benchmarks/raw_*.txt
 benchmarks/charts/
 chart
 report

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build test coverage lint bench bench-report bench-chart
+.PHONY: build test coverage lint bench bench-inverted bench-inverted-build bench-inverted-runtime bench-fulltext bench-json bench-report bench-chart
+
+SHELL := /bin/bash
 
 # Fail CI if total coverage drops below this percentage.
 # Current baseline: ~70.8% total (internal/minisql: 70.1%, internal/parser: 87.4%).
@@ -10,6 +12,15 @@ BENCH_COUNT ?= 1
 
 # Benchmark filter: run all by default, or pass e.g. BENCH=BenchmarkInsert to narrow.
 BENCH ?= .
+
+# Benchmark duration/count passed to go test -benchtime. Use e.g. BENCH_TIME=1x
+# for one-shot setup-heavy benchmarks such as index builds.
+BENCH_TIME ?= 1s
+
+# Inverted-index benchmarks mix setup-heavy index builds with steady-state
+# query/mutation benchmarks, so the grouped target uses separate defaults.
+BENCH_INVERTED_BUILD_TIME ?= 1x
+BENCH_INVERTED_RUNTIME_TIME ?= 10x
 
 build:
 	go build -v ./...
@@ -35,8 +46,35 @@ lint:
 #   make bench BENCH=BenchmarkInsert  # run only insert benchmarks
 bench:
 	@mkdir -p benchmarks
-	go test -tags bench -bench=$(BENCH) -benchmem -count=$(BENCH_COUNT) \
+	set -o pipefail; go test -tags bench -bench='$(BENCH)' -benchmem -benchtime=$(BENCH_TIME) -count=$(BENCH_COUNT) \
 		-run '^$$' ./benchmarks/ | tee benchmarks/raw.txt
+
+# bench-inverted: run only full-text and JSON inverted-index benchmarks.
+bench-inverted:
+	$(MAKE) bench-inverted-build
+	$(MAKE) bench-inverted-runtime
+	@cat benchmarks/raw_inverted_build.txt benchmarks/raw_inverted_runtime.txt > benchmarks/raw.txt
+
+# bench-inverted-build: run setup-heavy inverted-index build benchmarks.
+bench-inverted-build:
+	@mkdir -p benchmarks
+	set -o pipefail; go test -tags bench -bench='Benchmark(FullText|JSONInverted)_BuildIndex' -benchmem \
+		-benchtime=$(BENCH_INVERTED_BUILD_TIME) -count=$(BENCH_COUNT) -run '^$$' ./benchmarks/ | tee benchmarks/raw_inverted_build.txt
+
+# bench-inverted-runtime: run steady-state inverted-index query and maintenance benchmarks.
+bench-inverted-runtime:
+	@mkdir -p benchmarks
+	set -o pipefail; go test -tags bench \
+		-bench='BenchmarkFullText_(Insert|Search|Update|Delete)|BenchmarkJSONInverted_(Insert|Contains|Update|Delete)' \
+		-benchmem -benchtime=$(BENCH_INVERTED_RUNTIME_TIME) -count=$(BENCH_COUNT) -run '^$$' ./benchmarks/ | tee benchmarks/raw_inverted_runtime.txt
+
+# bench-fulltext: run only full-text index benchmarks.
+bench-fulltext:
+	$(MAKE) bench BENCH='BenchmarkFullText'
+
+# bench-json: run only JSON inverted-index benchmarks.
+bench-json:
+	$(MAKE) bench BENCH='BenchmarkJSONInverted'
 
 # bench-report: append a formatted Markdown table to benchmarks/RESULTS.md.
 bench-report:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,9 +11,19 @@ make bench
 # Run each benchmark 5 times for better statistical confidence
 make bench BENCH_COUNT=5
 
+# Run setup-heavy benchmarks exactly once per iteration
+make bench BENCH=BenchmarkFullText_BuildIndex BENCH_TIME=1x BENCH_COUNT=5
+
 # Run only a specific benchmark group
 make bench BENCH=BenchmarkInsert
 make bench BENCH=BenchmarkSelect
+
+# Run only the inverted-index benchmark families
+make bench-inverted BENCH_COUNT=5
+make bench-inverted-build BENCH_COUNT=5
+make bench-inverted-runtime BENCH_COUNT=5
+make bench-fulltext
+make bench-json
 ```
 
 ## Benchmark groups
@@ -30,8 +40,34 @@ make bench BENCH=BenchmarkSelect
 | `BenchmarkUpdate_ByPK` | UPDATE a single row by primary key |
 | `BenchmarkDelete_ByPK` | DELETE a single row by primary key |
 | `BenchmarkTxn_NInserts` | Commit overhead: 50 INSERTs per explicit transaction |
+| `BenchmarkFullText_BuildIndex` | Build a full-text index over seeded documents |
+| `BenchmarkFullText_Insert_WithIndex` | INSERT maintenance cost with full-text index present |
+| `BenchmarkFullText_Search_SingleTerm` | Rare, medium, and common token lookups |
+| `BenchmarkFullText_Search_MultiTermAND` | Multi-token posting-list intersection |
+| `BenchmarkFullText_Search_Phrase` | Positional phrase filtering |
+| `BenchmarkFullText_Update_WithIndex` | UPDATE maintenance cost with full-text index present |
+| `BenchmarkFullText_Delete_WithIndex` | DELETE maintenance cost with full-text index present |
+| `BenchmarkJSONInverted_BuildIndex` | Build a JSON inverted index over seeded payloads |
+| `BenchmarkJSONInverted_Insert_WithIndex` | INSERT maintenance cost with JSON inverted index present |
+| `BenchmarkJSONInverted_Contains_KeyValue` | JSON key/value containment lookup |
+| `BenchmarkJSONInverted_Contains_ObjectSubset` | Multi-term JSON subset containment lookup |
+| `BenchmarkJSONInverted_Update_WithIndex` | UPDATE maintenance cost with JSON inverted index present |
+| `BenchmarkJSONInverted_Delete_WithIndex` | DELETE maintenance cost with JSON inverted index present |
 
 Both drivers are configured for fair durability comparison: MiniSQL uses its default WAL mode; SQLite is opened with `PRAGMA journal_mode=WAL` and `PRAGMA synchronous=FULL`.
+
+Full-text benchmarks compare MiniSQL against SQLite FTS5 when the linked SQLite
+driver supports `CREATE VIRTUAL TABLE ... USING fts5`. JSON benchmarks always
+include MiniSQL indexed and sequential `JSON_CONTAINS` variants. SQLite JSON
+benchmarks are contextual only: `sqlite_json_scan` uses JSON/path predicates and
+`sqlite_json_expr_index` uses a fixed-path expression index, which is not
+equivalent to MiniSQL's JSON containment inverted index.
+
+`make bench-inverted` intentionally splits build and steady-state benchmarks.
+Index builds use `BENCH_INVERTED_BUILD_TIME=1x` by default because they rebuild
+the full fixture on every iteration. Runtime query and maintenance benchmarks
+use `BENCH_INVERTED_RUNTIME_TIME=10x` by default so repeated baseline runs stay
+practical while still averaging several operations.
 
 ## Generating charts
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,34 @@
-### 2026-05-10 (VisitRowIDs iterator + overflow bug fix — latest)
+### 2026-05-14 (Full-text and JSON inverted benchmark suite added — latest)
+
+Added the first dedicated benchmark suite for MiniSQL's inverted-index storage
+and recorded the initial baseline. The generated timing/memory tables for this
+run are appended below as `2026-05-14 21:13 UTC`.
+
+- Full-text: build index, insert maintenance, rare/medium/common single-term lookup, multi-term AND lookup, phrase lookup, update maintenance, and delete maintenance.
+- JSON inverted: build index, insert maintenance, key/value containment, object-subset containment, update maintenance, and delete maintenance.
+- Full-text benchmarks include SQLite FTS5 sub-benchmarks when the linked SQLite driver supports `fts5`.
+- JSON benchmarks include MiniSQL indexed vs MiniSQL sequential `JSON_CONTAINS`; SQLite JSON baselines are labelled contextual because SQLite does not provide an equivalent native JSON containment inverted index.
+
+Baseline highlights:
+- Full-text build is the clearest hotspot: MiniSQL averages **1.85 s/op** versus SQLite FTS5 at **57.7 ms/op** (**32× slower**) and allocates **3.6 GiB/op**.
+- Full-text indexed lookup is competitive for rare/medium terms (**0.8× SQLite**) but falls behind for common terms (**3.1× slower**), multi-term AND (**1.4× slower**), phrase search (**1.1× slower**), and especially UPDATE maintenance (**10× slower**).
+- Full-text INSERT and DELETE maintenance are already faster than SQLite FTS5 in this fixture (**0.4×** and **0.3×** SQLite respectively), but MiniSQL allocates much more memory per operation.
+- JSON inverted lookup is materially faster than MiniSQL's sequential JSON scan: key/value lookup is **2.4× faster**, object-subset lookup is **2.2× faster**.
+- JSON indexed lookup is still slower than SQLite's contextual baselines: roughly **1.3×** slower than SQLite JSON scan for key/value lookup and **3-4×** slower than SQLite fixed-path expression indexes.
+
+The baseline was collected with split inverted-index runs so build-index
+benchmarks do not auto-scale to impractical iteration counts:
+
+```sh
+make bench-inverted-build BENCH_COUNT=5
+make bench-inverted-runtime BENCH_COUNT=5
+cat benchmarks/raw_inverted_build.txt benchmarks/raw_inverted_runtime.txt > benchmarks/raw.txt
+make bench-report
+```
+
+---
+
+### 2026-05-10 (VisitRowIDs iterator + overflow bug fix)
 
 Three changes in this entry:
 
@@ -794,3 +824,45 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 | Select_IndexRangeScan | 772.4 KiB | 85.9 KiB |
 | Select_RangeScan | 2.1 MiB | 85.9 KiB |
 | Update_ByPK | 9.0 KiB | 263 B |
+### 2026-05-14 21:13 UTC
+
+#### Timing
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan | ratio |
+|---|---|---|---|---|---|---|---|
+| FullText_BuildIndex | 1.85 s/op | — | — | 57.70 ms/op | — | — | 32.0× |
+| JSONInverted_BuildIndex | — | 296.61 ms/op | — | — | — | — | — |
+| FullText_Insert_WithIndex | 87.92 µs/op | — | — | 224.76 µs/op | — | — | 0.4× |
+| FullText_Search_SingleTerm/rare | 215.50 µs/op | — | — | 279.90 µs/op | — | — | 0.8× |
+| FullText_Search_SingleTerm/medium | 228.22 µs/op | — | — | 282.04 µs/op | — | — | 0.8× |
+| FullText_Search_SingleTerm/common | 1.03 ms/op | — | — | 334.15 µs/op | — | — | 3.1× |
+| FullText_Search_MultiTermAND | 423.05 µs/op | — | — | 312.27 µs/op | — | — | 1.4× |
+| FullText_Search_Phrase | 312.12 µs/op | — | — | 273.05 µs/op | — | — | 1.1× |
+| FullText_Update_WithIndex | 3.28 ms/op | — | — | 328.61 µs/op | — | — | 10.0× |
+| FullText_Delete_WithIndex | 67.42 µs/op | — | — | 227.23 µs/op | — | — | 0.3× |
+| JSONInverted_Insert_WithIndex | — | 97.65 µs/op | — | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.25 ms/op | 3.05 ms/op | — | 340.98 µs/op | 990.32 µs/op | — |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.48 ms/op | 3.25 ms/op | — | 442.39 µs/op | 1.06 ms/op | — |
+| JSONInverted_Update_WithIndex | — | 1.20 ms/op | — | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 145.75 µs/op | — | — | — | — | — |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan |
+|---|---|---|---|---|---|---|
+| FullText_BuildIndex | 3624.8 MiB | — | — | 429.0 KiB | — | — |
+| JSONInverted_BuildIndex | — | 1327.3 MiB | — | — | — | — |
+| FullText_Insert_WithIndex | 66.7 KiB | — | — | 714 B | — | — |
+| FullText_Search_SingleTerm/rare | 62.9 KiB | — | — | 533 B | — | — |
+| FullText_Search_SingleTerm/medium | 68.5 KiB | — | — | 533 B | — | — |
+| FullText_Search_SingleTerm/common | 606.8 KiB | — | — | 548 B | — | — |
+| FullText_Search_MultiTermAND | 358.7 KiB | — | — | 532 B | — | — |
+| FullText_Search_Phrase | 176.6 KiB | — | — | 540 B | — | — |
+| FullText_Update_WithIndex | 6.0 MiB | — | — | 411 B | — | — |
+| FullText_Delete_WithIndex | 40.4 KiB | — | — | 260 B | — | — |
+| JSONInverted_Insert_WithIndex | — | 163.9 KiB | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.5 MiB | 3.3 MiB | — | 549 B | 548 B |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.8 MiB | 3.5 MiB | — | 549 B | 548 B |
+| JSONInverted_Update_WithIndex | — | 4.6 MiB | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 143.0 KiB | — | — | — | — |
+

--- a/benchmarks/cmd/chart/main.go
+++ b/benchmarks/cmd/chart/main.go
@@ -42,7 +42,10 @@ type result struct {
 // benchLine matches lines like:
 //
 //	BenchmarkInsert_SingleRow/minisql-10    1234    56789 ns/op
-var benchLine = regexp.MustCompile(`^(Benchmark\w+)/(\w+)-\d+\s+\d+\s+([\d.]+)\s+ns/op`)
+//
+// Nested sub-benchmark paths are supported; the final path segment is treated
+// as the driver, e.g. BenchmarkFullText_Search/rare/minisql-10.
+var benchLine = regexp.MustCompile(`^(Benchmark\S+)-\d+\s+\d+\s+([\d.]+)\s+ns/op`)
 
 // driver display order and colours.
 var (
@@ -122,13 +125,25 @@ func parse(r io.Reader) []result {
 		if m == nil {
 			continue
 		}
-		ns, err := strconv.ParseFloat(m[3], 64)
+		benchName, driver, ok := splitBenchmarkPath(m[1])
+		if !ok {
+			continue
+		}
+		ns, err := strconv.ParseFloat(m[2], 64)
 		if err != nil {
 			continue
 		}
-		results = append(results, result{benchmark: m[1], driver: m[2], nsPerOp: ns})
+		results = append(results, result{benchmark: benchName, driver: driver, nsPerOp: ns})
 	}
 	return results
+}
+
+func splitBenchmarkPath(path string) (benchName, driver string, ok bool) {
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 || idx == len(path)-1 {
+		return "", "", false
+	}
+	return path[:idx], path[idx+1:], true
 }
 
 // renderChart writes a grouped bar chart PNG for one benchmark to outDir.
@@ -145,9 +160,15 @@ func parse(r io.Reader) []result {
 //   - Give each driver's BarChart Offset = -(N-1)*half + i*barWidth so that the
 //     bars fan out symmetrically around the single x tick at data position 0.
 func renderChart(benchName string, results []result, outDir string) error {
-	nsMap := map[string]float64{}
+	nsTotals := map[string]float64{}
+	nsCounts := map[string]int{}
 	for _, res := range results {
-		nsMap[res.driver] = res.nsPerOp
+		nsTotals[res.driver] += res.nsPerOp
+		nsCounts[res.driver]++
+	}
+	nsMap := map[string]float64{}
+	for driver, total := range nsTotals {
+		nsMap[driver] = total / float64(nsCounts[driver])
 	}
 
 	// Collect present drivers in stable order.

--- a/benchmarks/cmd/report/main.go
+++ b/benchmarks/cmd/report/main.go
@@ -34,17 +34,24 @@ type row struct {
 	bPerOp  float64 // 0 if not reported
 }
 
+type sample struct {
+	nsPerOp float64
+	bPerOp  float64
+}
+
 // benchData holds all driver rows for a single benchmark.
 type benchData struct {
 	name    string
-	drivers map[string]row // driver name → metrics
+	drivers map[string]row // driver name → mean metrics
 }
 
-// benchLine matches the benchmark name, driver, and ns/op value.
+// benchLine matches the benchmark path and ns/op value. The final sub-benchmark
+// segment is treated as the driver, so both BenchmarkX/minisql and
+// BenchmarkX/case/minisql are supported.
 // B/op is extracted separately because a custom metric (e.g. "rows/op") may
 // appear between ns/op and B/op in the output line.
 var (
-	benchLine   = regexp.MustCompile(`^(Benchmark\w+)/(\w+)-\d+\s+\d+\s+([\d.]+)\s+ns/op`)
+	benchLine   = regexp.MustCompile(`^(Benchmark\S+)-\d+\s+\d+\s+([\d.]+)\s+ns/op`)
 	bPerOpField = regexp.MustCompile(`([\d.]+)\s+B/op`)
 )
 
@@ -95,7 +102,7 @@ func run() error {
 func parse(r io.Reader) []benchData {
 	// Preserve insertion order so benchmarks appear in the order they ran.
 	var order []string
-	byName := map[string]*benchData{}
+	byName := map[string]map[string][]sample{}
 
 	sc := bufio.NewScanner(r)
 	for sc.Scan() {
@@ -103,9 +110,12 @@ func parse(r io.Reader) []benchData {
 		if m == nil {
 			continue
 		}
-		benchName := m[1]
-		driver := m[2]
-		ns, err := strconv.ParseFloat(m[3], 64)
+		benchPath := m[1]
+		benchName, driver, ok := splitBenchmarkPath(benchPath)
+		if !ok {
+			continue
+		}
+		ns, err := strconv.ParseFloat(m[2], 64)
 		if err != nil {
 			continue
 		}
@@ -117,17 +127,49 @@ func parse(r io.Reader) []benchData {
 		}
 
 		if _, ok := byName[benchName]; !ok {
-			byName[benchName] = &benchData{name: benchName, drivers: map[string]row{}}
+			byName[benchName] = map[string][]sample{}
 			order = append(order, benchName)
 		}
-		byName[benchName].drivers[driver] = row{nsPerOp: ns, bPerOp: bop}
+		byName[benchName][driver] = append(byName[benchName][driver], sample{nsPerOp: ns, bPerOp: bop})
 	}
 
 	result := make([]benchData, 0, len(order))
 	for _, name := range order {
-		result = append(result, *byName[name])
+		data := benchData{name: name, drivers: map[string]row{}}
+		for driver, samples := range byName[name] {
+			data.drivers[driver] = meanRow(samples)
+		}
+		result = append(result, data)
 	}
 	return result
+}
+
+func splitBenchmarkPath(path string) (benchName, driver string, ok bool) {
+	idx := strings.LastIndex(path, "/")
+	if idx < 0 || idx == len(path)-1 {
+		return "", "", false
+	}
+	return path[:idx], path[idx+1:], true
+}
+
+func meanRow(samples []sample) row {
+	if len(samples) == 0 {
+		return row{}
+	}
+	var nsTotal, bTotal float64
+	var bCount int
+	for _, sample := range samples {
+		nsTotal += sample.nsPerOp
+		if sample.bPerOp > 0 {
+			bTotal += sample.bPerOp
+			bCount++
+		}
+	}
+	res := row{nsPerOp: nsTotal / float64(len(samples))}
+	if bCount > 0 {
+		res.bPerOp = bTotal / float64(bCount)
+	}
+	return res
 }
 
 func renderMarkdown(benches []benchData) string {

--- a/benchmarks/inverted_bench_test.go
+++ b/benchmarks/inverted_bench_test.go
@@ -1,0 +1,644 @@
+//go:build bench
+
+package benchmarks
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v7"
+)
+
+const invertedSeedN = 1_000
+
+type invertedBenchDriver struct {
+	name       string
+	driverName string
+	dsn        func(path string) string
+	afterOpen  func(testing.TB, *sql.DB)
+}
+
+var invertedBenchDrivers = []invertedBenchDriver{
+	{
+		name:       "minisql",
+		driverName: "minisql",
+		dsn:        func(path string) string { return path },
+	},
+	{
+		name:       "sqlite",
+		driverName: "sqlite",
+		dsn:        func(path string) string { return path + "?_pragma=journal_mode(WAL)" },
+	},
+}
+
+var minisqlOnlyInvertedBenchDrivers = []invertedBenchDriver{invertedBenchDrivers[0]}
+
+// BenchmarkFullText_BuildIndex measures building the full-text structure over
+// an already populated document table.
+func BenchmarkFullText_BuildIndex(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			for i := range b.N {
+				db, cleanup := openInvertedBenchDB(b, d)
+				createFullTextTable(b, db, d)
+				seedFullTextRows(b, db, d, invertedSeedN, int64(i))
+
+				b.StartTimer()
+				createFullTextIndex(b, db, d)
+				b.StopTimer()
+
+				cleanup()
+			}
+			b.ReportMetric(float64(invertedSeedN), "docs/op")
+		})
+	}
+}
+
+// BenchmarkFullText_Insert_WithIndex measures full-text index maintenance for
+// one inserted document per transaction.
+func BenchmarkFullText_Insert_WithIndex(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openInvertedBenchDB(b, d)
+			defer cleanup()
+			createFullTextTable(b, db, d)
+			createFullTextIndex(b, db, d)
+			stmt := prepareFullTextInsert(b, db, d)
+			defer stmt.Close()
+
+			faker := gofakeit.New(11)
+			b.ResetTimer()
+			for i := range b.N {
+				title, body := generatedFullTextDoc(faker, i)
+				if _, err := stmt.Exec(i+1, title, body); err != nil {
+					b.Fatalf("insert full-text row: %v", err)
+				}
+			}
+			b.ReportMetric(1, "docs/op")
+		})
+	}
+}
+
+// BenchmarkFullText_Search_SingleTerm measures indexed token lookup at rare,
+// medium, and common selectivities.
+func BenchmarkFullText_Search_SingleTerm(b *testing.B) {
+	cases := []struct {
+		name      string
+		query     string
+		wantRows  int
+		sqliteFts string
+	}{
+		{name: "rare", query: "rare0001", sqliteFts: "rare0001", wantRows: 1},
+		{name: "medium", query: "cohort17", sqliteFts: "cohort17", wantRows: invertedSeedN / 100},
+		{name: "common", query: "common", sqliteFts: "common", wantRows: invertedSeedN},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			for _, d := range fullTextComparableDrivers(b) {
+				b.Run(d.name, func(b *testing.B) {
+					db, cleanup := openSeededFullTextBenchDB(b, d, invertedSeedN)
+					defer cleanup()
+					query := fullTextSearchSQL(d, tc.query, tc.sqliteFts)
+
+					b.ResetTimer()
+					for range b.N {
+						n := queryCount(b, db, query)
+						if n != tc.wantRows {
+							b.Fatalf("expected %d rows, got %d", tc.wantRows, n)
+						}
+					}
+					b.ReportMetric(float64(tc.wantRows), "matches/op")
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkFullText_Search_MultiTermAND measures posting-list intersection.
+func BenchmarkFullText_Search_MultiTermAND(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openSeededFullTextBenchDB(b, d, invertedSeedN)
+			defer cleanup()
+			query := fullTextSearchSQL(d, "common cohort17", "common cohort17")
+
+			b.ResetTimer()
+			for range b.N {
+				n := queryCount(b, db, query)
+				if n != invertedSeedN/100 {
+					b.Fatalf("expected %d rows, got %d", invertedSeedN/100, n)
+				}
+			}
+			b.ReportMetric(float64(invertedSeedN/100), "matches/op")
+		})
+	}
+}
+
+// BenchmarkFullText_Search_Phrase measures positional phrase filtering.
+func BenchmarkFullText_Search_Phrase(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openSeededFullTextBenchDB(b, d, invertedSeedN)
+			defer cleanup()
+			query := fullTextSearchSQL(d, `"alpha beta"`, `"alpha beta"`)
+
+			b.ResetTimer()
+			for range b.N {
+				n := queryCount(b, db, query)
+				if n != invertedSeedN/10 {
+					b.Fatalf("expected %d rows, got %d", invertedSeedN/10, n)
+				}
+			}
+			b.ReportMetric(float64(invertedSeedN/10), "matches/op")
+		})
+	}
+}
+
+// BenchmarkFullText_Update_WithIndex measures replacing indexed text while the
+// full-text index removes old postings and inserts new ones.
+func BenchmarkFullText_Update_WithIndex(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openSeededFullTextBenchDB(b, d, 1_000)
+			defer cleanup()
+			stmt := prepareFullTextUpdate(b, db, d)
+			defer stmt.Close()
+			faker := gofakeit.New(12)
+
+			b.ResetTimer()
+			for i := range b.N {
+				id := (i % 1_000) + 1
+				body := generatedUpdatedFullTextDoc(faker, i)
+				if _, err := stmt.Exec(body, id); err != nil {
+					b.Fatalf("update full-text row: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFullText_Delete_WithIndex measures deleting indexed documents.
+func BenchmarkFullText_Delete_WithIndex(b *testing.B) {
+	for _, d := range fullTextComparableDrivers(b) {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openInvertedBenchDB(b, d)
+			defer cleanup()
+			createFullTextTable(b, db, d)
+			seedFullTextRows(b, db, d, b.N, 13)
+			createFullTextIndex(b, db, d)
+			stmt := prepareFullTextDelete(b, db, d)
+			defer stmt.Close()
+
+			b.ResetTimer()
+			for i := range b.N {
+				if _, err := stmt.Exec(i + 1); err != nil {
+					b.Fatalf("delete full-text row: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkJSONInverted_BuildIndex measures building MiniSQL's JSON inverted
+// index over an already populated JSON table.
+func BenchmarkJSONInverted_BuildIndex(b *testing.B) {
+	for _, d := range minisqlOnlyInvertedBenchDrivers {
+		b.Run(d.name+"_indexed", func(b *testing.B) {
+			for i := range b.N {
+				db, cleanup := openInvertedBenchDB(b, d)
+				createJSONTable(b, db, d)
+				seedJSONRows(b, db, d, invertedSeedN, int64(i))
+
+				b.StartTimer()
+				mustExec(b, db, `create inverted index "idx_events_payload" on "events_json" (payload)`)
+				b.StopTimer()
+
+				cleanup()
+			}
+			b.ReportMetric(float64(invertedSeedN), "docs/op")
+		})
+	}
+}
+
+// BenchmarkJSONInverted_Insert_WithIndex measures JSON inverted-index
+// maintenance for one inserted event per transaction.
+func BenchmarkJSONInverted_Insert_WithIndex(b *testing.B) {
+	for _, d := range minisqlOnlyInvertedBenchDrivers {
+		b.Run(d.name+"_indexed", func(b *testing.B) {
+			db, cleanup := openInvertedBenchDB(b, d)
+			defer cleanup()
+			createJSONTable(b, db, d)
+			mustExec(b, db, `create inverted index "idx_events_payload" on "events_json" (payload)`)
+			stmt := prepareJSONInsert(b, db, d)
+			defer stmt.Close()
+			faker := gofakeit.New(21)
+
+			b.ResetTimer()
+			for i := range b.N {
+				if _, err := stmt.Exec(i+1, fmt.Sprintf("event-%06d", i), generatedJSONPayload(faker, i)); err != nil {
+					b.Fatalf("insert JSON row: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkJSONInverted_Contains_KeyValue compares indexed MiniSQL JSON
+// containment with MiniSQL sequential JSON_CONTAINS and contextual SQLite JSON
+// baselines.
+func BenchmarkJSONInverted_Contains_KeyValue(b *testing.B) {
+	benchJSONContains(b, "key_value", `{"type":"click"}`, `json_extract(payload, '$.type') = 'click'`, jsonClickRows(invertedSeedN))
+}
+
+// BenchmarkJSONInverted_Contains_ObjectSubset measures a multi-term JSON
+// containment predicate.
+func BenchmarkJSONInverted_Contains_ObjectSubset(b *testing.B) {
+	benchJSONContains(b, "object_subset", `{"type":"click","tags":["web"]}`, `json_extract(payload, '$.type') = 'click' AND instr(payload, '"web"') > 0`, jsonClickRows(invertedSeedN))
+}
+
+// BenchmarkJSONInverted_Update_WithIndex measures replacing JSON payloads while
+// the inverted index removes old terms and inserts new ones.
+func BenchmarkJSONInverted_Update_WithIndex(b *testing.B) {
+	for _, d := range minisqlOnlyInvertedBenchDrivers {
+		b.Run(d.name+"_indexed", func(b *testing.B) {
+			db, cleanup := openSeededJSONBenchDB(b, d, 1_000, true)
+			defer cleanup()
+			stmt := prepareJSONUpdate(b, db, d)
+			defer stmt.Close()
+			faker := gofakeit.New(22)
+
+			b.ResetTimer()
+			for i := range b.N {
+				id := (i % 1_000) + 1
+				if _, err := stmt.Exec(generatedUpdatedJSONPayload(faker, i), id); err != nil {
+					b.Fatalf("update JSON row: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkJSONInverted_Delete_WithIndex measures deleting rows from a table
+// with a JSON inverted index.
+func BenchmarkJSONInverted_Delete_WithIndex(b *testing.B) {
+	for _, d := range minisqlOnlyInvertedBenchDrivers {
+		b.Run(d.name+"_indexed", func(b *testing.B) {
+			db, cleanup := openSeededJSONBenchDB(b, d, b.N, true)
+			defer cleanup()
+			stmt := prepareJSONDelete(b, db, d)
+			defer stmt.Close()
+
+			b.ResetTimer()
+			for i := range b.N {
+				if _, err := stmt.Exec(i + 1); err != nil {
+					b.Fatalf("delete JSON row: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func benchJSONContains(b *testing.B, name, minisqlPredicateJSON, sqlitePredicate string, wantRows int) {
+	b.Run(name, func(b *testing.B) {
+		for _, tc := range []struct {
+			name    string
+			driver  invertedBenchDriver
+			indexed bool
+			query   string
+		}{
+			{
+				name:    "minisql_indexed",
+				driver:  invertedBenchDrivers[0],
+				indexed: true,
+				query:   fmt.Sprintf(`select count(*) from "events_json" where JSON_CONTAINS(payload, '%s')`, minisqlPredicateJSON),
+			},
+			{
+				name:    "minisql_sequential",
+				driver:  invertedBenchDrivers[0],
+				indexed: false,
+				query:   fmt.Sprintf(`select count(*) from "events_json" where JSON_CONTAINS(payload, '%s')`, minisqlPredicateJSON),
+			},
+			{
+				name:    "sqlite_json_scan",
+				driver:  invertedBenchDrivers[1],
+				indexed: false,
+				query:   fmt.Sprintf(`SELECT count(*) FROM events_json WHERE %s`, sqlitePredicate),
+			},
+			{
+				name:    "sqlite_json_expr_index",
+				driver:  invertedBenchDrivers[1],
+				indexed: true,
+				query:   fmt.Sprintf(`SELECT count(*) FROM events_json WHERE %s`, sqlitePredicate),
+			},
+		} {
+			b.Run(tc.name, func(b *testing.B) {
+				db, cleanup := openSeededJSONBenchDB(b, tc.driver, invertedSeedN, tc.indexed)
+				defer cleanup()
+				b.ResetTimer()
+				for range b.N {
+					n := queryCount(b, db, tc.query)
+					if n != wantRows {
+						b.Fatalf("expected %d rows, got %d", wantRows, n)
+					}
+				}
+				b.ReportMetric(float64(wantRows), "matches/op")
+			})
+		}
+	})
+}
+
+func fullTextComparableDrivers(b *testing.B) []invertedBenchDriver {
+	b.Helper()
+	drivers := []invertedBenchDriver{invertedBenchDrivers[0]}
+	sqliteDriver := invertedBenchDrivers[1]
+	db, cleanup := openInvertedBenchDB(b, sqliteDriver)
+	defer cleanup()
+	if _, err := db.Exec(`CREATE VIRTUAL TABLE fts_probe USING fts5(body);`); err == nil {
+		drivers = append(drivers, sqliteDriver)
+	}
+	return drivers
+}
+
+func openSeededFullTextBenchDB(b testing.TB, d invertedBenchDriver, n int) (*sql.DB, func()) {
+	b.Helper()
+	db, cleanup := openInvertedBenchDB(b, d)
+	createFullTextTable(b, db, d)
+	seedFullTextRows(b, db, d, n, 1)
+	createFullTextIndex(b, db, d)
+	return db, cleanup
+}
+
+func openSeededJSONBenchDB(b testing.TB, d invertedBenchDriver, n int, indexed bool) (*sql.DB, func()) {
+	b.Helper()
+	db, cleanup := openInvertedBenchDB(b, d)
+	createJSONTable(b, db, d)
+	seedJSONRows(b, db, d, n, 2)
+	if indexed {
+		switch d.name {
+		case "minisql":
+			mustExec(b, db, `create inverted index "idx_events_payload" on "events_json" (payload)`)
+		case "sqlite":
+			mustExec(b, db, `CREATE INDEX idx_events_payload_type ON events_json(json_extract(payload, '$.type'))`)
+		}
+	}
+	return db, cleanup
+}
+
+func openInvertedBenchDB(t testing.TB, d invertedBenchDriver) (*sql.DB, func()) {
+	t.Helper()
+	dbDriver := dbDriver{
+		name:        d.name,
+		driverName:  d.driverName,
+		dsn:         d.dsn,
+		createTable: `create table "__bench_placeholder" (id int8 primary key)`,
+	}
+	db, cleanup := openDB(t, dbDriver)
+	mustExec(t, db, `drop table "__bench_placeholder"`)
+	if d.afterOpen != nil {
+		d.afterOpen(t, db)
+	}
+	return db, cleanup
+}
+
+func createFullTextTable(t testing.TB, db *sql.DB, d invertedBenchDriver) {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		mustExec(t, db, `create table "articles_fts" (id int8 primary key, title varchar(255), body text not null)`)
+	case "sqlite":
+		mustExec(t, db, `CREATE TABLE articles_fts (id INTEGER PRIMARY KEY, title TEXT, body TEXT NOT NULL)`)
+	}
+}
+
+func createFullTextIndex(t testing.TB, db *sql.DB, d invertedBenchDriver) {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		mustExec(t, db, `create fulltext index "idx_articles_body" on "articles_fts" (body) with (tokenizer = 'simple')`)
+	case "sqlite":
+		mustExec(t, db, `CREATE VIRTUAL TABLE articles_fts_index USING fts5(body, content='articles_fts', content_rowid='id')`)
+		mustExec(t, db, `INSERT INTO articles_fts_index(articles_fts_index) VALUES ('rebuild')`)
+		mustExec(t, db, `CREATE TRIGGER articles_fts_ai AFTER INSERT ON articles_fts BEGIN INSERT INTO articles_fts_index(rowid, body) VALUES (new.id, new.body); END`)
+		mustExec(t, db, `CREATE TRIGGER articles_fts_ad AFTER DELETE ON articles_fts BEGIN INSERT INTO articles_fts_index(articles_fts_index, rowid, body) VALUES('delete', old.id, old.body); END`)
+		mustExec(t, db, `CREATE TRIGGER articles_fts_au AFTER UPDATE ON articles_fts BEGIN INSERT INTO articles_fts_index(articles_fts_index, rowid, body) VALUES('delete', old.id, old.body); INSERT INTO articles_fts_index(rowid, body) VALUES (new.id, new.body); END`)
+	}
+}
+
+func seedFullTextRows(t testing.TB, db *sql.DB, d invertedBenchDriver, n int, seed int64) {
+	t.Helper()
+	stmt := prepareFullTextInsert(t, db, d)
+	defer stmt.Close()
+	faker := gofakeit.New(uint64(seed))
+	for i := range n {
+		title, body := generatedFullTextDoc(faker, i)
+		if _, err := stmt.Exec(i+1, title, body); err != nil {
+			t.Fatalf("seed full-text row %d: %v", i, err)
+		}
+	}
+}
+
+func prepareFullTextInsert(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`insert into "articles_fts" (id, title, body) values (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare full-text insert: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`INSERT INTO articles_fts (id, title, body) VALUES (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare full-text insert: %v", err)
+		}
+		return stmt
+	}
+}
+
+func prepareFullTextUpdate(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`update "articles_fts" set body = ? where id = ?`)
+		if err != nil {
+			t.Fatalf("prepare full-text update: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`UPDATE articles_fts SET body = ? WHERE id = ?`)
+		if err != nil {
+			t.Fatalf("prepare full-text update: %v", err)
+		}
+		return stmt
+	}
+}
+
+func prepareFullTextDelete(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`delete from "articles_fts" where id = ?`)
+		if err != nil {
+			t.Fatalf("prepare full-text delete: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`DELETE FROM articles_fts WHERE id = ?`)
+		if err != nil {
+			t.Fatalf("prepare full-text delete: %v", err)
+		}
+		return stmt
+	}
+}
+
+func fullTextSearchSQL(d invertedBenchDriver, minisqlQuery, sqliteQuery string) string {
+	switch d.name {
+	case "minisql":
+		return fmt.Sprintf(`select count(*) from "articles_fts" where MATCH(body, '%s')`, strings.ReplaceAll(minisqlQuery, `'`, `''`))
+	default:
+		return fmt.Sprintf(`SELECT count(*) FROM articles_fts_index WHERE articles_fts_index MATCH '%s'`, strings.ReplaceAll(sqliteQuery, `'`, `''`))
+	}
+}
+
+func createJSONTable(t testing.TB, db *sql.DB, d invertedBenchDriver) {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		mustExec(t, db, `create table "events_json" (id int8 primary key, name varchar(255), payload json not null)`)
+	case "sqlite":
+		mustExec(t, db, `CREATE TABLE events_json (id INTEGER PRIMARY KEY, name TEXT, payload TEXT NOT NULL)`)
+	}
+}
+
+func seedJSONRows(t testing.TB, db *sql.DB, d invertedBenchDriver, n int, seed int64) {
+	t.Helper()
+	stmt := prepareJSONInsert(t, db, d)
+	defer stmt.Close()
+	faker := gofakeit.New(uint64(seed))
+	for i := range n {
+		if _, err := stmt.Exec(i+1, fmt.Sprintf("event-%06d", i), generatedJSONPayload(faker, i)); err != nil {
+			t.Fatalf("seed JSON row %d: %v", i, err)
+		}
+	}
+}
+
+func prepareJSONInsert(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`insert into "events_json" (id, name, payload) values (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare JSON insert: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`INSERT INTO events_json (id, name, payload) VALUES (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare JSON insert: %v", err)
+		}
+		return stmt
+	}
+}
+
+func prepareJSONUpdate(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`update "events_json" set payload = ? where id = ?`)
+		if err != nil {
+			t.Fatalf("prepare JSON update: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`UPDATE events_json SET payload = ? WHERE id = ?`)
+		if err != nil {
+			t.Fatalf("prepare JSON update: %v", err)
+		}
+		return stmt
+	}
+}
+
+func prepareJSONDelete(t testing.TB, db *sql.DB, d invertedBenchDriver) *sql.Stmt {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		stmt, err := db.Prepare(`delete from "events_json" where id = ?`)
+		if err != nil {
+			t.Fatalf("prepare JSON delete: %v", err)
+		}
+		return stmt
+	default:
+		stmt, err := db.Prepare(`DELETE FROM events_json WHERE id = ?`)
+		if err != nil {
+			t.Fatalf("prepare JSON delete: %v", err)
+		}
+		return stmt
+	}
+}
+
+func generatedFullTextDoc(faker *gofakeit.Faker, i int) (string, string) {
+	title := fmt.Sprintf("Doc %06d %s", i, faker.Word())
+	terms := []string{
+		"common",
+		fmt.Sprintf("cohort%02d", i%100),
+		fmt.Sprintf("rare%04d", i),
+		"database",
+		"storage",
+		faker.Word(),
+		faker.Word(),
+	}
+	if i%10 == 0 {
+		terms = append(terms, "alpha", "beta")
+	}
+	return title, strings.Join(terms, " ")
+}
+
+func generatedUpdatedFullTextDoc(faker *gofakeit.Faker, i int) string {
+	return fmt.Sprintf("updated common cohort%02d revision%04d %s %s", i%100, i, faker.Word(), faker.Word())
+}
+
+func generatedJSONPayload(faker *gofakeit.Faker, i int) string {
+	eventType := "click"
+	if i%3 == 1 {
+		eventType = "view"
+	} else if i%3 == 2 {
+		eventType = "purchase"
+	}
+	tags := `["api","batch"]`
+	if eventType == "click" {
+		tags = `["web","batch"]`
+	}
+	return fmt.Sprintf(
+		`{"type":"%s","status":"%s","tags":%s,"user":{"id":"u%06d","country":"%s"},"active":%t}`,
+		eventType,
+		[]string{"new", "queued", "done"}[i%3],
+		tags,
+		i%1_000,
+		[]string{"GB", "US", "DE", "FR"}[i%4],
+		i%2 == 0,
+	)
+}
+
+func generatedUpdatedJSONPayload(faker *gofakeit.Faker, i int) string {
+	return fmt.Sprintf(
+		`{"type":"updated","status":"%s","tags":["maintenance"],"user":{"id":"u%06d"},"active":%t}`,
+		[]string{"queued", "done"}[i%2],
+		i%1_000,
+		i%2 == 0,
+	)
+}
+
+func queryCount(t testing.TB, db *sql.DB, query string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(query).Scan(&count); err != nil {
+		t.Fatalf("query count %q: %v", query, err)
+	}
+	return count
+}
+
+func jsonClickRows(n int) int {
+	return (n + 2) / 3
+}


### PR DESCRIPTION
Implemented the first inverted-index benchmark suite.

Added benchmarks/inverted_bench_test.go with benchmarks for:


- Full-text index build, insert, update, delete
- Full-text rare/medium/common single-term search
- Full-text multi-term AND and phrase search
- JSON inverted index build, insert, update, delete
- JSON containment key/value and object-subset lookup
- MiniSQL indexed vs MiniSQL sequential JSON comparisons
- SQLite FTS5 full-text reference, when available
- SQLite JSON scan / expression-index contextual baselines