### PR TITLE
refactor: buffer postings by term during CREATE FULLTEXT INDEX

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,37 @@
-### 2026-05-14 (Full-text and JSON inverted benchmark suite added — latest)
+### 2026-05-14 (bulk full-text CREATE INDEX population — latest)
+
+`CREATE FULLTEXT INDEX` now buffers postings by term during index population and
+uses a new `InsertMany` path on the dedicated inverted index. This avoids the
+old build-time pattern of decoding, regrouping, sorting, and re-encoding the
+same hot term once for every token occurrence.
+
+The generated build-only timing/memory table for this run is appended below as
+`2026-05-14 21:28 UTC`.
+
+#### Timing
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| FullText_BuildIndex/minisql | 1.85 s/op | 53.75 ms/op | 34.4× faster |
+| FullText_BuildIndex/sqlite | 57.70 ms/op | 67.87 ms/op | reference variance |
+| JSONInverted_BuildIndex/minisql_indexed | 296.61 ms/op | 294.46 ms/op | unchanged |
+
+#### Memory (B/op)
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| FullText_BuildIndex/minisql | 3624.8 MiB | 81.4 MiB | 44.5× lower |
+| FullText_BuildIndex/sqlite | 429.0 KiB | 428.8 KiB | unchanged |
+| JSONInverted_BuildIndex/minisql_indexed | 1327.3 MiB | 1327.7 MiB | unchanged |
+
+Full-text build is no longer the top timing hotspot in this fixture; it is now
+slightly faster than SQLite FTS5 on wall time. Allocation is still much higher
+than SQLite, so the next likely target is reducing tokenizer/posting allocation
+and then applying a similar build-time batching path to JSON inverted indexes.
+
+---
+
+### 2026-05-14 (Full-text and JSON inverted benchmark suite added)
 
 Added the first dedicated benchmark suite for MiniSQL's inverted-index storage
 and recorded the initial baseline. The generated timing/memory tables for this
@@ -865,4 +898,20 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 | JSONInverted_Contains_ObjectSubset/object_subset | — | 1.8 MiB | 3.5 MiB | — | 549 B | 548 B |
 | JSONInverted_Update_WithIndex | — | 4.6 MiB | — | — | — | — |
 | JSONInverted_Delete_WithIndex | — | 143.0 KiB | — | — | — | — |
+
+### 2026-05-14 21:28 UTC
+
+#### Timing
+
+| Benchmark | minisql | minisql_indexed | sqlite | ratio |
+|---|---|---|---|---|
+| FullText_BuildIndex | 53.75 ms/op | — | 67.87 ms/op | 0.8× |
+| JSONInverted_BuildIndex | — | 294.46 ms/op | — | — |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | minisql_indexed | sqlite |
+|---|---|---|---|
+| FullText_BuildIndex | 81.4 MiB | — | 428.8 KiB |
+| JSONInverted_BuildIndex | — | 1327.7 MiB | — |
 

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +23,8 @@ var (
 	errIndexAlreadyExists        = errors.New("index already exists")
 	errIndexOnJSONColumn         = errors.New("b-tree index on JSON column is not supported")
 )
+
+const populateFullTextIndexFlushPostings = 64 * 1024
 
 // WALConfig bundles the Write-Ahead Log objects that NewDatabase needs.
 // Pass nil when creating in-memory/test databases that do not require WAL.
