### PR TITLE
refactor: optimise inverted index runtime allocations

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,50 @@
-### 2026-05-14 (bulk JSON inverted CREATE INDEX population — latest)
+### 2026-05-15 (runtime inverted-index allocation pass — latest)
+
+Runtime inverted-index maintenance and scans received two targeted allocation
+improvements:
+
+- Full-text scans no longer allocate per-row phrase-position maps for queries
+  that do not contain phrases. Single-term and AND queries only need row-ID
+  intersection.
+- JSON inverted UPDATE maintenance now diffs old/new term sets and skips shared
+  row-ID terms instead of deleting and reinserting unchanged key-existence
+  terms.
+- Full-text UPDATE maintenance can replace changed positions for surviving
+  terms in a single term mutation, though this is a smaller win in the current
+  fixture because most updated terms are deleted or inserted outright.
+
+The generated runtime timing/memory table for this run is appended below as
+`2026-05-15 19:19 UTC`.
+
+#### Timing
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| JSONInverted_Update_WithIndex/minisql_indexed | 1.20 ms/op | 431.96 µs/op | 2.8× faster |
+| FullText_Search_MultiTermAND/minisql | 423.05 µs/op | 308.45 µs/op | 1.4× faster |
+| FullText_Search_SingleTerm/common/minisql | 1.03 ms/op | 956.69 µs/op | 1.1× faster |
+| FullText_Update_WithIndex/minisql | 3.28 ms/op | 3.25 ms/op | roughly unchanged |
+| JSONInverted_Contains_KeyValue/minisql_indexed | 1.25 ms/op | 1.26 ms/op | roughly unchanged |
+
+#### Memory (B/op)
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| JSONInverted_Update_WithIndex/minisql_indexed | 4.6 MiB | 1.2 MiB | 3.8× lower |
+| FullText_Search_MultiTermAND/minisql | 358.7 KiB | 283.7 KiB | 21% lower |
+| FullText_Search_SingleTerm/common/minisql | 606.8 KiB | 532.1 KiB | 12% lower |
+| JSONInverted_Contains_KeyValue/minisql_indexed | 1.5 MiB | 1.4 MiB | modest |
+| FullText_Update_WithIndex/minisql | 6.0 MiB | 5.9 MiB | modest |
+
+The remaining large runtime allocation target is full-text UPDATE. The current
+small improvement suggests the dominant cost is deeper than term-level duplicate
+work, likely posting-tree page mutation/write-set cloning and table row update
+overhead. That should be profiled with a dedicated allocation profiler or
+smaller microbenchmarks around posting-tree delete/insert/replace.
+
+---
+
+### 2026-05-14 (bulk JSON inverted CREATE INDEX population)
 
 `CREATE INVERTED INDEX` now uses the same build-time batching strategy as
 full-text indexes: postings are buffered by JSON term, terms are flushed in
@@ -964,4 +1010,42 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 |---|---|---|---|
 | FullText_BuildIndex | 81.5 MiB | — | 429.2 KiB |
 | JSONInverted_BuildIndex | — | 78.1 MiB | — |
