### PR TITLE
refactor: buffer postings by json term during CREATE INVERTED INDEX

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,38 @@
-### 2026-05-14 (bulk full-text CREATE INDEX population — latest)
+### 2026-05-14 (bulk JSON inverted CREATE INDEX population — latest)
+
+`CREATE INVERTED INDEX` now uses the same build-time batching strategy as
+full-text indexes: postings are buffered by JSON term, terms are flushed in
+sorted order, and each term is inserted with `InsertMany`. This avoids
+rebuilding repeated key/value posting lists for every row during index
+population.
+
+The generated build-only timing/memory table for this run is appended below as
+`2026-05-14 21:50 UTC`.
+
+#### Timing
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| JSONInverted_BuildIndex/minisql_indexed | 294.46 ms/op | 46.11 ms/op | 6.4× faster |
+| FullText_BuildIndex/minisql | 53.75 ms/op | 60.79 ms/op | run variance |
+| FullText_BuildIndex/sqlite | 67.87 ms/op | 63.68 ms/op | reference variance |
+
+#### Memory (B/op)
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| JSONInverted_BuildIndex/minisql_indexed | 1327.7 MiB | 78.1 MiB | 17.0× lower |
+| FullText_BuildIndex/minisql | 81.4 MiB | 81.5 MiB | unchanged |
+| FullText_BuildIndex/sqlite | 428.8 KiB | 429.2 KiB | unchanged |
+
+Both inverted index build paths now avoid the original per-posting rebuild
+pattern. The next storage optimisation target should move from build-time
+population to runtime lookup/update allocation, especially common-term
+full-text lookups, JSON indexed scans, and full-text UPDATE maintenance.
+
+---
+
+### 2026-05-14 (bulk full-text CREATE INDEX population)
 
 `CREATE FULLTEXT INDEX` now buffers postings by term during index population and
 uses a new `InsertMany` path on the dedicated inverted index. This avoids the
@@ -914,4 +948,20 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 |---|---|---|---|
 | FullText_BuildIndex | 81.4 MiB | — | 428.8 KiB |
 | JSONInverted_BuildIndex | — | 1327.7 MiB | — |
+
+### 2026-05-14 21:50 UTC
+
+#### Timing
+
+| Benchmark | minisql | minisql_indexed | sqlite | ratio |
+|---|---|---|---|---|
+| FullText_BuildIndex | 60.79 ms/op | — | 63.68 ms/op | 1.0× |
+| JSONInverted_BuildIndex | — | 46.11 ms/op | — | — |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | minisql_indexed | sqlite |
+|---|---|---|---|
+| FullText_BuildIndex | 81.5 MiB | — | 429.2 KiB |
+| JSONInverted_BuildIndex | — | 78.1 MiB | — |
 

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -24,7 +24,7 @@ var (
 	errIndexOnJSONColumn         = errors.New("b-tree index on JSON column is not supported")
 )
 
-const populateFullTextIndexFlushPostings = 64 * 1024
+const populateInvertedIndexFlushPostings = 64 * 1024
 
 // WALConfig bundles the Write-Ahead Log objects that NewDatabase needs.
 // Pass nil when creating in-memory/test databases that do not require WAL.