@@ -1463,6 +1466,10 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 }
 
 func (d *Database) populateIndex(ctx context.Context, table *Table, secondaryIndex SecondaryIndex) error {
+	if secondaryIndex.Method == IndexMethodFullText {
+		return d.populateFullTextIndex(ctx, table, secondaryIndex)
+	}
+
 	result, err := table.Select(ctx, Statement{
 		Kind:   Select,
 		Fields: fieldsFromColumns(table.Columns...),
@@ -1556,6 +1563,77 @@ func (d *Database) populateIndex(ctx context.Context, table *Table, secondaryInd
 	}
 
 	return nil
+}
+
+func (d *Database) populateFullTextIndex(ctx context.Context, table *Table, secondaryIndex SecondaryIndex) error {
+	if secondaryIndex.InvertedIndex == nil {
+		return fmt.Errorf("table %s has full-text index %s but no inverted index instance", table.Name, secondaryIndex.Name)
+	}
+
+	result, err := table.Select(ctx, Statement{
+		Kind:   Select,
+		Fields: fieldsFromColumns(table.Columns...),
+	})
+	if err != nil {
+		return err
+	}
+
+	postingsByTerm := make(map[string][]invertedPosting)
+	bufferedPostings := 0
+	flush := func() error {
+		if len(postingsByTerm) == 0 {
+			return nil
+		}
+		terms := make([]string, 0, len(postingsByTerm))
+		for term := range postingsByTerm {
+			terms = append(terms, term)
+		}
+		sort.Strings(terms)
+		for _, term := range terms {
+			if err := secondaryIndex.InvertedIndex.InsertMany(ctx, term, postingsByTerm[term]); err != nil {
+				return fmt.Errorf("failed to insert token batch for full-text index %s: %w", secondaryIndex.Name, err)
+			}
+		}
+		postingsByTerm = make(map[string][]invertedPosting)
+		bufferedPostings = 0
+		return nil
+	}
+
+	for result.Rows.Next(ctx) {
+		row := result.Rows.Row()
+
+		if len(secondaryIndex.WhereCond) > 0 {
+			ok, err := row.CheckOneOrMore(secondaryIndex.WhereCond)
+			if err != nil {
+				return fmt.Errorf("partial index %s where check: %w", secondaryIndex.Name, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		tokens, err := fullTextTokenPositionsForRow(secondaryIndex, row)
+		if err != nil {
+			return err
+		}
+		for _, token := range tokens {
+			postingsByTerm[token.Term] = append(postingsByTerm[token.Term], invertedPosting{
+				RowID:     row.Key,
+				Positions: []uint32{token.Position},
+			})
+			bufferedPostings++
+		}
+		if bufferedPostings >= populateFullTextIndexFlushPostings {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := result.Rows.Err(); err != nil {
+		return err
+	}
+	return flush()
 }
 
 func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -463,6 +463,12 @@ func (f *fakeFullTextInvertedIndex) Insert(_ context.Context, term string, posti
 	return nil
 }
 
+func (f *fakeFullTextInvertedIndex) InsertMany(_ context.Context, term string, postings []invertedPosting) error {
+	f.inserted = append(f.inserted, term)
+	f.postings[term] = append(f.postings[term], postings...)
+	return nil
+}
+
 func (f *fakeFullTextInvertedIndex) Delete(_ context.Context, term string, posting invertedPosting) error {
 	f.deleted = append(f.deleted, term)
 	postings := f.postings[term]

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -42,6 +42,7 @@ type invertedIndex interface {
 	GetRootPageIdx() PageIndex
 	Mode() invertedIndexPostingMode
 	Insert(ctx context.Context, term string, posting invertedPosting) error
+	InsertMany(ctx context.Context, term string, postings []invertedPosting) error
 	Delete(ctx context.Context, term string, posting invertedPosting) error
 	Lookup(ctx context.Context, term string) (invertedPostingIterator, error)
 	Stats(ctx context.Context, term string) (invertedPostingStats, error)
@@ -106,7 +107,30 @@ func (idx *dedicatedInvertedIndex) Insert(ctx context.Context, term string, post
 		return fmt.Errorf("inverted index term exceeds max index key size %d", MaxIndexKeySize)
 	}
 
-	separator, rightPageIdx, split, err := idx.insertEntry(ctx, idx.rootPageIdx, term, posting)
+	one := [1]invertedPosting{posting}
+	separator, rightPageIdx, split, err := idx.insertEntry(ctx, idx.rootPageIdx, term, one[:])
+	if err != nil {
+		return err
+	}
+	if !split {
+		return nil
+	}
+
+	return idx.splitRootEntryPage(ctx, separator, rightPageIdx)
+}
+
+// InsertMany adds a batch of postings for one term. It is primarily used by
+// CREATE INDEX population so a term's posting list can be encoded once instead
+// of being repeatedly decoded and re-encoded for every token occurrence.
+func (idx *dedicatedInvertedIndex) InsertMany(ctx context.Context, term string, postings []invertedPosting) error {
+	if len(postings) == 0 {
+		return nil
+	}
+	if len([]byte(term)) > MaxIndexKeySize {
+		return fmt.Errorf("inverted index term exceeds max index key size %d", MaxIndexKeySize)
+	}
+
+	separator, rightPageIdx, split, err := idx.insertEntry(ctx, idx.rootPageIdx, term, postings)
 	if err != nil {
 		return err
 	}
@@ -527,8 +551,8 @@ func (idx *dedicatedInvertedIndex) findEntryLeafPage(ctx context.Context, term s
 	}
 }
 
-// insertEntry recursively inserts a term posting and returns a split separator if needed.
-func (idx *dedicatedInvertedIndex) insertEntry(ctx context.Context, pageIdx PageIndex, term string, posting invertedPosting) (string, PageIndex, bool, error) {
+// insertEntry recursively inserts term postings and returns a split separator if needed.
+func (idx *dedicatedInvertedIndex) insertEntry(ctx context.Context, pageIdx PageIndex, term string, postings []invertedPosting) (string, PageIndex, bool, error) {
 	page, err := idx.pager.ReadPage(ctx, pageIdx)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("read inverted entry page %d: %w", pageIdx, err)
@@ -537,13 +561,13 @@ func (idx *dedicatedInvertedIndex) insertEntry(ctx context.Context, pageIdx Page
 		return "", 0, false, fmt.Errorf("inverted entry page %d is not an entry page", pageIdx)
 	}
 	if page.InvertedEntryPage.Header.IsLeaf {
-		return idx.insertEntryLeaf(ctx, pageIdx, term, posting)
+		return idx.insertEntryLeaf(ctx, pageIdx, term, postings)
 	}
-	return idx.insertEntryInternal(ctx, pageIdx, term, posting)
+	return idx.insertEntryInternal(ctx, pageIdx, term, postings)
 }
 
 // insertEntryLeaf inserts or updates one leaf cell, splitting the leaf on overflow.
-func (idx *dedicatedInvertedIndex) insertEntryLeaf(ctx context.Context, pageIdx PageIndex, term string, posting invertedPosting) (string, PageIndex, bool, error) {
+func (idx *dedicatedInvertedIndex) insertEntryLeaf(ctx context.Context, pageIdx PageIndex, term string, postings []invertedPosting) (string, PageIndex, bool, error) {
 	page, err := idx.pager.ModifyPage(ctx, pageIdx)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("modify inverted entry leaf %d: %w", pageIdx, err)
@@ -554,11 +578,11 @@ func (idx *dedicatedInvertedIndex) insertEntryLeaf(ctx context.Context, pageIdx 
 	}
 
 	cellIdx, found := findInvertedEntryCell(entryPage.Cells, term)
-	postings := []invertedPosting{posting}
+	allPostings := append([]invertedPosting(nil), postings...)
 	if found {
 		oldCell := entryPage.Cells[cellIdx]
-		if oldCell.PostingKind == invertedPostingKindTree {
-			updatedCell, mutated, err := idx.insertPostingIntoTreeCell(ctx, oldCell, posting)
+		if oldCell.PostingKind == invertedPostingKindTree && len(postings) == 1 {
+			updatedCell, mutated, err := idx.insertPostingIntoTreeCell(ctx, oldCell, postings[0])
 			if err != nil {
 				return "", 0, false, err
 			}
@@ -568,14 +592,14 @@ func (idx *dedicatedInvertedIndex) insertEntryLeaf(ctx context.Context, pageIdx 
 			}
 		}
 		var err error
-		postings, err = idx.decodeInvertedEntryCell(ctx, oldCell)
+		existingPostings, err := idx.decodeInvertedEntryCell(ctx, oldCell)
 		if err != nil {
 			return "", 0, false, err
 		}
-		postings = append(postings, posting)
+		allPostings = append(existingPostings, allPostings...)
 	}
 
-	cell, err := idx.makeInvertedEntryCell(ctx, term, postings, entryPage.Cells[cellIdx:cellIdx+boolToInt(found)])
+	cell, err := idx.makeInvertedEntryCell(ctx, term, allPostings, entryPage.Cells[cellIdx:cellIdx+boolToInt(found)])
 	if err != nil {
 		return "", 0, false, err
 	}
@@ -596,7 +620,7 @@ func (idx *dedicatedInvertedIndex) insertEntryLeaf(ctx context.Context, pageIdx 
 }
 
 // insertEntryInternal descends into a child and absorbs child splits.
-func (idx *dedicatedInvertedIndex) insertEntryInternal(ctx context.Context, pageIdx PageIndex, term string, posting invertedPosting) (string, PageIndex, bool, error) {
+func (idx *dedicatedInvertedIndex) insertEntryInternal(ctx context.Context, pageIdx PageIndex, term string, postings []invertedPosting) (string, PageIndex, bool, error) {
 	page, err := idx.pager.ReadPage(ctx, pageIdx)
 	if err != nil {
 		return "", 0, false, fmt.Errorf("read inverted entry internal %d: %w", pageIdx, err)
@@ -610,7 +634,7 @@ func (idx *dedicatedInvertedIndex) insertEntryInternal(ctx context.Context, page
 		return "", 0, false, err
 	}
 
-	separator, rightChildIdx, split, err := idx.insertEntry(ctx, childIdx, term, posting)
+	separator, rightChildIdx, split, err := idx.insertEntry(ctx, childIdx, term, postings)
 	if err != nil || !split {
 		return "", 0, false, err
 	}

--- a/internal/minisql/inverted_index_test.go
+++ b/internal/minisql/inverted_index_test.go
@@ -112,6 +112,37 @@ func TestDedicatedInvertedIndex_PositionalInlinePostings(t *testing.T) {
 	}, postings)
 }
 
+func TestDedicatedInvertedIndex_InsertManyPositionalPostings(t *testing.T) {
+	index, txManager := newTestDedicatedInvertedIndex(t, "idx_body", invertedIndexPostingModePositions)
+	ctx := context.Background()
+
+	require.NoError(t, txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		if err := index.InsertMany(ctx, "database", []invertedPosting{
+			{RowID: 10, Positions: []uint32{4, 2, 4}},
+			{RowID: 5, Positions: []uint32{1}},
+			{RowID: 10, Positions: []uint32{7}},
+		}); err != nil {
+			return err
+		}
+		return index.InsertMany(ctx, "search", []invertedPosting{
+			{RowID: 2, Positions: []uint32{9}},
+			{RowID: 1, Positions: []uint32{3}},
+		})
+	}))
+
+	stats, err := index.Stats(ctx, "database")
+	require.NoError(t, err)
+	assert.Equal(t, invertedPostingStats{DocFreq: 2, PostingCount: 4}, stats)
+	assert.Equal(t, []invertedPosting{
+		{RowID: 5, Positions: []uint32{1}},
+		{RowID: 10, Positions: []uint32{2, 4, 7}},
+	}, collectDedicatedInvertedPostings(t, ctx, index, "database"))
+	assert.Equal(t, []invertedPosting{
+		{RowID: 1, Positions: []uint32{3}},
+		{RowID: 2, Positions: []uint32{9}},
+	}, collectDedicatedInvertedPostings(t, ctx, index, "search"))
+}
+
 func TestDedicatedInvertedIndex_DeleteInlinePostings(t *testing.T) {
 	index, txManager := newTestDedicatedInvertedIndex(t, "idx_body", invertedIndexPostingModePositions)
 	ctx := context.Background()


### PR DESCRIPTION
I optimized `CREATE FULLTEXT INDEX` population so it buffers postings by term and uses a new InsertMany path instead of inserting one token occurrence at a time. That avoids repeatedly decoding/sorting/re-encoding hot posting lists during index build.

Result for BenchmarkFullText_BuildIndex/minisql:
```
Before: 1.85 s/op, 3624.8 MiB/op
After:  53.75 ms/op, 81.4 MiB/op
```

That is about 34x faster and 44x lower allocation for the 1,000-doc fixture. It is now slightly faster than the SQLite FTS5 build baseline in this run, though still much heavier on memory.