+
+### 2026-05-15 19:19 UTC
+
+#### Timing
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan | ratio |
+|---|---|---|---|---|---|---|---|
+| FullText_Insert_WithIndex | 70.28 µs/op | — | — | 162.56 µs/op | — | — | 0.4× |
+| FullText_Search_SingleTerm/rare | 207.69 µs/op | — | — | 274.34 µs/op | — | — | 0.8× |
+| FullText_Search_SingleTerm/medium | 195.04 µs/op | — | — | 330.99 µs/op | — | — | 0.6× |
+| FullText_Search_SingleTerm/common | 956.69 µs/op | — | — | 328.30 µs/op | — | — | 2.9× |
+| FullText_Search_MultiTermAND | 308.45 µs/op | — | — | 301.59 µs/op | — | — | 1.0× |
+| FullText_Search_Phrase | 275.49 µs/op | — | — | 387.63 µs/op | — | — | 0.7× |
+| FullText_Update_WithIndex | 3.25 ms/op | — | — | 375.41 µs/op | — | — | 8.6× |
+| FullText_Delete_WithIndex | 76.67 µs/op | — | — | 337.64 µs/op | — | — | 0.2× |
+| JSONInverted_Insert_WithIndex | — | 103.79 µs/op | — | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.26 ms/op | 3.10 ms/op | — | 278.97 µs/op | 991.60 µs/op | — |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.42 ms/op | 3.34 ms/op | — | 513.01 µs/op | 1.03 ms/op | — |
+| JSONInverted_Update_WithIndex | — | 431.96 µs/op | — | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 102.73 µs/op | — | — | — | — | — |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan |
+|---|---|---|---|---|---|---|
+| FullText_Insert_WithIndex | 66.9 KiB | — | — | 714 B | — | — |
+| FullText_Search_SingleTerm/rare | 66.8 KiB | — | — | 533 B | — | — |
+| FullText_Search_SingleTerm/medium | 71.5 KiB | — | — | 533 B | — | — |
+| FullText_Search_SingleTerm/common | 532.1 KiB | — | — | 548 B | — | — |
+| FullText_Search_MultiTermAND | 283.7 KiB | — | — | 533 B | — | — |
+| FullText_Search_Phrase | 171.2 KiB | — | — | 540 B | — | — |
+| FullText_Update_WithIndex | 5.9 MiB | — | — | 412 B | — | — |
+| FullText_Delete_WithIndex | 40.4 KiB | — | — | 259 B | — | — |
+| JSONInverted_Insert_WithIndex | — | 164.3 KiB | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.4 MiB | 3.3 MiB | — | 550 B | 548 B |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.7 MiB | 3.5 MiB | — | 548 B | 549 B |
+| JSONInverted_Update_WithIndex | — | 1.2 MiB | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 142.5 KiB | — | — | — | — |
 

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -446,6 +446,7 @@ type fakeFullTextInvertedIndex struct {
 	postings map[string][]invertedPosting
 	inserted []string
 	deleted  []string
+	replaced []string
 	mode     invertedPostingMode
 }
 
