### PR TITLE
refactor: optimise JSON indexed scans

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1127,3 +1127,14 @@ Snapshot isolation (MVCC) for read-only transactions + TOCTOU fix in `ReadPage`:
 | JSONInverted_Update_WithIndex | — | 1.2 MiB | — | — | — | — |
 | JSONInverted_Delete_WithIndex | — | 142.6 KiB | — | — | — | — |
 
+### 2026-05-15 19:55 UTC
+
+Targeted JSON indexed scan allocation pass. MiniSQL now predecodes literal
+`JSON_CONTAINS` queries for inverted-index rechecks and skips document rechecks
+when generated JSON terms are exact for scalar/object and unique scalar-array
+membership queries.
+
+| Benchmark | Before | After | Allocation Before | Allocation After |
+|---|---:|---:|---:|---:|
+| JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 1.32 ms/op | ~422 µs/op | 1.4 MiB/op | ~409 KiB/op |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 1.78 ms/op | ~432 µs/op | 1.7 MiB/op | ~660 KiB/op |

--- a/internal/minisql/json_inverted.go
+++ b/internal/minisql/json_inverted.go
@@ -18,13 +18,19 @@ func jsonInvertedTermColumn() Column {
 // Objects must contain every queried key recursively, arrays must contain every
 // queried element, and scalar values must match by JSON type and value.
 func jsonContains(doc, query string) (bool, error) {
-	docValue, err := decodeJSONForInvertedIndex(doc)
-	if err != nil {
-		return false, fmt.Errorf("invalid JSON document: %w", err)
-	}
 	queryValue, err := decodeJSONForInvertedIndex(query)
 	if err != nil {
 		return false, fmt.Errorf("invalid JSON query: %w", err)
+	}
+	return jsonContainsDecodedQuery(doc, queryValue)
+}
+
+// jsonContainsDecodedQuery checks containment when the query side has already
+// been decoded, avoiding repeated parsing for indexed scan rechecks.
+func jsonContainsDecodedQuery(doc string, queryValue any) (bool, error) {
+	docValue, err := decodeJSONForInvertedIndex(doc)
+	if err != nil {
+		return false, fmt.Errorf("invalid JSON document: %w", err)
 	}
 	return jsonContainsValue(docValue, queryValue), nil
 }
@@ -48,6 +54,62 @@ func jsonInvertedTermsForQuery(query string) ([]string, error) {
 		return nil, err
 	}
 	return jsonInvertedTerms(value), nil
+}
+
+// jsonInvertedQueryTermsAreExact reports whether the generated terms fully
+// prove JSON containment without reparsing the candidate document. Array and
+// empty-container queries still need rechecking unless the array contains only
+// unique scalar values whose term presence is enough to prove membership.
+func jsonInvertedQueryTermsAreExact(value any) bool {
+	return jsonInvertedQueryTermsAreExactAt("", value)
+}
+
+func jsonInvertedQueryTermsAreExactAt(path string, value any) bool {
+	switch v := value.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			return false
+		}
+		for key, child := range v {
+			childPath := joinJSONInvertedPath(path, key)
+			if len([]byte("k:"+childPath)) > MaxIndexKeySize {
+				return false
+			}
+			if !jsonInvertedQueryTermsAreExactAt(childPath, child) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		return jsonInvertedScalarArrayTermsAreExactAt(path+"[]", v)
+	default:
+		if path == "" {
+			path = "$"
+		}
+		return len([]byte("kv:"+path+":"+jsonInvertedScalarTerm(v))) <= MaxIndexKeySize
+	}
+}
+
+func jsonInvertedScalarArrayTermsAreExactAt(path string, values []any) bool {
+	if len(values) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		switch value.(type) {
+		case map[string]any, []any:
+			return false
+		}
+		term := "kv:" + path + ":" + jsonInvertedScalarTerm(value)
+		if len([]byte(term)) > MaxIndexKeySize {
+			return false
+		}
+		if _, ok := seen[term]; ok {
+			return false
+		}
+		seen[term] = struct{}{}
+	}
+	return true
 }
 
 // decodeJSONForInvertedIndex parses JSON with numbers preserved as json.Number

--- a/internal/minisql/json_inverted_test.go
+++ b/internal/minisql/json_inverted_test.go
@@ -93,6 +93,34 @@ func TestJSONContains(t *testing.T) {
 	}
 }
 
