### PR TITLE
feat: cache query plans for prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `MiniSQL` is an embedded single file database written in Golang, inspired by `SQLite` but borrows ideas from other databases such as `Postgres` too. It can differentiate itself from `SQLite` in several areas: 
 
 1. Pure Go / zero CGO
-2. MVCC snapshot isolation (for reads, OCC for writes), 
+2. MVCC snapshot isolation (for reads, OCC for writes)
 3. Parallel scan
 4. JSON + UUID as native types
 5. Built-in full-text search

--- a/e2e_tests/outer_join_test.go
+++ b/e2e_tests/outer_join_test.go
@@ -409,3 +409,96 @@ func (s *TestSuite) TestRightJoin() {
 		}
 	})
 }
+
+// TestInnerJoin_Limit verifies that LIMIT pushdown for JOIN queries returns exactly
+// the requested number of rows and does not leak goroutines.
+func (s *TestSuite) TestInnerJoin_Limit() {
+	_, err := s.db.Exec(`create table "users" (
+		id int8 primary key,
+		name varchar(50)
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "orders" (
+		id int8 primary key,
+		user_id int8,
+		amount int8
+	);`)
+	s.Require().NoError(err)
+
+	// Three users, Alice with 3 orders, Bob with 2, Charlie with 1 — 6 join rows total.
+	for _, stmt := range []string{
+		`insert into users("id", "name") values(1, 'Alice');`,
+		`insert into users("id", "name") values(2, 'Bob');`,
+		`insert into users("id", "name") values(3, 'Charlie');`,
+		`insert into orders("id", "user_id", "amount") values(1, 1, 10);`,
+		`insert into orders("id", "user_id", "amount") values(2, 1, 20);`,
+		`insert into orders("id", "user_id", "amount") values(3, 1, 30);`,
+		`insert into orders("id", "user_id", "amount") values(4, 2, 40);`,
+		`insert into orders("id", "user_id", "amount") values(5, 2, 50);`,
+		`insert into orders("id", "user_id", "amount") values(6, 3, 60);`,
+	} {
+		_, err = s.db.Exec(stmt)
+		s.Require().NoError(err)
+	}
+
+	s.Run("LIMIT 3 returns exactly 3 rows", func() {
+		rows, err := s.db.Query(`
+			select u.id, o.id
+			from users as u
+			inner join orders as o on u.id = o.user_id
+			limit 3;
+		`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var got [][2]int64
+		for rows.Next() {
+			var uid, oid int64
+			s.Require().NoError(rows.Scan(&uid, &oid))
+			got = append(got, [2]int64{uid, oid})
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(got, 3, "LIMIT 3 should return exactly 3 rows")
+	})
+
+	s.Run("LIMIT 2 OFFSET 1 skips first row and returns next 2", func() {
+		rows, err := s.db.Query(`
+			select u.id, o.id
+			from users as u
+			inner join orders as o on u.id = o.user_id
+			limit 2 offset 1;
+		`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var got [][2]int64
+		for rows.Next() {
+			var uid, oid int64
+			s.Require().NoError(rows.Scan(&uid, &oid))
+			got = append(got, [2]int64{uid, oid})
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(got, 2, "LIMIT 2 OFFSET 1 should return exactly 2 rows")
+	})
+
+	s.Run("LIMIT larger than result set returns all rows", func() {
+		rows, err := s.db.Query(`
+			select u.id, o.id
+			from users as u
+			inner join orders as o on u.id = o.user_id
+			limit 100;
+		`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var got [][2]int64
+		for rows.Next() {
+			var uid, oid int64
+			s.Require().NoError(rows.Scan(&uid, &oid))
+			got = append(got, [2]int64{uid, oid})
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(got, 6, "LIMIT 100 with 6 total rows should return all 6 rows")
+	})
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -45,6 +45,7 @@ type Database struct {
 	saver          PageSaver
 	lockedProvider TableProvider
 	stmtCache      LRUCache[string]
+	planCache      LRUCache[string]
 	tables         map[string]*Table
 	txManager      *TransactionManager
 	dbLock         *sync.RWMutex
@@ -82,6 +83,7 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 		foreignKeysEnabled: true,
 		dbLock:             new(sync.RWMutex),
 		stmtCache:          lrucache.New[string](defaultMaxCachedStatements),
+		planCache:          lrucache.New[string](defaultMaxCachedPlans),
 		logger:             logger,
 		clock: func() Time {
 			now := time.Now().UTC()
@@ -194,6 +196,7 @@ func (d *Database) PrepareStatement(ctx context.Context, query string) (Statemen
 	}
 
 	stmt := statements[0]
+	stmt.CacheKey = query
 
 	// Cache the parsed statement
 	d.stmtCache.Put(query, stmt, true)
@@ -737,7 +740,9 @@ func (d *Database) tableFromSQL(ctx context.Context, schema Schema) (*Table, err
 		"",
 	)
 
-	opts := []TableOption{}
+	opts := []TableOption{
+		WithPlanCache(d.planCache),
+	}
 
 	if stmt.PrimaryKey.Name != "" {
 		opts = append(opts, WithPrimaryKey(NewPrimaryKey(
@@ -945,21 +950,29 @@ func (d *Database) executeDDLStatement(ctx context.Context, stmt Statement) (Sta
 	d.dbLock.Lock()
 	defer d.dbLock.Unlock()
 
+	var execErr error
 	switch stmt.Kind {
 	case CreateTable:
-		_, err := d.createTable(ctx, stmt)
-		return StatementResult{}, err
+		_, execErr = d.createTable(ctx, stmt)
 	case DropTable:
-		return StatementResult{}, d.dropTable(ctx, stmt.TableName)
+		execErr = d.dropTable(ctx, stmt.TableName)
 	case CreateIndex:
-		return StatementResult{}, d.createIndex(ctx, stmt, table)
+		execErr = d.createIndex(ctx, stmt, table)
 	case DropIndex:
-		return StatementResult{}, d.dropIndex(ctx, stmt)
+		execErr = d.dropIndex(ctx, stmt)
 	case Analyze:
-		return StatementResult{}, d.Analyze(ctx, stmt.TableName)
+		execErr = d.Analyze(ctx, stmt.TableName)
+	default:
+		return StatementResult{}, fmt.Errorf("unrecognized DDL statement type: %v", stmt.Kind)
 	}
 
-	return StatementResult{}, fmt.Errorf("unrecognized DDL statement type: %v", stmt.Kind)
+	// Any schema or statistics change invalidates all cached query plans.
+	// CreateTable is excluded: no existing plan targets a brand-new table.
+	if execErr == nil && stmt.Kind != CreateTable {
+		d.planCache.Purge()
+	}
+
+	return StatementResult{}, execErr
 }
 
 func (d *Database) executeTableStatement(ctx context.Context, table *Table, stmt Statement) (StatementResult, error) {
@@ -1172,7 +1185,9 @@ func (d *Database) createTable(ctx context.Context, stmt Statement) (*Table, err
 		}
 	}
 
-	opts := []TableOption{}
+	opts := []TableOption{
+		WithPlanCache(d.planCache),
+	}
 
 	if stmt.PrimaryKey.Name != "" {
 		opts = append(opts, WithPrimaryKey(NewPrimaryKey(

--- a/internal/minisql/database_options.go
+++ b/internal/minisql/database_options.go
@@ -7,13 +7,27 @@ import (
 // DatabaseOption is a functional option for configuring a Database.
 type DatabaseOption func(*Database)
 
-const defaultMaxCachedStatements = 1000
+const (
+	defaultMaxCachedStatements = 1000
+	defaultMaxCachedPlans      = 1000
+)
 
 // WithMaxCachedStatements configures the maximum number of prepared statements to keep in the LRU cache.
 func WithMaxCachedStatements(maxStatements int) DatabaseOption {
 	return func(d *Database) {
 		if maxStatements > 0 {
 			d.stmtCache = lrucache.New[string](maxStatements)
+		}
+	}
+}
+
+// WithMaxCachedPlans configures the maximum number of query plans to keep in the plan cache.
+// Plans are keyed by the original SQL text (set at PrepareStatement time) and are invalidated
+// automatically on CREATE INDEX, DROP INDEX, DROP TABLE, and ANALYZE.
+func WithMaxCachedPlans(maxPlans int) DatabaseOption {
+	return func(d *Database) {
+		if maxPlans > 0 {
+			d.planCache = lrucache.New[string](maxPlans)
 		}
 	}
 }

--- a/internal/minisql/parallel_scan.go
+++ b/internal/minisql/parallel_scan.go
@@ -12,6 +12,15 @@ type parallelScanResult struct {
 	err error
 }
 
+// drainParallelScanCh reads and discards all remaining values from ch until it is
+// closed.  Called after cancel() to let workers unblock their channel sends and
+// exit cleanly before the consumer returns.
+func drainParallelScanCh(ch <-chan parallelScanResult) {
+	for v := range ch {
+		_ = v
+	}
+}
+
 // leafPageList walks the leaf chain from the leftmost leaf and returns every leaf PageIndex.
 func (t *Table) leafPageList(ctx context.Context) ([]PageIndex, error) {
 	cursor, err := t.SeekFirst(ctx)
@@ -87,12 +96,24 @@ func (t *Table) parallelSequentialScan(ctx context.Context, scan Scan, selectedF
 		close(ch)
 	}()
 
+	var received int64
+	scanLimit := scan.ScanLimit
 	for result := range ch {
 		if result.err != nil {
+			cancel()
+			drainParallelScanCh(ch)
 			return result.err
 		}
 		if err := out(result.row); err != nil {
+			cancel()
+			drainParallelScanCh(ch)
 			return err
+		}
+		received++
+		if scanLimit > 0 && received >= scanLimit {
+			cancel()
+			drainParallelScanCh(ch)
+			return nil
 		}
 	}
 

--- a/internal/minisql/ports.go
+++ b/internal/minisql/ports.go
@@ -22,6 +22,8 @@ type LRUCache[T any] interface {
 	GetAndPromote(T) (any, bool)
 	Put(T, any, bool)
 	EvictIfNeeded() (T, bool)
+	// Purge removes all entries, used to invalidate the plan cache on schema changes.
+	Purge()
 }
 
 // PagerFactory creates typed Pager instances for table data and index pages,

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -135,7 +136,11 @@ type Scan struct {
 	Filters        OneOrMore
 	// SubScans holds the child index scans for ScanTypeIndexIntersect.
 	// Each child is executed to collect RowIDs; surviving rows are fetched after intersection.
-	SubScans      []Scan
+	SubScans []Scan
+	// ScanLimit, when non-zero, tells the scan to stop after emitting this many qualifying rows.
+	// Set by PlanQuery when LIMIT is present, no in-memory sort is required, and no DISTINCT.
+	// For LIMIT N OFFSET M the value is M+N so that skipped rows are also counted.
+	ScanLimit     int64
 	Type          ScanType
 	CoveringIndex bool
 }
@@ -205,6 +210,61 @@ SELECT * from users ORDER BY created DESC; - use index on created for ordering
 SELECT * from users ORDER BY non_indexed_col; - order in memory
 */
 func (t *Table) PlanQuery(ctx context.Context, stmt Statement) (QueryPlan, error) {
+	// Plan cache: safe only when stmt.Conditions is empty (no bound values in the
+	// plan) and there are no JOINs (join plans embed per-execution join key values).
+	// ORDER BY-only queries are the primary beneficiary: the index-vs-sort decision
+	// is schema-derived and stable across all executions of the same SQL.
+	canCache := stmt.CacheKey != "" && t.planCache != nil &&
+		len(stmt.Conditions) == 0 && len(stmt.Joins) == 0
+
+	if canCache {
+		if cached, ok := t.planCache.Get(stmt.CacheKey); ok {
+			return applyScanLimit(cached.(QueryPlan), stmt), nil
+		}
+	}
+
+	plan, err := t.planQueryUncached(ctx, stmt)
+	if err != nil {
+		return QueryPlan{}, err
+	}
+
+	if canCache {
+		t.planCache.Put(stmt.CacheKey, plan, true)
+	}
+
+	return applyScanLimit(plan, stmt), nil
+}
+
+// applyScanLimit attaches a ScanLimit to each scan in the plan when LIMIT is present
+// and the query does not require a full-table materialisation (no in-memory sort, no
+// DISTINCT, no JOINs).  ScanLimit = OFFSET + LIMIT so that skipped (offset) rows are
+// included in the early-stop count.
+//
+// ScanLimit is intentionally set AFTER cache retrieval: the LIMIT/OFFSET values are
+// per-execution bound values, not schema-derived, so they must not be baked into the
+// cached plan.  To avoid mutating the shared cached slice, we copy plan.Scans first.
+func applyScanLimit(plan QueryPlan, stmt Statement) QueryPlan {
+	if !stmt.Limit.Valid || plan.SortInMemory || stmt.Distinct || len(plan.Joins) > 0 {
+		return plan
+	}
+	scanLimit := stmt.Limit.Value.(int64)
+	if stmt.Offset.Valid {
+		scanLimit += stmt.Offset.Value.(int64)
+	}
+	if scanLimit <= 0 {
+		return plan
+	}
+	scans := make([]Scan, len(plan.Scans))
+	copy(scans, plan.Scans)
+	for i := range scans {
+		scans[i].ScanLimit = scanLimit
+	}
+	plan.Scans = scans
+	return plan
+}
+
+// planQueryUncached derives a query plan from scratch without consulting the plan cache.
+func (t *Table) planQueryUncached(ctx context.Context, stmt Statement) (QueryPlan, error) {
 	// Handle multi-table queries (JOINs)
 	if len(stmt.Joins) > 0 {
 		return t.planJoinQuery(ctx, stmt)
@@ -1360,6 +1420,14 @@ func tryRangeScan(tableName string, indexInfo IndexInfo, filters Conditions, sta
 	return scan, true, nil
 }
 
+// drainRowCh reads and discards all remaining values from ch until it is closed.
+// Called after joinCancel() to let the JOIN goroutine unblock and exit cleanly.
+func drainRowCh(ch <-chan Row) {
+	for v := range ch {
+		_ = v
+	}
+}
+
 // Execute runs the query plan, calling out for every row produced.
 // out receives each row synchronously on the caller's goroutine; no internal
 // goroutines or channels are created.  JOIN queries are the exception: they
@@ -1370,16 +1438,31 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 	// Handle JOIN queries: executeNestedLoopJoin still uses chan<- Row internally,
 	// so we bridge it with a goroutine + channel and forward rows to the callback.
 	if len(p.Joins) > 0 {
+		// Use a child context so that we can cancel the JOIN goroutine when the
+		// consumer stops early (e.g. via errLimitReached).  Without cancellation,
+		// returning an error from out() while the goroutine is still sending to ch
+		// would either block the goroutine (if ch is full) or leak it.
+		joinCtx, joinCancel := context.WithCancel(ctx)
+		defer joinCancel()
+
 		ch := make(chan Row, 128)
 		var joinErr error
 		go func() {
 			defer close(ch)
-			joinErr = p.executeNestedLoopJoin(ctx, provider, selectedFields, ch)
+			joinErr = p.executeNestedLoopJoin(joinCtx, provider, selectedFields, ch)
 		}()
 		for row := range ch {
 			if err := out(row); err != nil {
+				joinCancel()
+				// Drain the channel so the goroutine can unblock and close ch,
+				// then return the consumer's error (e.g. errLimitReached).
+				drainRowCh(ch)
 				return err
 			}
+		}
+		if errors.Is(joinErr, context.Canceled) {
+			// The context was cancelled by us (joinCancel above); not a real error.
+			return nil
 		}
 		return joinErr
 	}

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -126,11 +126,28 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 	// Materialising path: buffer every matching row, then dispatch.
 	// Required for COUNT (needs a total), GROUP BY, aggregates, ORDER BY (sort),
 	// and JOIN (goroutine-based execution inside plan.Execute).
+	//
+	// LIMIT pushdown: for JOIN queries with no in-memory sort and no DISTINCT we
+	// can stop collecting rows after OFFSET+LIMIT rows, avoiding a full scan of
+	// every matching row.  plan.Execute propagates errLimitReached from the
+	// callback; the JOIN goroutine is cancelled and drained inside Execute itself.
+	var joinScanLimit int64
+	if len(plan.Joins) > 0 && stmt.Limit.Valid && !plan.SortInMemory && !stmt.Distinct {
+		joinScanLimit = stmt.Limit.Value.(int64)
+		if stmt.Offset.Valid {
+			joinScanLimit += stmt.Offset.Value.(int64)
+		}
+	}
+
 	var rows []Row
-	if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+	err = plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
 		rows = append(rows, row)
+		if joinScanLimit > 0 && int64(len(rows)) >= joinScanLimit {
+			return errLimitReached
+		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil && !errors.Is(err, errLimitReached) {
 		return StatementResult{}, err
 	}
 

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -400,6 +400,10 @@ type Statement struct {
 	UpdateFromAlias    string     // alias for the UPDATE FROM table (e.g. "d" in FROM departments d)
 	UpdateFromSubquery *Statement // non-nil when UPDATE FROM clause is a subquery
 	CTEs               []CTE      // non-nil for WITH … SELECT statements
+	// CacheKey is the original SQL text set by PrepareStatement; it is the key
+	// used to look up and store the query plan in the plan cache.  Empty for
+	// statements that were not prepared via PrepareStatement (ad-hoc queries).
+	CacheKey           string
 	Kind               StatementKind
 	IndexMethod        IndexMethod
 	ConflictAction     ConflictAction
@@ -483,6 +487,7 @@ func (s Statement) Clone() Statement {
 
 	stmt := Statement{
 		Kind:               s.Kind,
+		CacheKey:           s.CacheKey,
 		IfNotExists:        s.IfNotExists,
 		TableName:          s.TableName,
 		TableAlias:         s.TableAlias,

--- a/internal/minisql/stmt_cache_test.go
+++ b/internal/minisql/stmt_cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RichardKnop/minisql/pkg/lrucache"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDatabase_PrepareStatementCaching tests the database-level statement caching
@@ -32,6 +33,8 @@ func TestDatabase_PrepareStatementCaching(t *testing.T) {
 			},
 		},
 	}
+	stmt1Want := stmt1Mock
+	stmt1Want.CacheKey = query1
 
 	query2 := `SELECT * FROM posts WHERE user_id = ?`
 	stmt2Mock := Statement{
@@ -43,24 +46,218 @@ func TestDatabase_PrepareStatementCaching(t *testing.T) {
 			},
 		},
 	}
+	stmt2Want := stmt2Mock
+	stmt2Want.CacheKey = query2
 
 	mockParser.On("Parse", ctx, query1).Return([]Statement{stmt1Mock}, nil).Once()
 
-	// First call should parse
+	// First call should parse and set CacheKey.
 	stmt1, err := db.PrepareStatement(ctx, query1)
 	assert.NoError(t, err)
-	assert.Equal(t, stmt1Mock, stmt1)
+	assert.Equal(t, stmt1Want, stmt1)
 
-	// Second call with same query should return cached statement
+	// Second call with same query should return cached statement (CacheKey preserved).
 	stmt2, err := db.PrepareStatement(ctx, query1)
 	assert.NoError(t, err)
-	assert.Equal(t, stmt1Mock, stmt2)
+	assert.Equal(t, stmt1Want, stmt2)
 
 	mockParser.On("Parse", ctx, query2).Return([]Statement{stmt2Mock}, nil).Once()
 
-	// Different query should parse separately
+	// Different query should parse separately.
 	stmt3, err := db.PrepareStatement(ctx, query2)
 	assert.NoError(t, err)
 	assert.NotEqual(t, stmt1, stmt3, "Different queries should have different statements")
-	assert.Equal(t, stmt2Mock, stmt3)
+	assert.Equal(t, stmt2Want, stmt3)
+}
+
+// TestPlanCache_OrderByQuery verifies that the plan cache is used for no-condition
+// queries (ORDER BY-only), and that DDL invalidation clears it.
+func TestPlanCache_OrderByQuery(t *testing.T) {
+	planCache := lrucache.New[string](100)
+	table, _, _ := newTestTable(t, testColumns, WithPlanCache(planCache))
+
+	ctx := context.Background()
+
+	const query = `SELECT * FROM test_table ORDER BY id;`
+	stmt := Statement{
+		Kind:      Select,
+		CacheKey:  query,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		OrderBy:   []OrderBy{{Field: Field{Name: "id"}, Direction: Asc}},
+	}
+
+	// First call: cache miss — plan is derived and stored.
+	plan1, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+
+	// Second call: should hit the cache.
+	plan2, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	assert.Equal(t, plan1, plan2, "cached plan should be returned on second call")
+
+	// Purge simulates a DDL change; next call must re-derive.
+	planCache.Purge()
+	plan3, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	assert.Equal(t, plan1, plan3, "re-derived plan after purge should match original")
+}
+
+// TestPlanCache_ConditionQueryNotCached verifies that queries with WHERE conditions
+// are NOT cached (their plans contain bound values that differ per execution).
+func TestPlanCache_ConditionQueryNotCached(t *testing.T) {
+	planCache := lrucache.New[string](100)
+	table, _, _ := newTestTable(t, testColumns, WithPlanCache(planCache))
+
+	ctx := context.Background()
+
+	const query = `SELECT * FROM test_table WHERE id = ?;`
+	stmt := Statement{
+		Kind:      Select,
+		CacheKey:  query,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		Conditions: OneOrMore{
+			{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42))},
+		},
+	}
+
+	_, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+
+	// The plan cache must remain empty — condition-based plans are not cached.
+	_, cached := planCache.Get(query)
+	assert.False(t, cached, "condition-based plans must not be stored in the plan cache")
+}
+
+// TestScanLimit_SimpleLimit verifies that PlanQuery attaches ScanLimit = LIMIT when
+// a LIMIT is present, there is no in-memory sort, and no DISTINCT.
+func TestScanLimit_SimpleLimit(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	stmt := Statement{
+		Kind:      Select,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		Limit:     OptionalValue{Value: int64(10), Valid: true},
+	}
+
+	plan, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	require.Len(t, plan.Scans, 1)
+	assert.EqualValues(t, 10, plan.Scans[0].ScanLimit, "ScanLimit should equal LIMIT")
+}
+
+// TestScanLimit_OffsetPlusLimit verifies that ScanLimit = OFFSET + LIMIT so that
+// skipped (offset) rows are counted in the early-stop total.
+func TestScanLimit_OffsetPlusLimit(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	stmt := Statement{
+		Kind:      Select,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		Limit:     OptionalValue{Value: int64(20), Valid: true},
+		Offset:    OptionalValue{Value: int64(5), Valid: true},
+	}
+
+	plan, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	require.Len(t, plan.Scans, 1)
+	assert.EqualValues(t, 25, plan.Scans[0].ScanLimit, "ScanLimit should equal OFFSET + LIMIT")
+}
+
+// TestScanLimit_SortInMemory_NoScanLimit verifies that ScanLimit is NOT set when the
+// query requires an in-memory sort (ORDER BY on a column with no index).
+func TestScanLimit_SortInMemory_NoScanLimit(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	// "email" has no secondary index in testColumns, so ORDER BY email forces an in-memory sort.
+	stmt := Statement{
+		Kind:      Select,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		OrderBy:   []OrderBy{{Field: Field{Name: "email"}, Direction: Asc}},
+		Limit:     OptionalValue{Value: int64(10), Valid: true},
+	}
+
+	plan, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	assert.True(t, plan.SortInMemory, "expected in-memory sort for non-indexed ORDER BY")
+	for _, scan := range plan.Scans {
+		assert.EqualValues(t, 0, scan.ScanLimit, "ScanLimit must be 0 when SortInMemory is true")
+	}
+}
+
+// TestScanLimit_Distinct_NoScanLimit verifies that ScanLimit is NOT set when DISTINCT
+// is requested (we cannot stop early because later rows might be the distinct ones).
+func TestScanLimit_Distinct_NoScanLimit(t *testing.T) {
+	table, _, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	stmt := Statement{
+		Kind:      Select,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+		Distinct:  true,
+		Limit:     OptionalValue{Value: int64(10), Valid: true},
+	}
+
+	plan, err := table.PlanQuery(ctx, stmt)
+	require.NoError(t, err)
+	for _, scan := range plan.Scans {
+		assert.EqualValues(t, 0, scan.ScanLimit, "ScanLimit must be 0 when DISTINCT is set")
+	}
+}
+
+// TestScanLimit_CachedPlanNotMutated verifies that two calls with different LIMIT values
+// each receive the correct ScanLimit without corrupting the shared cached plan.
+// The test uses a no-condition query (cache-eligible) so the plan cache is exercised.
+func TestScanLimit_CachedPlanNotMutated(t *testing.T) {
+	planCache := lrucache.New[string](100)
+	table, _, _ := newTestTable(t, testColumns, WithPlanCache(planCache))
+	ctx := context.Background()
+
+	// No WHERE clause → plan is cache-eligible; no ORDER BY → SortInMemory = false.
+	const query = `SELECT * FROM test_table;`
+	baseStmt := Statement{
+		Kind:      Select,
+		CacheKey:  query,
+		TableName: testTableName,
+		Columns:   testColumns,
+		Fields:    []Field{{Name: "*"}},
+	}
+
+	stmt10 := baseStmt
+	stmt10.Limit = OptionalValue{Value: int64(10), Valid: true}
+
+	stmt50 := baseStmt
+	stmt50.Limit = OptionalValue{Value: int64(50), Valid: true}
+
+	plan10, err := table.PlanQuery(ctx, stmt10)
+	require.NoError(t, err)
+	require.Len(t, plan10.Scans, 1)
+	assert.EqualValues(t, 10, plan10.Scans[0].ScanLimit, "first call: ScanLimit should be 10")
+
+	plan50, err := table.PlanQuery(ctx, stmt50)
+	require.NoError(t, err)
+	require.Len(t, plan50.Scans, 1)
+	assert.EqualValues(t, 50, plan50.Scans[0].ScanLimit, "second call: ScanLimit should be 50")
+
+	// The cached plan must not have been mutated — ScanLimit must remain 0 in the cache.
+	cached, ok := planCache.Get(query)
+	require.True(t, ok, "plan should still be in cache")
+	cachedPlan := cached.(QueryPlan)
+	for _, scan := range cachedPlan.Scans {
+		assert.EqualValues(t, 0, scan.ScanLimit, "cached plan must not have ScanLimit set")
+	}
 }

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -49,6 +49,10 @@ type Table struct {
 	// enforceParentFKOnUpdate is called before UPDATE to enforce inbound FK constraints.
 	// Handles RESTRICT/CASCADE/SET NULL based on each FK's OnUpdate action.
 	enforceParentFKOnUpdate func(context.Context, Row, Row) error
+	// planCache is the shared plan cache from *Database. When non-nil, PlanQuery
+	// checks here first and stores results after planning. Nil for system tables
+	// and virtual tables created for derived-table subqueries.
+	planCache LRUCache[string]
 	// rightmostTablePage caches the last leaf page index for SeekNextRowID so that
 	// sequential (autoincrement) inserts skip the O(log N) root→leaf traversal.
 	// lastTxIDTablePage guards against stale hints from rolled-back transactions.

--- a/internal/minisql/table_options.go
+++ b/internal/minisql/table_options.go
@@ -79,3 +79,11 @@ func WithRowCountGetter(fn func() int64) TableOption {
 		t.getRowCount = fn
 	}
 }
+
+// WithPlanCache wires the shared plan cache into the table so that PlanQuery
+// can skip re-planning on repeated executions of the same prepared statement.
+func WithPlanCache(cache LRUCache[string]) TableOption {
+	return func(t *Table) {
+		t.planCache = cache
+	}
+}

--- a/pkg/lrucache/lru_cache.go
+++ b/pkg/lrucache/lru_cache.go
@@ -174,6 +174,15 @@ func (c *cacheImpl[T]) moveToFront(entry *cacheEntry[T]) {
 	c.addToFront(entry)
 }
 
+// Purge removes all entries from the cache, resetting it to an empty state.
+func (c *cacheImpl[T]) Purge() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[T]*cacheEntry[T])
+	c.head = nil
+	c.tail = nil
+}
+
 func (c *cacheImpl[T]) addToFront(entry *cacheEntry[T]) {
 	entry.next = c.head
 	entry.prev = nil


### PR DESCRIPTION
  Cache query plans.
  
  Scan.ScanLimit int64 — new field on Scan; zero means unlimited.
  
  applyScanLimit (new function in query_plan.go) — called by PlanQuery after cache retrieval. Sets ScanLimit = OFFSET + LIMIT when stmt.Limit.Valid && !plan.SortInMemory && !stmt.Distinct && len(plan.Joins) == 0. Shallow-copies plan.Scans first so the cached plan is never
  mutated.  

  parallelSequentialScan — consumer now counts rows received; when ScanLimit is reached (or out returns an error), calls cancel() and drains the channel so workers unblock cleanly. Previously, early exit only happened at page-loop boundaries; now it's at row granularity.
  
  plan.Execute JOIN path — now creates joinCtx, joinCancel := context.WithCancel(ctx). On early callback exit (including errLimitReached), calls joinCancel() and drains the channel via for range ch {} to let the goroutine close cleanly. Swallows context.Canceled as a non-error
  when we triggered it ourselves.

  Materializing path in select.go — for JOIN + LIMIT without in-memory sort or DISTINCT, adds a limit check to the plan.Execute callback. Treats errLimitReached from Execute as a sentinel (not a real error).