### PR TITLE
refactor: encode already-grouped postings and use binary search for t…

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,4 +1,44 @@
-### 2026-05-15 (runtime inverted-index allocation pass — latest)
+### 2026-05-15 (posting-tree block packing optimisation — latest)
+
+Full-text UPDATE was traced to hot posting-tree mutation. A focused internal
+benchmark showed a single hot positional posting-tree mutation costing roughly
+`3.1 ms/op`, `5.8 MiB/op`, and `60k allocs/op`. The root cause was
+`encodeLargestInvertedPostingBlock`: it searched for a fitting compressed block
+by re-encoding every prefix from `1..N`, and each prefix encode regrouped and
+resorted postings.
+
+Posting block packing now:
+
+- encodes already-grouped postings without regrouping each prefix;
+- uses binary search to find the largest prefix that fits a posting block;
+- keeps the existing block format unchanged.
+
+The focused mutation benchmark now measures hot `Replace` at roughly
+`0.14 ms/op`, `0.2 MiB/op`, and `1.5k allocs/op`. The generated runtime table
+for the full inverted benchmark suite is appended below as `2026-05-15 19:35 UTC`.
+
+#### Timing
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| FullText_Update_WithIndex/minisql | 3.25 ms/op | 474.57 µs/op | 6.8× faster |
+| FullText_Update_WithIndex/sqlite | 375.41 µs/op | 451.48 µs/op | reference variance |
+| JSONInverted_Update_WithIndex/minisql_indexed | 431.96 µs/op | 421.89 µs/op | roughly unchanged |
+
+#### Memory (B/op)
+
+| Benchmark | before | after | improvement |
+|---|---|---|---|
+| FullText_Update_WithIndex/minisql | 5.9 MiB | 586.1 KiB | 10.3× lower |
+| JSONInverted_Update_WithIndex/minisql_indexed | 1.2 MiB | 1.2 MiB | unchanged |
+
+Full-text UPDATE is now roughly at SQLite FTS5 wall-time parity in this fixture,
+though MiniSQL still allocates much more memory. The next likely runtime targets
+are lookup allocation for common full-text terms and JSON indexed scans.
+
+---
+
+### 2026-05-15 (runtime inverted-index allocation pass)
 
 Runtime inverted-index maintenance and scans received two targeted allocation
 improvements:
@@ -1048,4 +1088,42 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 | JSONInverted_Contains_ObjectSubset/object_subset | — | 1.7 MiB | 3.5 MiB | — | 548 B | 549 B |
 | JSONInverted_Update_WithIndex | — | 1.2 MiB | — | — | — | — |
 | JSONInverted_Delete_WithIndex | — | 142.5 KiB | — | — | — | — |
