### PR TITLE
refactor: full-text multi-term allocation

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1150,3 +1150,14 @@ materializing per-row position maps before fetching rows.
 | FullText_Search_SingleTerm/common/minisql | 1.01 ms/op | ~539 µs/op | 531.4 KiB/op | ~320 KiB/op |
 | FullText_Search_SingleTerm/medium/minisql | 209.67 µs/op | ~217 µs/op | 71.5 KiB/op | ~69.6 KiB/op |
 | FullText_Search_SingleTerm/rare/minisql | 209.33 µs/op | ~189 µs/op | 66.8 KiB/op | ~65.7 KiB/op |
+
+### 2026-05-16 00:21 UTC
+
+Targeted full-text multi-term AND lookup pass. MiniSQL now handles non-phrase
+multi-term full-text queries by loading row IDs only, ordering terms by document
+frequency, and intersecting sorted row-id lists instead of materializing
+per-term position maps.
+
+| Benchmark | Before | After | Allocation Before | Allocation After |
+|---|---:|---:|---:|---:|
+| FullText_Search_MultiTermAND/minisql | 332.81 µs/op | ~241 µs/op | 283.7 KiB/op | ~78.3 KiB/op |

--- a/internal/minisql/full_text_index_test.go
+++ b/internal/minisql/full_text_index_test.go
@@ -247,6 +247,46 @@ func TestFullTextIndexScanSingleTermStreamsRowIDs(t *testing.T) {
 	assert.Equal(t, []RowID{3, 7, 9}, rowIDs)
 }
 