+func TestJSONInvertedQueryTermsAreExact(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{name: "scalar root", query: `"click"`, want: true},
+		{name: "non-empty object scalar tree", query: `{"type":"click","user":{"id":"u1"}}`, want: true},
+		{name: "unique scalar array query", query: `{"tags":["web","mobile"]}`, want: true},
+		{name: "duplicate scalar array query needs recheck", query: `{"tags":["web","web"]}`, want: false},
+		{name: "object array query needs recheck", query: `{"tags":[{"name":"web"}]}`, want: false},
+		{name: "empty object needs recheck", query: `{"user":{}}`, want: false},
+		{name: "empty array needs recheck", query: `{"tags":[]}`, want: false},
+		{name: "overlong scalar term needs recheck", query: `{"long":"` + strings.Repeat("x", MaxIndexKeySize+1) + `"}`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			value, err := decodeJSONForInvertedIndex(tt.query)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, jsonInvertedQueryTermsAreExact(value))
+		})
+	}
+}
+
 func TestJSONInvertedIndexHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1273,7 +1273,7 @@ func (t *Table) invertedIndexScan(ctx context.Context, scan Scan, selectedFields
 	}
 
 	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
-	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	tableFilter := compileInvertedScanFilter(t.Columns, scan.Filters)
 	for _, rowID := range surviving {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -1684,6 +1684,100 @@ func compileScanFilter(columns []Column, filters OneOrMore) func(Row) (bool, err
 	return func(row Row) (bool, error) {
 		return row.CheckOneOrMoreWithColumnIndexes(filters, columnIndexes)
 	}
+}
+
+// compileInvertedScanFilter specializes JSON_CONTAINS rechecks for indexed
+// inverted scans while preserving the generic filter path for all other cases.
+func compileInvertedScanFilter(columns []Column, filters OneOrMore) func(Row) (bool, error) {
+	jsonFilter, remainingFilters, ok := compileJSONContainsRecheck(columns, filters)
+	if !ok {
+		return compileScanFilter(columns, filters)
+	}
+	remainingFilter := compileScanFilter(columns, remainingFilters)
+	return func(row Row) (bool, error) {
+		ok, err := jsonFilter(row)
+		if err != nil || !ok {
+			return ok, err
+		}
+		if remainingFilter == nil {
+			return true, nil
+		}
+		return remainingFilter(row)
+	}
+}
+
+func compileJSONContainsRecheck(columns []Column, filters OneOrMore) (func(Row) (bool, error), OneOrMore, bool) {
+	if len(filters) != 1 {
+		return nil, nil, false
+	}
+	columnIndexes := make(map[string]int, len(columns))
+	for i := range columns {
+		columnIndexes[columns[i].Name] = i
+	}
+
+	for condIdx, cond := range filters[0] {
+		columnName, query, ok := jsonContainsLiteralCondition(cond)
+		if !ok {
+			continue
+		}
+		columnIdx, ok := columnIndexes[columnName]
+		if !ok {
+			return nil, nil, false
+		}
+		queryValue, err := decodeJSONForInvertedIndex(query)
+		if err != nil {
+			return nil, nil, false
+		}
+		exactTerms := jsonInvertedQueryTermsAreExact(queryValue)
+		remaining := make(Conditions, 0, len(filters[0])-1)
+		remaining = append(remaining, filters[0][:condIdx]...)
+		remaining = append(remaining, filters[0][condIdx+1:]...)
+		var remainingFilters OneOrMore
+		if len(remaining) > 0 {
+			remainingFilters = OneOrMore{remaining}
+		}
+		return func(row Row) (bool, error) {
+			if exactTerms {
+				return true, nil
+			}
+			if columnIdx >= len(row.Values) {
+				return false, nil
+			}
+			value := row.Values[columnIdx]
+			if !value.Valid {
+				return false, nil
+			}
+			doc, ok := toStringVal(value.Value)
+			if !ok {
+				return false, fmt.Errorf("JSON_CONTAINS: first argument must be a string")
+			}
+			return jsonContainsDecodedQuery(doc, queryValue)
+		}, remainingFilters, true
+	}
+
+	return nil, nil, false
+}
+
+func jsonContainsLiteralCondition(cond Condition) (string, string, bool) {
+	if cond.Operator != Eq || cond.Operand2.Type != OperandBoolean || cond.Operand2.Value != true {
+		return "", "", false
+	}
+	if cond.Operand1.Type != OperandExpr {
+		return "", "", false
+	}
+	expr, ok := cond.Operand1.Value.(*Expr)
+	if !ok || expr.FuncName != "JSON_CONTAINS" || len(expr.Args) != 2 {
+		return "", "", false
+	}
+	columnName := expr.Args[0].Column
+	if columnName == "" {
+		return "", "", false
+	}
+	query, ok := literalText(expr.Args[1])
+	if !ok {
+		return "", "", false
+	}
+	return columnName, query, true
 }
 
 // virtualSequentialScan iterates the table's in-memory virtualRows, applies the

--- a/internal/minisql/select_test.go
+++ b/internal/minisql/select_test.go
@@ -556,6 +556,89 @@ func TestCompileScanFilter(t *testing.T) {
 	})
 }
 