@@ -467,6 +468,14 @@ func (f *fakeFullTextInvertedIndex) InsertMany(_ context.Context, term string, p
 	f.inserted = append(f.inserted, term)
 	f.postings[term] = append(f.postings[term], postings...)
 	return nil
+}
+
+func (f *fakeFullTextInvertedIndex) Replace(_ context.Context, term string, oldPosting, newPosting invertedPosting) error {
+	f.replaced = append(f.replaced, term)
+	if err := f.Delete(context.Background(), term, oldPosting); err != nil {
+		return err
+	}
+	return f.Insert(context.Background(), term, newPosting)
 }
 
 func (f *fakeFullTextInvertedIndex) Delete(_ context.Context, term string, posting invertedPosting) error {

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -43,6 +43,7 @@ type invertedIndex interface {
 	Mode() invertedIndexPostingMode
 	Insert(ctx context.Context, term string, posting invertedPosting) error
 	InsertMany(ctx context.Context, term string, postings []invertedPosting) error
+	Replace(ctx context.Context, term string, oldPosting, newPosting invertedPosting) error
 	Delete(ctx context.Context, term string, posting invertedPosting) error
 	Lookup(ctx context.Context, term string) (invertedPostingIterator, error)
 	Stats(ctx context.Context, term string) (invertedPostingStats, error)
@@ -139,6 +140,59 @@ func (idx *dedicatedInvertedIndex) InsertMany(ctx context.Context, term string, 
 	}
 
 	return idx.splitRootEntryPage(ctx, separator, rightPageIdx)
+}
+
+// Replace swaps one posting for another under the same term. It is used by
+// UPDATE maintenance when a term remains present but its positions changed.
+func (idx *dedicatedInvertedIndex) Replace(ctx context.Context, term string, oldPosting, newPosting invertedPosting) error {
+	if len([]byte(term)) > MaxIndexKeySize {
+		return fmt.Errorf("inverted index term exceeds max index key size %d", MaxIndexKeySize)
+	}
+
+	leafPage, err := idx.findEntryLeafPage(ctx, term)
+	if err != nil {
+		return err
+	}
+	page, err := idx.pager.ModifyPage(ctx, leafPage.Index)
+	if err != nil {
+		return fmt.Errorf("modify inverted entry leaf %d: %w", leafPage.Index, err)
+	}
+	if page.InvertedEntryPage == nil || !page.InvertedEntryPage.Header.IsLeaf {
+		return fmt.Errorf("inverted entry page %d is not a leaf", page.Index)
+	}
+	entryPage := page.InvertedEntryPage
+	cellIdx, found := findInvertedEntryCell(entryPage.Cells, term)
+	if !found {
+		return idx.Insert(ctx, term, newPosting)
+	}
+
+	oldCell := entryPage.Cells[cellIdx]
+	if oldCell.PostingKind == invertedPostingKindTree && oldCell.PostingCount > 64 {
+		updatedCell, mutated, err := idx.replacePostingInTreeCell(ctx, oldCell, oldPosting, newPosting)
+		if err != nil {
+			return err
+		}
+		if mutated {
+			entryPage.Cells[cellIdx] = updatedCell
+			return nil
+		}
+	}
+
+	postings, err := idx.decodeInvertedEntryCell(ctx, oldCell)
+	if err != nil {
+		return err
+	}
+	postings = removeInvertedPosting(idx.mode, postings, oldPosting)
+	postings = append(postings, newPosting)
+	cell, err := idx.makeInvertedEntryCell(ctx, term, postings, []invertedEntryCell{oldCell})
+	if err != nil {
+		return err
+	}
+	entryPage.Cells[cellIdx] = cell
+	if err := ensureInvertedEntryPageFits(entryPage, invertedPageBodySize(page.Index)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Delete removes a posting from a compressed posting list for term.
@@ -1008,6 +1062,70 @@ func (idx *dedicatedInvertedIndex) insertPostingIntoTreeCell(ctx context.Context
 	if oldDocFreq == newDocFreq && oldPostingCount == newPostingCount {
 		return cell, true, nil
 	}
+
+	replacementBlocks, err := makeInvertedPostingBlocks(idx.mode, updatedPostings)
+	if err != nil {
+		return invertedEntryCell{}, false, err
+	}
+	candidate := leaf.InvertedPostPage.Clone()
+	candidate.Blocks = replaceInvertedPostingBlocks(candidate.Blocks, blockIdx, replacementBlocks)
+	fits := ensureInvertedPostingPageFits(candidate, invertedPageBodySize(leaf.Index)) == nil
+	if fits {
+		page, err := idx.pager.ModifyPage(ctx, leaf.Index)
+		if err != nil {
+			return invertedEntryCell{}, false, fmt.Errorf("modify inverted posting leaf %d: %w", leaf.Index, err)
+		}
+		page.InvertedPostPage = candidate
+		if err := idx.refreshPostingAncestors(ctx, page.Index); err != nil {
+			return invertedEntryCell{}, false, err
+		}
+	} else {
+		newRoot, err := idx.splitPostingLeafForBlocks(ctx, cell.Child, leaf, blockIdx, replacementBlocks)
+		if err != nil {
+			return invertedEntryCell{}, false, err
+		}
+		cell.Child = newRoot
+	}
+
+	updatedCell := cell
+	updatedCell.DocFreq = uint32(int(updatedCell.DocFreq) + newDocFreq - oldDocFreq)
+	updatedCell.PostingCount = uint32(int(updatedCell.PostingCount) + int(newPostingCount) - int(oldPostingCount))
+	return updatedCell, true, nil
+}
+
+// replacePostingInTreeCell updates one posting-tree leaf block by removing an
+// old posting and adding its replacement in a single page mutation.
+func (idx *dedicatedInvertedIndex) replacePostingInTreeCell(
+	ctx context.Context,
+	cell invertedEntryCell,
+	oldPosting, newPosting invertedPosting,
+) (invertedEntryCell, bool, error) {
+	if oldPosting.RowID != newPosting.RowID {
+		return invertedEntryCell{}, false, nil
+	}
+	leaf, blockIdx, err := idx.findPostingLeafBlock(ctx, cell.Child, oldPosting.RowID)
+	if err != nil {
+		return invertedEntryCell{}, false, err
+	}
+	if blockIdx < 0 {
+		return invertedEntryCell{}, false, nil
+	}
+
+	block := leaf.InvertedPostPage.Blocks[blockIdx]
+	mode, blockPostings, err := decodeInvertedPostingList(block.Payload)
+	if err != nil {
+		return invertedEntryCell{}, false, err
+	}
+	if mode != idx.mode {
+		return invertedEntryCell{}, false, fmt.Errorf("inverted posting block uses posting mode %d, expected %d", mode, idx.mode)
+	}
+
+	oldDocFreq := len(blockPostings)
+	oldPostingCount := countInvertedPostings(idx.mode, blockPostings)
+	updatedPostings := removeInvertedPosting(idx.mode, blockPostings, oldPosting)
+	updatedPostings = groupInvertedPostings(idx.mode, append(updatedPostings, newPosting))
+	newDocFreq := len(updatedPostings)
+	newPostingCount := countInvertedPostings(idx.mode, updatedPostings)
 
 	replacementBlocks, err := makeInvertedPostingBlocks(idx.mode, updatedPostings)
 	if err != nil {

--- a/internal/minisql/inverted_index_test.go
+++ b/internal/minisql/inverted_index_test.go
@@ -169,6 +169,28 @@ func TestDedicatedInvertedIndex_InsertManyPositionalPostings(t *testing.T) {
 	}, collectDedicatedInvertedPostings(t, ctx, index, "search"))
 }
 
+func TestDedicatedInvertedIndex_ReplacePositionalPosting(t *testing.T) {
+	index, txManager := newTestDedicatedInvertedIndex(t, "idx_body", invertedIndexPostingModePositions)
+	ctx := context.Background()
+
+	require.NoError(t, txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		for rowID := 1; rowID <= 120; rowID++ {
+			if err := index.Insert(ctx, "common", invertedPosting{RowID: RowID(rowID), Positions: []uint32{1, 3}}); err != nil {
+				return err
+			}
+		}
+		return index.Replace(ctx, "common", invertedPosting{RowID: 42, Positions: []uint32{1, 3}}, invertedPosting{RowID: 42, Positions: []uint32{2, 5, 8}})
+	}))
+
+	stats, err := index.Stats(ctx, "common")
+	require.NoError(t, err)
+	assert.Equal(t, invertedPostingStats{DocFreq: 120, PostingCount: 241}, stats)
+
+	postings := collectDedicatedInvertedPostings(t, ctx, index, "common")
+	require.Len(t, postings, 120)
+	assert.Equal(t, invertedPosting{RowID: 42, Positions: []uint32{2, 5, 8}}, postings[41])
+}
+
 func TestDedicatedInvertedIndex_DeleteInlinePostings(t *testing.T) {
 	index, txManager := newTestDedicatedInvertedIndex(t, "idx_body", invertedIndexPostingModePositions)
 	ctx := context.Background()

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1101,11 +1101,15 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 		if !ok {
 			continue
 		}
+		stats, err := secondaryIndex.InvertedIndex.Stats(ctx, term)
+		if err != nil {
+			return fmt.Errorf("full-text stats lookup failed: %w", err)
+		}
 		iter, err := secondaryIndex.InvertedIndex.Lookup(ctx, term)
 		if err != nil {
 			return fmt.Errorf("full-text lookup failed: %w", err)
 		}
-		rows := make(map[RowID][]uint32)
+		rows := make(map[RowID][]uint32, stats.DocFreq)
 		for {
 			block, ok, err := iter.NextBlock(ctx)
 			if err != nil {
@@ -1133,24 +1137,32 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 
 	firstRows := postingsByTerm[queryTokens[0]]
 	surviving := make([]RowID, 0, len(firstRows))
+	needsPositions := len(query.Phrases) > 0
 	for rowID := range firstRows {
-		positions := make(map[string][]uint32, len(queryTokens))
 		matches := true
+		var positions map[string][]uint32
+		if needsPositions {
+			positions = make(map[string][]uint32, len(queryTokens))
+		}
 		for _, term := range queryTokens {
 			termPositions := postingsByTerm[term][rowID]
 			if len(termPositions) == 0 {
 				matches = false
 				break
 			}
-			positions[term] = termPositions
+			if needsPositions {
+				positions[term] = termPositions
+			}
 		}
 		if !matches {
 			continue
 		}
-		for _, phrase := range query.Phrases {
-			if !textSearchPhraseMatches(positions, phrase) {
-				matches = false
-				break
+		if needsPositions {
+			for _, phrase := range query.Phrases {
+				if !textSearchPhraseMatches(positions, phrase) {
+					matches = false
+					break
+				}
 			}
 		}
 		if matches {
@@ -1216,11 +1228,15 @@ func (t *Table) invertedIndexScan(ctx context.Context, scan Scan, selectedFields
 		if !ok {
 			continue
 		}
+		stats, err := secondaryIndex.InvertedIndex.Stats(ctx, term)
+		if err != nil {
+			return fmt.Errorf("inverted stats lookup failed: %w", err)
+		}
 		iter, err := secondaryIndex.InvertedIndex.Lookup(ctx, term)
 		if err != nil {
 			return fmt.Errorf("inverted lookup failed: %w", err)
 		}
-		rowIDs := make([]RowID, 0)
+		rowIDs := make([]RowID, 0, stats.DocFreq)
 		for {
 			block, ok, err := iter.NextBlock(ctx)
 			if err != nil {
@@ -1243,8 +1259,6 @@ func (t *Table) invertedIndexScan(ctx context.Context, scan Scan, selectedFields
 		if len(rowIDs) == 0 {
 			return nil
 		}
-		sortRowIDs(rowIDs)
-		rowIDs = compactRowIDs(rowIDs)
 		if i == 0 {
 			surviving = rowIDs
 			continue
@@ -1800,21 +1814,6 @@ func sortRowIDs(ids []RowID) {
 			ids[j-1], ids[j] = ids[j], ids[j-1]
 		}
 	}
-}
-
-func compactRowIDs(ids []RowID) []RowID {
-	if len(ids) < 2 {
-		return ids
-	}
-	write := 1
-	for read := 1; read < len(ids); read++ {
-		if ids[read] == ids[read-1] {
-			continue
-		}
-		ids[write] = ids[read]
-		write += 1
-	}
-	return ids[:write]
 }
 
 // indexIntersectScan executes a ScanTypeIndexIntersect plan:

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -3,6 +3,7 @@ package minisql
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"go.uber.org/zap"
 )
@@ -258,19 +259,55 @@ func (t *Table) insertFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 }
 
 func (t *Table) updateFullTextIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, oldRow, row Row) error {
+	if secondaryIndex.InvertedIndex == nil {
+		return fmt.Errorf("table %s has full-text index %s but no inverted index instance", t.Name, secondaryIndex.Name)
+	}
 	rowID := row.Key
-	if oldInIndex, err := secondaryIndex.rowSatisfiesWhereCond(oldRow); err != nil {
+	oldInIndex, err := secondaryIndex.rowSatisfiesWhereCond(oldRow)
+	if err != nil {
 		return fmt.Errorf("partial full-text index %s where check (old row): %w", secondaryIndex.Name, err)
-	} else if oldInIndex {
-		if err := t.deleteFullTextIndexKeys(ctx, secondaryIndex, rowID, oldRow); err != nil {
-			return err
-		}
+	}
+	newInIndex, err := secondaryIndex.rowSatisfiesWhereCond(row)
+	if err != nil {
+		return fmt.Errorf("partial full-text index %s where check (new row): %w", secondaryIndex.Name, err)
+	}
+	if oldInIndex && !newInIndex {
+		return t.deleteFullTextIndexKeys(ctx, secondaryIndex, rowID, oldRow)
+	}
+	if !oldInIndex && newInIndex {
+		return t.insertFullTextIndexKeys(ctx, secondaryIndex, rowID, row)
+	}
+	if !oldInIndex && !newInIndex {
+		return nil
 	}
 
-	if newInIndex, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
-		return fmt.Errorf("partial full-text index %s where check (new row): %w", secondaryIndex.Name, err)
-	} else if newInIndex {
-		return t.insertFullTextIndexKeys(ctx, secondaryIndex, rowID, row)
+	oldPostings, err := fullTextPostingsByTermForRow(secondaryIndex, rowID, oldRow)
+	if err != nil {
+		return err
+	}
+	newPostings, err := fullTextPostingsByTermForRow(secondaryIndex, rowID, row)
+	if err != nil {
+		return err
+	}
+	for term, oldPosting := range oldPostings {
+		newPosting, ok := newPostings[term]
+		if !ok {
+			if err := secondaryIndex.InvertedIndex.Delete(ctx, term, oldPosting); err != nil {
+				return fmt.Errorf("failed to delete token for full-text index %s: %w", secondaryIndex.Name, err)
+			}
+			continue
+		}
+		if !slices.Equal(oldPosting.Positions, newPosting.Positions) {
+			if err := secondaryIndex.InvertedIndex.Replace(ctx, term, oldPosting, newPosting); err != nil {
+				return fmt.Errorf("failed to replace token for full-text index %s: %w", secondaryIndex.Name, err)
+			}
+		}
+		delete(newPostings, term)
+	}
+	for term, posting := range newPostings {
+		if err := secondaryIndex.InvertedIndex.Insert(ctx, term, posting); err != nil {
+			return fmt.Errorf("failed to insert token for full-text index %s: %w", secondaryIndex.Name, err)
+		}
 	}
 	return nil
 }
@@ -290,6 +327,26 @@ func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 		}
 	}
 	return nil
+}
+
+func fullTextPostingsByTermForRow(secondaryIndex SecondaryIndex, rowID RowID, row Row) (map[string]invertedPosting, error) {
+	tokens, err := fullTextTokenPositionsForRow(secondaryIndex, row)
+	if err != nil {
+		return nil, err
+	}
+	postings := make(map[string]invertedPosting, len(tokens))
+	for _, token := range tokens {
+		posting := postings[token.Term]
+		posting.RowID = rowID
+		posting.Positions = append(posting.Positions, token.Position)
+		postings[token.Term] = posting
+	}
+	for term, posting := range postings {
+		slices.Sort(posting.Positions)
+		posting.Positions = slices.Compact(posting.Positions)
+		postings[term] = posting
+	}
+	return postings, nil
 }
 
 func (t *Table) insertInvertedIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, rowID RowID, row Row) error {
@@ -315,19 +372,49 @@ func (t *Table) insertInvertedIndexKeys(ctx context.Context, secondaryIndex Seco
 }
 
 func (t *Table) updateInvertedIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, oldRow, row Row) error {
+	if secondaryIndex.InvertedIndex == nil {
+		return fmt.Errorf("table %s has inverted index %s but no inverted index instance", t.Name, secondaryIndex.Name)
+	}
 	rowID := row.Key
-	if oldInIndex, err := secondaryIndex.rowSatisfiesWhereCond(oldRow); err != nil {
+	oldInIndex, err := secondaryIndex.rowSatisfiesWhereCond(oldRow)
+	if err != nil {
 		return fmt.Errorf("partial inverted index %s where check (old row): %w", secondaryIndex.Name, err)
-	} else if oldInIndex {
-		if err := t.deleteInvertedIndexKeys(ctx, secondaryIndex, rowID, oldRow); err != nil {
-			return err
-		}
+	}
+	newInIndex, err := secondaryIndex.rowSatisfiesWhereCond(row)
+	if err != nil {
+		return fmt.Errorf("partial inverted index %s where check (new row): %w", secondaryIndex.Name, err)
+	}
+	if oldInIndex && !newInIndex {
+		return t.deleteInvertedIndexKeys(ctx, secondaryIndex, rowID, oldRow)
+	}
+	if !oldInIndex && newInIndex {
+		return t.insertInvertedIndexKeys(ctx, secondaryIndex, rowID, row)
+	}
+	if !oldInIndex && !newInIndex {
+		return nil
 	}
 
-	if newInIndex, err := secondaryIndex.rowSatisfiesWhereCond(row); err != nil {
-		return fmt.Errorf("partial inverted index %s where check (new row): %w", secondaryIndex.Name, err)
-	} else if newInIndex {
-		return t.insertInvertedIndexKeys(ctx, secondaryIndex, rowID, row)
+	oldTerms, err := jsonInvertedTermSetForRow(secondaryIndex, oldRow)
+	if err != nil {
+		return err
+	}
+	newTerms, err := jsonInvertedTermSetForRow(secondaryIndex, row)
+	if err != nil {
+		return err
+	}
+	for term := range oldTerms {
+		if _, ok := newTerms[term]; ok {
+			delete(newTerms, term)
+			continue
+		}
+		if err := secondaryIndex.InvertedIndex.Delete(ctx, term, invertedPosting{RowID: rowID}); err != nil {
+			return fmt.Errorf("failed to delete JSON term for inverted index %s: %w", secondaryIndex.Name, err)
+		}
+	}
+	for term := range newTerms {
+		if err := secondaryIndex.InvertedIndex.Insert(ctx, term, invertedPosting{RowID: rowID}); err != nil {
+			return fmt.Errorf("failed to insert JSON term for inverted index %s: %w", secondaryIndex.Name, err)
+		}
 	}
 	return nil
 }
@@ -361,6 +448,18 @@ func jsonInvertedTermsForRow(secondaryIndex SecondaryIndex, row Row) ([]string, 
 		return nil, fmt.Errorf("inverted index %s column %q must be JSON text", secondaryIndex.Name, secondaryIndex.Columns[0].Name)
 	}
 	return jsonInvertedTermsForDocument(doc)
+}
+
+func jsonInvertedTermSetForRow(secondaryIndex SecondaryIndex, row Row) (map[string]struct{}, error) {
+	terms, err := jsonInvertedTermsForRow(secondaryIndex, row)
+	if err != nil {
+		return nil, err
+	}
+	termSet := make(map[string]struct{}, len(terms))
+	for _, term := range terms {
+		termSet[term] = struct{}{}
+	}
+	return termSet, nil
 }
 
 func fullTextTokensForRow(secondaryIndex SecondaryIndex, row Row) ([]string, error) {


### PR DESCRIPTION
First runtime allocation pass, one strong win plus a couple of smaller ones.

The best improvement is JSON inverted UPDATE maintenance. It now diffs old/new JSON term sets and skips terms that are still present, instead of deleting and reinserting unchanged row-ID postings like k:type, k:status, k:user.id.

```
JSONInverted_Update_WithIndex
Before: 1.20 ms/op, 4.6 MiB/op
After:  431.96 µs/op, 1.2 MiB/op
```

I also cleaned up full-text scan allocation: non-phrase queries no longer allocate a per-row positions map. That helped common-term and AND searches:

```
FullText_Search_MultiTermAND:       358.7 KiB -> 283.7 KiB
FullText_Search_SingleTerm/common:  606.8 KiB -> 532.1 KiB
```

Full-text UPDATE got only a modest improvement despite adding a Replace path for terms that survive an update with changed positions:

```
FullText_Update_WithIndex: 6.0 MiB -> 5.9 MiB
```