@@ -1469,6 +1469,9 @@ func (d *Database) populateIndex(ctx context.Context, table *Table, secondaryInd
 	if secondaryIndex.Method == IndexMethodFullText {
 		return d.populateFullTextIndex(ctx, table, secondaryIndex)
 	}
+	if secondaryIndex.Method == IndexMethodInverted {
+		return d.populateJSONInvertedIndex(ctx, table, secondaryIndex)
+	}
 
 	result, err := table.Select(ctx, Statement{
 		Kind:   Select,
@@ -1623,7 +1626,75 @@ func (d *Database) populateFullTextIndex(ctx context.Context, table *Table, seco
 			})
 			bufferedPostings++
 		}
-		if bufferedPostings >= populateFullTextIndexFlushPostings {
+		if bufferedPostings >= populateInvertedIndexFlushPostings {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := result.Rows.Err(); err != nil {
+		return err
+	}
+	return flush()
+}
+
+func (d *Database) populateJSONInvertedIndex(ctx context.Context, table *Table, secondaryIndex SecondaryIndex) error {
+	if secondaryIndex.InvertedIndex == nil {
+		return fmt.Errorf("table %s has inverted index %s but no inverted index instance", table.Name, secondaryIndex.Name)
+	}
+
+	result, err := table.Select(ctx, Statement{
+		Kind:   Select,
+		Fields: fieldsFromColumns(table.Columns...),
+	})
+	if err != nil {
+		return err
+	}
+
+	postingsByTerm := make(map[string][]invertedPosting)
+	bufferedPostings := 0
+	flush := func() error {
+		if len(postingsByTerm) == 0 {
+			return nil
+		}
+		terms := make([]string, 0, len(postingsByTerm))
+		for term := range postingsByTerm {
+			terms = append(terms, term)
+		}
+		sort.Strings(terms)
+		for _, term := range terms {
+			if err := secondaryIndex.InvertedIndex.InsertMany(ctx, term, postingsByTerm[term]); err != nil {
+				return fmt.Errorf("failed to insert JSON term batch for inverted index %s: %w", secondaryIndex.Name, err)
+			}
+		}
+		postingsByTerm = make(map[string][]invertedPosting)
+		bufferedPostings = 0
+		return nil
+	}
+
+	for result.Rows.Next(ctx) {
+		row := result.Rows.Row()
+
+		if len(secondaryIndex.WhereCond) > 0 {
+			ok, err := row.CheckOneOrMore(secondaryIndex.WhereCond)
+			if err != nil {
+				return fmt.Errorf("partial index %s where check: %w", secondaryIndex.Name, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		terms, err := jsonInvertedTermsForRow(secondaryIndex, row)
+		if err != nil {
+			return err
+		}
+		for _, term := range terms {
+			postingsByTerm[term] = append(postingsByTerm[term], invertedPosting{RowID: row.Key})
+			bufferedPostings++
+		}
+		if bufferedPostings >= populateInvertedIndexFlushPostings {
 			if err := flush(); err != nil {
 				return err
 			}

--- a/internal/minisql/inverted_index_test.go
+++ b/internal/minisql/inverted_index_test.go
@@ -91,6 +91,32 @@ func TestDedicatedInvertedIndex_RowIDInlinePostings(t *testing.T) {
 	assert.Empty(t, collectDedicatedInvertedPostings(t, ctx, index, "missing"))
 }
 
+func TestDedicatedInvertedIndex_InsertManyRowIDPostings(t *testing.T) {
+	index, txManager := newTestDedicatedInvertedIndex(t, "idx_json", invertedIndexPostingModeRowIDs)
+	ctx := context.Background()
+
+	require.NoError(t, txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		if err := index.InsertMany(ctx, `kv:type:s:"click"`, []invertedPosting{
+			{RowID: 7},
+			{RowID: 3},
+			{RowID: 7},
+			{RowID: 1},
+		}); err != nil {
+			return err
+		}
+		return index.InsertMany(ctx, "k:user.id", []invertedPosting{
+			{RowID: 5},
+			{RowID: 2},
+		})
+	}))
+
+	stats, err := index.Stats(ctx, `kv:type:s:"click"`)
+	require.NoError(t, err)
+	assert.Equal(t, invertedPostingStats{DocFreq: 3, PostingCount: 3}, stats)
+	assert.Equal(t, []invertedPosting{{RowID: 1}, {RowID: 3}, {RowID: 7}}, collectDedicatedInvertedPostings(t, ctx, index, `kv:type:s:"click"`))
+	assert.Equal(t, []invertedPosting{{RowID: 2}, {RowID: 5}}, collectDedicatedInvertedPostings(t, ctx, index, "k:user.id"))
+}
+
 func TestDedicatedInvertedIndex_PositionalInlinePostings(t *testing.T) {
 	index, txManager := newTestDedicatedInvertedIndex(t, "idx_body", invertedIndexPostingModePositions)
 	ctx := context.Background()


### PR DESCRIPTION
I added a bulk JSON inverted index population path in database.go. `CREATE INVERTED INDEX` now buffers row-ID postings by JSON term and flushes them through InsertMany, instead of repeatedly updating the same posting lists term-by-term during the table scan.

Benchmark result for BenchmarkJSONInverted_BuildIndex/minisql_indexed:
```
Before: 294.46 ms/op, 1327.7 MiB/op
After:   46.11 ms/op,   78.1 MiB/op
```

That is about 6.4x faster and 17x lower allocation. I also added row-ID InsertMany coverage in inverted_index_test.go, and recorded the before/after in benchmarks/RESULTS.md.