+func TestCompileInvertedScanFilter(t *testing.T) {
+	t.Parallel()
+
+	columns := []Column{
+		{Name: "payload", Kind: JSON, Size: MaxInlineVarchar},
+		{Name: "kind", Kind: Varchar, Size: MaxInlineVarchar},
+	}
+	row := NewRowWithValues(columns, []OptionalValue{
+		{Value: NewTextPointer([]byte(`{"type":"click","user":{"id":"u1"}}`)), Valid: true},
+		{Value: NewTextPointer([]byte("event")), Valid: true},
+	})
+
+	t.Run("predecodes json contains query", func(t *testing.T) {
+		t.Parallel()
+
+		filter := compileInvertedScanFilter(columns, OneOrMore{{jsonContainsCondition("payload", `{"user":{"id":"u1"}}`)}})
+		require.NotNil(t, filter)
+
+		ok, err := filter(row)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("applies remaining filters", func(t *testing.T) {
+		t.Parallel()
+
+		filters := OneOrMore{{
+			jsonContainsCondition("payload", `{"type":"click"}`),
+			FieldIsEqual(Field{Name: "kind"}, OperandQuotedString, NewTextPointer([]byte("audit"))),
+		}}
+		filter := compileInvertedScanFilter(columns, filters)
+		require.NotNil(t, filter)
+
+		ok, err := filter(row)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("rechecks object array queries", func(t *testing.T) {
+		t.Parallel()
+
+		arrayRow := NewRowWithValues(columns, []OptionalValue{
+			{Value: NewTextPointer([]byte(`{"tags":[{"name":"mobile"}]}`)), Valid: true},
+			{Value: NewTextPointer([]byte("event")), Valid: true},
+		})
+		filter := compileInvertedScanFilter(columns, OneOrMore{{jsonContainsCondition("payload", `{"tags":[{"name":"web"}]}`)}})
+		require.NotNil(t, filter)
+
+		ok, err := filter(arrayRow)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("falls back for generic filters", func(t *testing.T) {
+		t.Parallel()
+
+		filters := OneOrMore{{FieldIsEqual(Field{Name: "kind"}, OperandQuotedString, NewTextPointer([]byte("event")))}}
+		filter := compileInvertedScanFilter(columns, filters)
+		require.NotNil(t, filter)
+
+		ok, err := filter(row)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
+func jsonContainsCondition(columnName, query string) Condition {
+	return Condition{
+		Operand1: Operand{
+			Type: OperandExpr,
+			Value: &Expr{
+				FuncName: "JSON_CONTAINS",
+				Args: []*Expr{
+					{Column: columnName},
+					{Literal: NewTextPointer([]byte(query))},
+				},
+			},
+		},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandBoolean, Value: true},
+	}
+}
+
 func TestTable_Select_Overflow(t *testing.T) {
 	table, txManager, _ := newTestTable(t, testOverflowColumns)
 	var (


### PR DESCRIPTION
JSON indexed scan allocation pass.

What changed:
- JSON inverted scans now use a specialized JSON_CONTAINS recheck path in select.go.
- Literal JSON query values are decoded once instead of once per candidate row.
- For exact term queries, we now skip document reparse entirely:
  - scalar/object trees
  - unique scalar array membership
- We still recheck safely for arrays of objects, duplicate scalar arrays, empty containers, and overlong terms.
- Added focused tests in select_test.go and json_inverted_test.go.
- Updated RESULTS.md.


Benchmark improvement recorded:

- JSONInverted_Contains_KeyValue: 1.32 ms/op, 1.4 MiB/op -> ~422 µs/op, ~409 KiB/op
- JSONInverted_Contains_ObjectSubset: 1.78 ms/op, 1.7 MiB/op -> ~432 µs/op, ~660 KiB/op