+
+### 2026-05-15 19:35 UTC
+
+#### Timing
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan | ratio |
+|---|---|---|---|---|---|---|---|
+| FullText_Insert_WithIndex | 91.09 µs/op | — | — | 224.51 µs/op | — | — | 0.4× |
+| FullText_Search_SingleTerm/rare | 209.33 µs/op | — | — | 361.07 µs/op | — | — | 0.6× |
+| FullText_Search_SingleTerm/medium | 209.67 µs/op | — | — | 438.83 µs/op | — | — | 0.5× |
+| FullText_Search_SingleTerm/common | 1.01 ms/op | — | — | 432.22 µs/op | — | — | 2.3× |
+| FullText_Search_MultiTermAND | 332.81 µs/op | — | — | 354.13 µs/op | — | — | 0.9× |
+| FullText_Search_Phrase | 330.16 µs/op | — | — | 367.14 µs/op | — | — | 0.9× |
+| FullText_Update_WithIndex | 474.57 µs/op | — | — | 451.48 µs/op | — | — | 1.1× |
+| FullText_Delete_WithIndex | 90.31 µs/op | — | — | 197.68 µs/op | — | — | 0.5× |
+| JSONInverted_Insert_WithIndex | — | 113.81 µs/op | — | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.32 ms/op | 3.10 ms/op | — | 424.78 µs/op | 1.05 ms/op | — |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.78 ms/op | 3.87 ms/op | — | 455.52 µs/op | 1.09 ms/op | — |
+| JSONInverted_Update_WithIndex | — | 421.89 µs/op | — | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 120.44 µs/op | — | — | — | — | — |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan |
+|---|---|---|---|---|---|---|
+| FullText_Insert_WithIndex | 66.9 KiB | — | — | 705 B | — | — |
+| FullText_Search_SingleTerm/rare | 66.8 KiB | — | — | 532 B | — | — |
+| FullText_Search_SingleTerm/medium | 71.5 KiB | — | — | 533 B | — | — |
+| FullText_Search_SingleTerm/common | 531.4 KiB | — | — | 548 B | — | — |
+| FullText_Search_MultiTermAND | 283.7 KiB | — | — | 532 B | — | — |
+| FullText_Search_Phrase | 173.4 KiB | — | — | 540 B | — | — |
+| FullText_Update_WithIndex | 586.1 KiB | — | — | 412 B | — | — |
+| FullText_Delete_WithIndex | 40.4 KiB | — | — | 260 B | — | — |
+| JSONInverted_Insert_WithIndex | — | 164.3 KiB | — | — | — | — |
+| JSONInverted_Contains_KeyValue/key_value | — | 1.4 MiB | 3.3 MiB | — | 548 B | 548 B |
+| JSONInverted_Contains_ObjectSubset/object_subset | — | 1.7 MiB | 3.5 MiB | — | 550 B | 549 B |
+| JSONInverted_Update_WithIndex | — | 1.2 MiB | — | — | — | — |
+| JSONInverted_Delete_WithIndex | — | 142.6 KiB | — | — | — | — |
 

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -2093,23 +2093,33 @@ func replaceInvertedPostingBlocks(blocks []invertedPostingBlock, idx int, replac
 
 // encodeLargestInvertedPostingBlock finds the largest prefix that fits one block.
 func encodeLargestInvertedPostingBlock(mode invertedPostingMode, postings []invertedPosting, maxPayload int) (int, []byte, error) {
-	var (
-		bestPayload []byte
-		bestN       int
-	)
-	for n := 1; n <= len(postings); n++ {
-		payload, err := encodeInvertedPostingList(mode, postings[:n])
+	if len(postings) == 0 {
+		return 0, nil, fmt.Errorf("cannot encode empty inverted posting block")
+	}
+	firstPayload, err := encodeGroupedInvertedPostingList(mode, postings[:1])
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(firstPayload) > maxPayload {
+		return 1, firstPayload, nil
+	}
+
+	lo, hi := 1, len(postings)
+	bestN := 1
+	bestPayload := firstPayload
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		payload, err := encodeGroupedInvertedPostingList(mode, postings[:mid])
 		if err != nil {
 			return 0, nil, err
 		}
-		if len(payload) > maxPayload && n > 1 {
-			break
+		if len(payload) <= maxPayload {
+			bestN = mid
+			bestPayload = payload
+			lo = mid + 1
+			continue
 		}
-		bestPayload = payload
-		bestN = n
-		if len(payload) > maxPayload {
-			break
-		}
+		hi = mid - 1
 	}
 	return bestN, bestPayload, nil
 }

--- a/internal/minisql/inverted_index_bench_test.go
+++ b/internal/minisql/inverted_index_bench_test.go
@@ -1,0 +1,115 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func BenchmarkDedicatedInvertedIndex_PositionalPostingTreeMutation(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		run  func(context.Context, *dedicatedInvertedIndex, RowID, []uint32) error
+	}{
+		{
+			name: "replace_hot",
+			run: func(ctx context.Context, index *dedicatedInvertedIndex, rowID RowID, positions []uint32) error {
+				next := []uint32{positions[0] + 1}
+				if err := index.Replace(ctx, "common", invertedPosting{RowID: rowID, Positions: positions}, invertedPosting{RowID: rowID, Positions: next}); err != nil {
+					return err
+				}
+				positions[0] = next[0]
+				return nil
+			},
+		},
+		{
+			name: "delete_insert_hot",
+			run: func(ctx context.Context, index *dedicatedInvertedIndex, rowID RowID, positions []uint32) error {
+				if err := index.Delete(ctx, "common", invertedPosting{RowID: rowID, Positions: positions}); err != nil {
+					return err
+				}
+				next := []uint32{positions[0] + 1}
+				if err := index.Insert(ctx, "common", invertedPosting{RowID: rowID, Positions: next}); err != nil {
+					return err
+				}
+				positions[0] = next[0]
+				return nil
+			},
+		},
+		{
+			name: "delete_rare_insert_rare",
+			run: func(ctx context.Context, index *dedicatedInvertedIndex, rowID RowID, positions []uint32) error {
+				oldTerm := fmt.Sprintf("rare-%04d-%d", rowID, positions[0])
+				newTerm := fmt.Sprintf("rare-%04d-%d", rowID, positions[0]+1)
+				if err := index.Delete(ctx, oldTerm, invertedPosting{RowID: rowID, Positions: positions}); err != nil {
+					return err
+				}
+				next := []uint32{positions[0] + 1}
+				if err := index.Insert(ctx, newTerm, invertedPosting{RowID: rowID, Positions: next}); err != nil {
+					return err
+				}
+				positions[0] = next[0]
+				return nil
+			},
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			index, txManager := newBenchmarkDedicatedInvertedIndex(b, "idx_body", invertedIndexPostingModePositions)
+			ctx := context.Background()
+			positionsByRow := make(map[RowID][]uint32, 1000)
+			requireNoErrorB(b, txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+				for rowID := RowID(1); rowID <= 1000; rowID++ {
+					positions := []uint32{1}
+					positionsByRow[rowID] = positions
+					if err := index.Insert(ctx, "common", invertedPosting{RowID: rowID, Positions: positions}); err != nil {
+						return err
+					}
+					if err := index.Insert(ctx, fmt.Sprintf("rare-%04d-1", rowID), invertedPosting{RowID: rowID, Positions: positions}); err != nil {
+						return err
+					}
+				}
+				return nil
+			}))
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := range b.N {
+				rowID := RowID(i%1000 + 1)
+				positions := positionsByRow[rowID]
+				requireNoErrorB(b, txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+					return bm.run(ctx, index, rowID, positions)
+				}))
+			}
+		})
+	}
+}
+
+func requireNoErrorB(b *testing.B, err error) {
+	b.Helper()
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
+func newBenchmarkDedicatedInvertedIndex(b *testing.B, name string, mode invertedIndexPostingMode) (*dedicatedInvertedIndex, *TransactionManager) {
+	b.Helper()
+
+	tempFile, err := os.CreateTemp("", testDBName)
+	requireNoErrorB(b, err)
+	b.Cleanup(func() { _ = os.Remove(tempFile.Name()) })
+
+	pager, err := NewPager(tempFile, PageSize, 1000)
+	requireNoErrorB(b, err)
+	basePager := pager.ForInvertedIndex()
+	txManager := NewTransactionManager(zap.NewNop(), tempFile.Name(), mockPagerFactory(basePager), pager, nil)
+	txPager := NewTransactionalPager(basePager, txManager, "test_table", name)
+	index, err := NewDedicatedInvertedIndex(name, mode, txPager, 0)
+	requireNoErrorB(b, err)
+	requireNoErrorB(b, txManager.ExecuteInTransaction(context.Background(), index.InitRootPage))
+	return index, txManager
+}

--- a/internal/minisql/inverted_posting.go
+++ b/internal/minisql/inverted_posting.go
@@ -31,7 +31,16 @@ func encodeInvertedPostingList(mode invertedPostingMode, postings []invertedPost
 		return nil, fmt.Errorf("unknown inverted posting mode %d", mode)
 	}
 
-	grouped := groupInvertedPostings(mode, postings)
+	return encodeGroupedInvertedPostingList(mode, groupInvertedPostings(mode, postings))
+}
+
+// encodeGroupedInvertedPostingList serializes postings that are already sorted,
+// grouped by row ID, and deduplicated. It is used by posting-tree block packing
+// to avoid repeatedly regrouping prefixes while searching for a block boundary.
+func encodeGroupedInvertedPostingList(mode invertedPostingMode, grouped []invertedPosting) ([]byte, error) {
+	if mode != invertedPostingModeRowIDs && mode != invertedPostingModePositions {
+		return nil, fmt.Errorf("unknown inverted posting mode %d", mode)
+	}
 	buf := make([]byte, 0, 2+len(grouped)*binary.MaxVarintLen64*2)
 	buf = append(buf, invertedPostingCodecVersion, byte(mode))
 


### PR DESCRIPTION
The dominant full-text UPDATE cost was not table update or tokenization. It was hot posting-tree mutation. A focused benchmark showed one hot positional posting-tree mutation costing about:

```
Before: ~3.1 ms/op, 5.8 MiB/op, 60k allocs/op
After:  ~0.14 ms/op, 0.2 MiB/op, 1.5k allocs/op
```

Root cause: encodeLargestInvertedPostingBlock found the largest compressed block by re-encoding every prefix from 1..N, and each prefix encode regrouped/resorted postings. I changed it to encode already-grouped postings and use binary search for the largest fitting prefix. Storage format stays unchanged.

End-to-end full-text UPDATE improved a lot:

```
FullText_Update_WithIndex
Before: 3.25 ms/op, 5.9 MiB/op
After:  474.57 µs/op, 586.1 KiB/op
```

So it is now roughly at SQLite FTS5 wall-time parity in this fixture, though MiniSQL still allocates much more memory.