### PR TITLE
feat: implement constant folding

### DIFF
--- a/e2e_tests/constant_fold_test.go
+++ b/e2e_tests/constant_fold_test.go
@@ -1,0 +1,77 @@
+package e2etests
+
+func (s *TestSuite) TestConstantFolding() {
+	_, err := s.db.Exec(`create table "items" (
+		id     int8 primary key autoincrement,
+		name   varchar(100) not null,
+		status varchar(20) not null,
+		price  int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "items" (name, status, price) values ('Widget', 'active', 10)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "items" (name, status, price) values ('Gadget', 'ACTIVE', 20)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "items" (name, status, price) values ('Doohickey', 'inactive', 5)`)
+	s.Require().NoError(err)
+
+	s.Run("const_expr_rhs_folded_to_index_eligible", func() {
+		// UPPER('active') is a constant expression; after folding, the condition
+		// becomes status = 'ACTIVE' which is a normal field comparison.
+		rows, err := s.db.Query(`select name from "items" where status = UPPER('active')`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Gadget"}, names)
+	})
+
+	s.Run("always_false_where_returns_no_rows", func() {
+		// 1 = 2 is always false; the scan should be skipped entirely.
+		rows, err := s.db.Query(`select name from "items" where 1 = 2`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.False(rows.Next(), "expected no rows for always-false WHERE")
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("always_true_where_returns_all_rows", func() {
+		// 1 = 1 is always true; all rows should be returned.
+		rows, err := s.db.Query(`select name from "items" where 1 = 1`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(names, 3, "expected all 3 rows for always-true WHERE")
+	})
+
+	s.Run("const_func_both_sides_tautology", func() {
+		// LOWER('FOO') = LOWER('FOO') is always true → all rows returned.
+		rows, err := s.db.Query(`select name from "items" where LOWER('FOO') = LOWER('foo')`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(names, 3, "always-true expression should return all rows")
+	})
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -482,6 +482,19 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 				return StatementResult{}, err
 			}
 			stmt.Conditions = resolved
+
+			// Constant folding: replace OperandExpr operands that contain no
+			// column references with their evaluated literal values.  This
+			// enables index use for patterns like WHERE col = UPPER('foo') and
+			// prunes AND groups that are always false.
+			folded, alwaysFalse, err := FoldConditions(stmt.Conditions)
+			if err != nil {
+				return StatementResult{}, err
+			}
+			if alwaysFalse {
+				return StatementResult{Rows: NewSliceIterator(nil)}, nil
+			}
+			stmt.Conditions = folded // nil when WHERE is always true → no filter
 		}
 
 		// SELECT with UNION / UNION ALL branches is handled by the union executor.

--- a/internal/minisql/fold.go
+++ b/internal/minisql/fold.go
@@ -1,0 +1,168 @@
+package minisql
+
+// isConstExpr returns true when e contains no column references and can be
+// evaluated at plan time against an empty row.
+func isConstExpr(e *Expr) bool {
+	if e == nil {
+		return true
+	}
+	if e.Column != "" {
+		return false
+	}
+	for _, arg := range e.Args {
+		if !isConstExpr(arg) {
+			return false
+		}
+	}
+	for _, clause := range e.CaseClauses {
+		// Searched CASE: WHEN <condition> — conservatively treat as non-const
+		// because ConditionNode may reference columns.
+		if clause.Cond != nil {
+			return false
+		}
+		if !isConstExpr(clause.When) || !isConstExpr(clause.Then) {
+			return false
+		}
+	}
+	return isConstExpr(e.Left) && isConstExpr(e.Right) &&
+		isConstExpr(e.CastExpr) && isConstExpr(e.CaseInput) && isConstExpr(e.CaseElse)
+}
+
+// anyToOperand converts a concrete Go value returned by Expr.Eval into the
+// matching Operand type so that the condition evaluator can use it directly.
+func anyToOperand(v any) Operand {
+	switch val := v.(type) {
+	case nil:
+		return Operand{Type: OperandNull}
+	case int64:
+		return Operand{Type: OperandInteger, Value: val}
+	case int32:
+		return Operand{Type: OperandInteger, Value: int64(val)}
+	case float64:
+		return Operand{Type: OperandFloat, Value: val}
+	case float32:
+		return Operand{Type: OperandFloat, Value: float64(val)}
+	case bool:
+		return Operand{Type: OperandBoolean, Value: val}
+	case TextPointer:
+		return Operand{Type: OperandQuotedString, Value: val}
+	case TimestampMicros:
+		return Operand{Type: OperandQuotedString, Value: val}
+	default:
+		return Operand{Type: OperandExpr, Value: v}
+	}
+}
+
+// FoldConditions evaluates constant sub-expressions in conds, replacing
+// OperandExpr operands with concrete literals where possible.
+//
+// Three outcomes:
+//   - (result, false, nil): result is the folded conditions (may be shorter).
+//     If result is nil/empty the WHERE is always true (no filter needed).
+//   - (nil, true, nil):  every AND group was pruned; the WHERE can never match.
+//   - (_, _, err):       an expression evaluation error occurred.
+func FoldConditions(conds OneOrMore) (result OneOrMore, alwaysFalse bool, err error) {
+	for _, group := range conds {
+		folded, groupFalse, groupTrue, ferr := foldAndGroup(group)
+		if ferr != nil {
+			return nil, false, ferr
+		}
+		if groupFalse {
+			continue // this OR branch can never fire — prune it
+		}
+		if groupTrue {
+			// One OR branch is always satisfied → whole WHERE is always true.
+			return nil, false, nil
+		}
+		result = append(result, folded)
+	}
+	if len(result) == 0 && len(conds) > 0 {
+		return nil, true, nil
+	}
+	return result, false, nil
+}
+
+func foldAndGroup(group Conditions) (folded Conditions, alwaysFalse, alwaysTrue bool, err error) {
+	for _, cond := range group {
+		fc, condFalse, condTrue, ferr := foldCondition(cond)
+		if ferr != nil {
+			return nil, false, false, ferr
+		}
+		if condFalse {
+			return nil, true, false, nil // AND short-circuits to false
+		}
+		if condTrue {
+			continue // tautology — drop from AND group
+		}
+		folded = append(folded, fc)
+	}
+	if len(folded) == 0 {
+		return nil, false, true, nil // all conditions were tautologies
+	}
+	return folded, false, false, nil
+}
+
+// foldCondition folds any constant OperandExpr operands in cond and, when
+// neither operand references a row column, evaluates the whole condition.
+// condFalse=true means the condition can never be true (prune the AND group).
+// condTrue=true means the condition is always true (drop it from the group).
+func foldCondition(cond Condition) (fc Condition, condFalse, condTrue bool, err error) {
+	if cond.Operand1.Type == OperandExpr {
+		if expr, ok := cond.Operand1.Value.(*Expr); ok && isConstExpr(expr) {
+			val, evalErr := expr.Eval(Row{})
+			if evalErr != nil {
+				return cond, false, false, evalErr
+			}
+			cond.Operand1 = anyToOperand(val)
+		}
+	}
+	if cond.Operand2.Type == OperandExpr {
+		if expr, ok := cond.Operand2.Value.(*Expr); ok && isConstExpr(expr) {
+			val, evalErr := expr.Eval(Row{})
+			if evalErr != nil {
+				return cond, false, false, evalErr
+			}
+			cond.Operand2 = anyToOperand(val)
+		}
+	}
+	// If neither side references a field after folding, evaluate now.
+	if !cond.Operand1.IsField() && !cond.Operand2.IsField() &&
+		cond.Operand1.Type != OperandExpr && cond.Operand2.Type != OperandExpr {
+		result, canEval := evalConstCond(cond)
+		if canEval {
+			return cond, !result, result, nil
+		}
+	}
+	return cond, false, false, nil
+}
+
+// evalConstCond evaluates a condition where neither operand references a row
+// column. Returns (result, canEval): canEval is false when the comparison
+// cannot be performed (e.g. unsupported type), in which case result is meaningless.
+func evalConstCond(cond Condition) (result, canEval bool) {
+	if cond.Operand1.Type == OperandNull {
+		switch cond.Operator {
+		case Eq:
+			return cond.Operand2.Type == OperandNull, true
+		case Ne:
+			return cond.Operand2.Type != OperandNull, true
+		default:
+			return false, false
+		}
+	}
+	if cond.Operand2.Type == OperandNull {
+		switch cond.Operator {
+		case Eq:
+			return false, true
+		case Ne:
+			return true, true
+		default:
+			return false, false
+		}
+	}
+	ok, err := compareScalarToOperand(cond.Operand1.Value, cond.Operand2, cond.Operator)
+	if err != nil {
+		return false, false
+	}
+	return ok, true
+}

--- a/internal/minisql/fold_test.go
+++ b/internal/minisql/fold_test.go
@@ -1,0 +1,290 @@
+package minisql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsConstExpr verifies the constant-expression detector.
+func TestIsConstExpr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		expr  *Expr
+		want  bool
+	}{
+		{
+			name: "nil",
+			expr: nil,
+			want: true,
+		},
+		{
+			name: "integer literal",
+			expr: &Expr{Literal: int64(42)},
+			want: true,
+		},
+		{
+			name: "string literal",
+			expr: &Expr{Literal: NewTextPointer([]byte("hello"))},
+			want: true,
+		},
+		{
+			name: "null literal",
+			expr: &Expr{IsNull: true},
+			want: true,
+		},
+		{
+			name: "column reference",
+			expr: &Expr{Column: "status"},
+			want: false,
+		},
+		{
+			name: "NOW() — no column ref",
+			expr: &Expr{FuncName: "NOW"},
+			want: true,
+		},
+		{
+			name: "UPPER with literal arg",
+			expr: &Expr{
+				FuncName: "UPPER",
+				Args:     []*Expr{{Literal: NewTextPointer([]byte("hello"))}},
+			},
+			want: true,
+		},
+		{
+			name: "UPPER with column arg",
+			expr: &Expr{
+				FuncName: "UPPER",
+				Args:     []*Expr{{Column: "status"}},
+			},
+			want: false,
+		},
+		{
+			name: "arithmetic with literals",
+			expr: &Expr{
+				Left:  &Expr{Literal: int64(1)},
+				Right: &Expr{Literal: int64(2)},
+				Op:    ArithAdd,
+			},
+			want: true,
+		},
+		{
+			name: "arithmetic with column",
+			expr: &Expr{
+				Left:  &Expr{Column: "price"},
+				Right: &Expr{Literal: int64(2)},
+				Op:    ArithMul,
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isConstExpr(tc.expr))
+		})
+	}
+}
+
+// TestAnyToOperand verifies the Go-value → Operand conversion.
+func TestAnyToOperand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input any
+		want  Operand
+	}{
+		{
+			name:  "nil → null",
+			input: nil,
+			want:  Operand{Type: OperandNull},
+		},
+		{
+			name:  "int64",
+			input: int64(7),
+			want:  Operand{Type: OperandInteger, Value: int64(7)},
+		},
+		{
+			name:  "int32 promoted to int64",
+			input: int32(3),
+			want:  Operand{Type: OperandInteger, Value: int64(3)},
+		},
+		{
+			name:  "float64",
+			input: float64(3.14),
+			want:  Operand{Type: OperandFloat, Value: float64(3.14)},
+		},
+		{
+			name:  "float32 promoted to float64",
+			input: float32(1.5),
+			want:  Operand{Type: OperandFloat, Value: float64(float32(1.5))},
+		},
+		{
+			name:  "bool",
+			input: true,
+			want:  Operand{Type: OperandBoolean, Value: true},
+		},
+		{
+			name:  "TextPointer",
+			input: NewTextPointer([]byte("HELLO")),
+			want:  Operand{Type: OperandQuotedString, Value: NewTextPointer([]byte("HELLO"))},
+		},
+		{
+			name:  "TimestampMicros",
+			input: TimestampMicros(1000),
+			want:  Operand{Type: OperandQuotedString, Value: TimestampMicros(1000)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, anyToOperand(tc.input))
+		})
+	}
+}
+
+// TestFoldConditions_ConstExprRHS verifies that a constant OperandExpr on the
+// RHS of a field condition is folded to a concrete operand.
+func TestFoldConditions_ConstExprRHS(t *testing.T) {
+	t.Parallel()
+
+	upperExpr := &Expr{
+		FuncName: "UPPER",
+		Args:     []*Expr{{Literal: NewTextPointer([]byte("active"))}},
+	}
+	cond := Condition{
+		Operand1: Operand{Type: OperandField, Value: Field{Name: "status"}},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandExpr, Value: upperExpr},
+	}
+	conds := OneOrMore{{cond}}
+
+	result, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.False(t, alwaysFalse)
+	require.Len(t, result, 1)
+	require.Len(t, result[0], 1)
+
+	got := result[0][0]
+	assert.Equal(t, OperandField, got.Operand1.Type, "operand1 should remain a field")
+	assert.Equal(t, OperandQuotedString, got.Operand2.Type, "const expr should fold to QuotedString")
+	assert.Equal(t, NewTextPointer([]byte("ACTIVE")), got.Operand2.Value)
+}
+
+// TestFoldConditions_ConstExprLHS verifies folding on the left side.
+func TestFoldConditions_ConstExprLHS(t *testing.T) {
+	t.Parallel()
+
+	addExpr := &Expr{
+		Left:  &Expr{Literal: int64(1)},
+		Right: &Expr{Literal: int64(2)},
+		Op:    ArithAdd,
+	}
+	cond := Condition{
+		Operand1: Operand{Type: OperandExpr, Value: addExpr},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandInteger, Value: int64(3)},
+	}
+	conds := OneOrMore{{cond}}
+
+	result, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.False(t, alwaysFalse)
+	// 1+2 = 3 is always true → condition is a tautology → AND group empty → alwaysTrue → no filter
+	assert.Empty(t, result, "tautology should fold to no conditions")
+}
+
+// TestFoldConditions_AlwaysFalse verifies that a demonstrably false condition
+// causes its AND group to be pruned; if all groups are pruned, alwaysFalse=true.
+func TestFoldConditions_AlwaysFalse(t *testing.T) {
+	t.Parallel()
+
+	// 1 = 2 is always false
+	cond := Condition{
+		Operand1: Operand{Type: OperandInteger, Value: int64(1)},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandInteger, Value: int64(2)},
+	}
+	conds := OneOrMore{{cond}}
+
+	_, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.True(t, alwaysFalse)
+}
+
+// TestFoldConditions_AlwaysTrue verifies that a tautology condition causes the
+// whole WHERE to be dropped (result is nil/empty, alwaysFalse=false).
+func TestFoldConditions_AlwaysTrue(t *testing.T) {
+	t.Parallel()
+
+	// 5 > 3 is always true
+	cond := Condition{
+		Operand1: Operand{Type: OperandInteger, Value: int64(5)},
+		Operator: Gt,
+		Operand2: Operand{Type: OperandInteger, Value: int64(3)},
+	}
+	conds := OneOrMore{{cond}}
+
+	result, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.False(t, alwaysFalse)
+	assert.Empty(t, result, "always-true WHERE should reduce to no conditions")
+}
+
+// TestFoldConditions_ColumnExprNotFolded verifies that an OperandExpr containing
+// a column reference is NOT folded (it requires a row value at scan time).
+func TestFoldConditions_ColumnExprNotFolded(t *testing.T) {
+	t.Parallel()
+
+	colExpr := &Expr{Column: "price"}
+	cond := Condition{
+		Operand1: Operand{Type: OperandExpr, Value: colExpr},
+		Operator: Gt,
+		Operand2: Operand{Type: OperandInteger, Value: int64(100)},
+	}
+	conds := OneOrMore{{cond}}
+
+	result, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.False(t, alwaysFalse)
+	require.Len(t, result, 1)
+	require.Len(t, result[0], 1)
+	// Column ref expression must stay as OperandExpr
+	assert.Equal(t, OperandExpr, result[0][0].Operand1.Type)
+}
+
+// TestFoldConditions_MixedGroups verifies OR group semantics: if one AND group is
+// always false it is pruned, but other groups survive.
+func TestFoldConditions_MixedGroups(t *testing.T) {
+	t.Parallel()
+
+	// Group 0: 1 = 2 (always false) → pruned
+	falseCond := Condition{
+		Operand1: Operand{Type: OperandInteger, Value: int64(1)},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandInteger, Value: int64(2)},
+	}
+	// Group 1: status = UPPER('active') — field condition, stays
+	upperExpr := &Expr{
+		FuncName: "UPPER",
+		Args:     []*Expr{{Literal: NewTextPointer([]byte("active"))}},
+	}
+	realCond := Condition{
+		Operand1: Operand{Type: OperandField, Value: Field{Name: "status"}},
+		Operator: Eq,
+		Operand2: Operand{Type: OperandExpr, Value: upperExpr},
+	}
+	conds := OneOrMore{{falseCond}, {realCond}}
+
+	result, alwaysFalse, err := FoldConditions(conds)
+	require.NoError(t, err)
+	assert.False(t, alwaysFalse, "one OR branch survives")
+	require.Len(t, result, 1, "the always-false group should be pruned")
+	assert.Equal(t, OperandQuotedString, result[0][0].Operand2.Type, "expr should be folded")
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -569,7 +569,7 @@ func (p *parserItem) peekWithLength() (string, int) {
 }
 
 func (p *parserItem) peekQuotedStringWithLength() (string, int) {
-	if len(p.sql) < p.i || p.sql[p.i] != '\'' {
+	if p.i >= len(p.sql) || p.sql[p.i] != '\'' {
 		return "", 0
 	}
 	for i := p.i + 1; i < len(p.sql); i++ {
@@ -589,7 +589,7 @@ func (p *parserItem) peekBooleanWithLength() (bool, int) {
 }
 
 func (p *parserItem) peekIntWithLength() (int64, int) {
-	if len(p.sql) < p.i || !unicode.IsDigit(rune(p.sql[p.i])) {
+	if p.i >= len(p.sql) || !unicode.IsDigit(rune(p.sql[p.i])) {
 		return 0, 0
 	}
 	for i := p.i + 1; i < len(p.sql); i++ {
@@ -610,7 +610,7 @@ func (p *parserItem) peekIntWithLength() (int64, int) {
 }
 
 func (p *parserItem) peekNumberWithLength() (float64, int) {
-	if len(p.sql) < p.i || !unicode.IsDigit(rune(p.sql[p.i])) {
+	if p.i >= len(p.sql) || !unicode.IsDigit(rune(p.sql[p.i])) {
 		return 0.0, 0
 	}
 	for i := p.i + 1; i < len(p.sql); i++ {

--- a/internal/parser/where.go
+++ b/internal/parser/where.go
@@ -173,6 +173,25 @@ func (p *parserItem) parseLeafCondition() (*minisql.ConditionNode, error) {
 	identifier := p.peek()
 	upperIdent := strings.ToUpper(identifier)
 
+	// Literal value on the left side of a condition (e.g. WHERE 1 = 1, WHERE true).
+	// These are constant-foldable at plan time.
+	if v, ln := p.peekValue(); ln != 0 {
+		p.pop()
+		var op1 minisql.Operand
+		switch val := v.(type) {
+		case int64:
+			op1 = minisql.Operand{Type: minisql.OperandInteger, Value: val}
+		case float64:
+			op1 = minisql.Operand{Type: minisql.OperandFloat, Value: val}
+		case bool:
+			op1 = minisql.Operand{Type: minisql.OperandBoolean, Value: val}
+		case string:
+			op1 = minisql.Operand{Type: minisql.OperandQuotedString, Value: minisql.NewTextPointer([]byte(val))}
+		}
+		cond := minisql.Condition{Operand1: op1}
+		return p.parseCondOperatorAndRHS(&cond)
+	}
+
 	// Built-in function call or CAST as WHERE left operand:
 	//   LOWER(email) = ?, DATE_TRUNC('month', ts) = ?, CAST(x AS INT8) > 0, etc.
 	if isBuiltinFunction(upperIdent) || upperIdent == "CAST" {
@@ -462,6 +481,16 @@ func (p *parserItem) parseCondScalarValue(cond *minisql.Condition) error {
 			return err
 		}
 		cond.Operand2 = minisql.Operand{Type: minisql.OperandSubquery, Value: subStmt}
+		return nil
+	}
+	// Built-in function call or CAST on the right side (e.g. UPPER('active'), CAST(? AS INT8)).
+	// Parsed as an OperandExpr; constant-foldable at plan time.
+	if upperIdent := strings.ToUpper(p.peek()); isBuiltinFunction(upperIdent) || upperIdent == "CAST" {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return err
+		}
+		cond.Operand2 = minisql.Operand{Type: minisql.OperandExpr, Value: expr}
 		return nil
 	}
 	if identifier := p.peek(); isIdentifier(identifier) {


### PR DESCRIPTION
Constant folding is complete. Here's a summary of everything that was implemented:

  internal/minisql/fold.go (new file, ~130 lines):
  - isConstExpr(e *Expr) bool — detects expressions with no column references
  - anyToOperand(v any) Operand — converts Expr.Eval result to a concrete Operand
  - FoldConditions(conds OneOrMore) (OneOrMore, bool, error) — walks all AND/OR groups, replacing const OperandExpr with literals; returns alwaysFalse=true when all groups are pruned
  - evalConstCond(cond Condition) (bool, bool) — evaluates a condition where neither side is a field; reuses compareScalarToOperand
  
  internal/minisql/database.go — FoldConditions wired into ExecuteStatement after resolveSubqueries:
  - alwaysFalse → early return with NewSliceIterator(nil) (no scan)
  - alwaysTrue → stmt.Conditions = nil (no filter)
  
  internal/parser/where.go — two parser extensions:
  - parseLeafCondition: literal values (1, 'foo', true) now valid on the LHS
  - parseCondScalarValue: built-in function calls (UPPER(...), LOWER(...), NOW(), etc.) now valid on the RHS, stored as OperandExpr
  
  internal/parser/parser.go — fixed pre-existing off-by-one bug (len(sql) < i → i >= len(sql)) in peekQuotedStringWithLength, peekIntWithLength, and peekNumberWithLength, exposed by the new peekValue() call path.