+func TestFullTextIndexScanMultiTermIntersectsRowIDs(t *testing.T) {
+	t.Parallel()
+
+	index := &fakeFullTextInvertedIndex{
+		postings: map[string][]invertedPosting{
+			"common": {
+				{RowID: 9, Positions: []uint32{1}},
+				{RowID: 3, Positions: []uint32{1}},
+				{RowID: 7, Positions: []uint32{1}},
+				{RowID: 11, Positions: []uint32{1}},
+			},
+			"cohort": {
+				{RowID: 7, Positions: []uint32{2}},
+				{RowID: 3, Positions: []uint32{2}},
+			},
+		},
+	}
+	table := NewTable(testLogger, nil, nil, "articles", []Column{{Name: "body", Kind: Text}}, 0, nil, WithSecondaryIndex(SecondaryIndex{
+		IndexInfo: IndexInfo{
+			Name:    "idx_body_fts",
+			Method:  IndexMethodFullText,
+			Columns: []Column{{Name: "body", Kind: Text}},
+		},
+		InvertedIndex: index,
+	}))
+
+	var rowIDs []RowID
+	err := table.fullTextIndexScan(context.Background(), Scan{
+		Type:          ScanTypeFullText,
+		IndexName:     "idx_body_fts",
+		IndexKeys:     []any{"common", "cohort"},
+		FullTextQuery: &textSearchQuery{Terms: []string{"common", "cohort"}},
+	}, nil, func(row Row) error {
+		rowIDs = append(rowIDs, row.Key)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []RowID{3, 7}, rowIDs)
+}
+
 func TestPlanQuery_FullTextIndexSkipsOverlongQueryToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.uber.org/zap"
@@ -1097,6 +1098,9 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 	if len(queryTokens) == 1 && len(query.Phrases) == 0 {
 		return t.fullTextSingleTermIndexScan(ctx, secondaryIndex, scan, queryTokens[0], selectedFields, out)
 	}
+	if len(query.Phrases) == 0 {
+		return t.fullTextMultiTermIndexScan(ctx, secondaryIndex, scan, queryTokens, selectedFields, out)
+	}
 
 	postingsByTerm := make(map[string]map[RowID][]uint32, len(queryTokens))
 	for _, key := range scan.IndexKeys {
@@ -1180,6 +1184,130 @@ func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields
 	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
 	tableFilter := compileScanFilter(t.Columns, scan.Filters)
 	for _, rowID := range surviving {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var row Row
+		if len(selectedFields) == 0 {
+			row = NewRowWithValues(t.Columns, nil)
+			row.Key = rowID
+		} else {
+			cursor, err := t.Seek(ctx, rowID)
+			if err != nil {
+				return fmt.Errorf("full-text seek: %w", err)
+			}
+			row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+			if err != nil {
+				return fmt.Errorf("full-text fetch: %w", err)
+			}
+		}
+
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		if err := out(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Table) fullTextMultiTermIndexScan(ctx context.Context, secondaryIndex SecondaryIndex, scan Scan, terms []string, selectedFields []Field, out func(Row) error) error {
+	termsByDocFreq := make([]string, 0, len(terms))
+	docFreqByTerm := make(map[string]uint32, len(terms))
+	for _, term := range terms {
+		stats, err := secondaryIndex.InvertedIndex.Stats(ctx, term)
+		if err != nil {
+			return fmt.Errorf("full-text stats lookup failed: %w", err)
+		}
+		if stats.DocFreq == 0 {
+			return nil
+		}
+		docFreqByTerm[term] = stats.DocFreq
+		termsByDocFreq = append(termsByDocFreq, term)
+	}
+	slices.SortFunc(termsByDocFreq, func(a, b string) int {
+		if docFreqByTerm[a] < docFreqByTerm[b] {
+			return -1
+		}
+		if docFreqByTerm[a] > docFreqByTerm[b] {
+			return 1
+		}
+		return strings.Compare(a, b)
+	})
+
+	var surviving []RowID
+	for i, term := range termsByDocFreq {
+		rowIDs, err := loadFullTextRowIDsForTerm(ctx, secondaryIndex, scan.IndexName, term, docFreqByTerm[term])
+		if err != nil {
+			return err
+		}
+		if len(rowIDs) == 0 {
+			return nil
+		}
+		if i == 0 {
+			surviving = rowIDs
+			continue
+		}
+		surviving = intersectTwoSortedSets(surviving, rowIDs)
+		if len(surviving) == 0 {
+			return nil
+		}
+	}
+
+	return t.emitFullTextRows(ctx, scan, selectedFields, surviving, out)
+}
+
+func loadFullTextRowIDsForTerm(ctx context.Context, secondaryIndex SecondaryIndex, indexName, term string, docFreq uint32) ([]RowID, error) {
+	iter, err := secondaryIndex.InvertedIndex.Lookup(ctx, term)
+	if err != nil {
+		return nil, fmt.Errorf("full-text lookup failed: %w", err)
+	}
+
+	rowIDs := make([]RowID, 0, docFreq)
+	var (
+		lastRowID RowID
+		haveLast  bool
+	)
+	for {
+		block, ok, err := iter.NextBlock(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("full-text lookup failed: %w", err)
+		}
+		if !ok {
+			break
+		}
+		mode, err := forEachInvertedPostingRowID(block.Payload, func(rowID RowID) error {
+			if haveLast && rowID == lastRowID {
+				return nil
+			}
+			haveLast = true
+			lastRowID = rowID
+			rowIDs = append(rowIDs, rowID)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if mode != invertedPostingModePositions {
+			return nil, fmt.Errorf("full-text index %s uses posting mode %d", indexName, mode)
+		}
+	}
+	return rowIDs, nil
+}
+
+func (t *Table) emitFullTextRows(ctx context.Context, scan Scan, selectedFields []Field, rowIDs []RowID, out func(Row) error) error {
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	for _, rowID := range rowIDs {
 		if err := ctx.Err(); err != nil {
 			return err
 		}


### PR DESCRIPTION
What changed:

- Added a non-phrase multi-term fast path in select.go.
- It orders terms by DocFreq, decodes only row IDs, intersects sorted row-id lists, and avoids building per-term position maps.
- Added unit coverage in full_text_index_test.go.
- Updated RESULTS.md.

Benchmark result:

- FullText_Search_MultiTermAND/minisql: 332.81 µs/op, 283.7 KiB/op -> ~241 µs/op, ~78.3 KiB/op