### PR TITLE
refactor: full-text common-term lookup streaming

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1138,3 +1138,15 @@ membership queries.
 |---|---:|---:|---:|---:|
 | JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 1.32 ms/op | ~422 µs/op | 1.4 MiB/op | ~409 KiB/op |
 | JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 1.78 ms/op | ~432 µs/op | 1.7 MiB/op | ~660 KiB/op |
+
+### 2026-05-15 20:06 UTC
+
+Targeted full-text common-term lookup pass. MiniSQL now streams single-token,
+non-phrase full-text posting lists directly and decodes only row IDs instead of
+materializing per-row position maps before fetching rows.
+
+| Benchmark | Before | After | Allocation Before | Allocation After |
+|---|---:|---:|---:|---:|
+| FullText_Search_SingleTerm/common/minisql | 1.01 ms/op | ~539 µs/op | 531.4 KiB/op | ~320 KiB/op |
+| FullText_Search_SingleTerm/medium/minisql | 209.67 µs/op | ~217 µs/op | 71.5 KiB/op | ~69.6 KiB/op |
+| FullText_Search_SingleTerm/rare/minisql | 209.33 µs/op | ~189 µs/op | 66.8 KiB/op | ~65.7 KiB/op |

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -212,6 +212,41 @@ func TestFullTextIndexScanMissingIndex(t *testing.T) {
 	assert.Contains(t, err.Error(), "no index found for full-text scan")
 }
 
+func TestFullTextIndexScanSingleTermStreamsRowIDs(t *testing.T) {
+	t.Parallel()
+
+	index := &fakeFullTextInvertedIndex{
+		postings: map[string][]invertedPosting{
+			"common": {
+				{RowID: 9, Positions: []uint32{1}},
+				{RowID: 3, Positions: []uint32{1, 4}},
+				{RowID: 7, Positions: []uint32{2}},
+			},
+		},
+	}
+	table := NewTable(testLogger, nil, nil, "articles", []Column{{Name: "body", Kind: Text}}, 0, nil, WithSecondaryIndex(SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Name:    "idx_body_fts",
+			Method:  IndexMethodFullText,
+			Columns: []Column{{Name: "body", Kind: Text}},
+		},
+		InvertedIndex: index,
+	}))
+
+	var rowIDs []RowID
+	err := table.fullTextIndexScan(context.Background(), Scan{
+		Type:          ScanTypeFullText,
+		IndexName:     "idx_body_fts",
+		IndexKeys:     []any{"common"},
+		FullTextQuery: &textSearchQuery{Terms: []string{"common"}},
+	}, nil, func(row Row) error {
+		rowIDs = append(rowIDs, row.Key)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []RowID{3, 7, 9}, rowIDs)
+}
+
 func TestPlanQuery_FullTextIndexSkipsOverlongQueryToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/inverted_posting.go
+++ b/internal/minisql/inverted_posting.go
@@ -136,6 +136,62 @@ func decodeInvertedPostingList(encoded []byte) (invertedPostingMode, []invertedP
 	return mode, postings, nil
 }
 
+// forEachInvertedPostingRowID decodes only row IDs from an encoded posting
+// block. Positional payloads are skipped without allocating per-row positions,
+// which keeps common single-term full-text scans lightweight.
+func forEachInvertedPostingRowID(encoded []byte, fn func(RowID) error) (invertedPostingMode, error) {
+	if len(encoded) < 2 {
+		return 0, fmt.Errorf("decode inverted postings: short buffer")
+	}
+	if encoded[0] != invertedPostingCodecVersion {
+		return 0, fmt.Errorf("decode inverted postings: unsupported codec version %d", encoded[0])
+	}
+	mode := invertedPostingMode(encoded[1])
+	if mode != invertedPostingModeRowIDs && mode != invertedPostingModePositions {
+		return 0, fmt.Errorf("decode inverted postings: unknown mode %d", mode)
+	}
+
+	var (
+		prevRowID RowID
+		offset    = 2
+		haveRow   bool
+	)
+	for offset < len(encoded) {
+		rowDelta, n := binary.Uvarint(encoded[offset:])
+		if n <= 0 {
+			return 0, fmt.Errorf("decode inverted posting row delta at byte %d", offset)
+		}
+		offset += n
+
+		rowID := RowID(rowDelta)
+		if haveRow {
+			rowID = prevRowID + RowID(rowDelta)
+		}
+		if err := fn(rowID); err != nil {
+			return 0, err
+		}
+
+		if mode == invertedPostingModePositions {
+			positionCount, n := binary.Uvarint(encoded[offset:])
+			if n <= 0 {
+				return 0, fmt.Errorf("decode inverted posting position count at byte %d", offset)
+			}
+			offset += n
+			for range positionCount {
+				_, n := binary.Uvarint(encoded[offset:])
+				if n <= 0 {
+					return 0, fmt.Errorf("decode inverted posting position delta at byte %d", offset)
+				}
+				offset += n
+			}
+		}
+
+		prevRowID = rowID
+		haveRow = true
+	}
+	return mode, nil
+}
+
 // groupInvertedPostings canonicalizes postings before encoding. JSON-style
 // row-only postings deduplicate row IDs; full-text postings merge and sort
 // positions by row ID.

--- a/internal/minisql/inverted_posting_test.go
+++ b/internal/minisql/inverted_posting_test.go
@@ -48,6 +48,26 @@ func TestInvertedPostingCodec_Positions(t *testing.T) {
 	}, decoded)
 }
 
+func TestForEachInvertedPostingRowIDSkipsPositions(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := encodeInvertedPostingList(invertedPostingModePositions, []invertedPosting{
+		{RowID: 7, Positions: []uint32{12, 3}},
+		{RowID: 2, Positions: []uint32{1}},
+		{RowID: 7, Positions: []uint32{20}},
+	})
+	require.NoError(t, err)
+
+	var rowIDs []RowID
+	mode, err := forEachInvertedPostingRowID(encoded, func(rowID RowID) error {
+		rowIDs = append(rowIDs, rowID)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, invertedPostingModePositions, mode)
+	assert.Equal(t, []RowID{2, 7}, rowIDs)
+}
+
 func TestInvertedPostingCodec_Empty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1094,6 +1094,9 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 	if len(queryTokens) == 0 {
 		return nil
 	}
+	if len(queryTokens) == 1 && len(query.Phrases) == 0 {
+		return t.fullTextSingleTermIndexScan(ctx, secondaryIndex, scan, queryTokens[0], selectedFields, out)
+	}
 
 	postingsByTerm := make(map[string]map[RowID][]uint32, len(queryTokens))
 	for _, key := range scan.IndexKeys {
@@ -1208,6 +1211,73 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 
 		if err := out(row); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (t *Table) fullTextSingleTermIndexScan(ctx context.Context, secondaryIndex SecondaryIndex, scan Scan, term string, selectedFields []Field, out func(Row) error) error {
+	iter, err := secondaryIndex.InvertedIndex.Lookup(ctx, term)
+	if err != nil {
+		return fmt.Errorf("full-text lookup failed: %w", err)
+	}
+
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	var (
+		lastRowID RowID
+		haveLast  bool
+	)
+	for {
+		block, ok, err := iter.NextBlock(ctx)
+		if err != nil {
+			return fmt.Errorf("full-text lookup failed: %w", err)
+		}
+		if !ok {
+			break
+		}
+		mode, err := forEachInvertedPostingRowID(block.Payload, func(rowID RowID) error {
+			if haveLast && rowID == lastRowID {
+				return nil
+			}
+			haveLast = true
+			lastRowID = rowID
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			var row Row
+			if len(selectedFields) == 0 {
+				row = NewRowWithValues(t.Columns, nil)
+				row.Key = rowID
+			} else {
+				cursor, err := t.Seek(ctx, rowID)
+				if err != nil {
+					return fmt.Errorf("full-text seek: %w", err)
+				}
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+				if err != nil {
+					return fmt.Errorf("full-text fetch: %w", err)
+				}
+			}
+
+			if tableFilter != nil {
+				ok, err := tableFilter(row)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return nil
+				}
+			}
+
+			return out(row)
+		})
+		if err != nil {
+			return err
+		}
+		if mode != invertedPostingModePositions {
+			return fmt.Errorf("full-text index %s uses posting mode %d", scan.IndexName, mode)
 		}
 	}
 	return nil


### PR DESCRIPTION
Implemented:

- Added a row-ID-only posting decoder in inverted_posting.go.
- Added a streaming fast path for single-token, non-phrase full-text scans in select.go.
- Added unit coverage for the decoder and streaming scan path.
- Updated RESULTS.md.

Benchmark result:

- FullText_Search_SingleTerm/common/minisql: 1.01 ms/op, 531.4 KiB/op -> ~539 µs/op, ~320 KiB/op