### PR TITLE
feat: run N index scans, merge their sorted row ID lists, deduplicate…

### DIFF
--- a/e2e_tests/or_union_test.go
+++ b/e2e_tests/or_union_test.go
@@ -1,0 +1,114 @@
+package e2etests
+
+import "sort"
+
+func (s *TestSuite) TestORIndexUnion() {
+	_, err := s.db.Exec(`create table "tickets" (
+		id       int8 primary key autoincrement,
+		status   varchar(20) not null,
+		priority varchar(20) not null,
+		score    int8 not null
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create index idx_tickets_status on "tickets" (status);`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create index idx_tickets_priority on "tickets" (priority);`)
+	s.Require().NoError(err)
+
+	// Row 1: open, low, 10
+	_, err = s.db.Exec(`insert into "tickets" (status, priority, score) values ('open', 'low', 10)`)
+	s.Require().NoError(err)
+	// Row 2: closed, critical, 20
+	_, err = s.db.Exec(`insert into "tickets" (status, priority, score) values ('closed', 'critical', 20)`)
+	s.Require().NoError(err)
+	// Row 3: open, critical, 30  ← matches BOTH OR groups
+	_, err = s.db.Exec(`insert into "tickets" (status, priority, score) values ('open', 'critical', 30)`)
+	s.Require().NoError(err)
+	// Row 4: closed, low, 40  ← matches neither
+	_, err = s.db.Exec(`insert into "tickets" (status, priority, score) values ('closed', 'low', 40)`)
+	s.Require().NoError(err)
+
+	s.Run("or_two_indexed_columns", func() {
+		// Row 1 (status=open), Row 2 (priority=critical), Row 3 (both).
+		// Row 3 must appear exactly once (deduplication).
+		rows, err := s.db.Query(`select id from "tickets" where status = 'open' OR priority = 'critical'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int
+		for rows.Next() {
+			var id int
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		sort.Ints(ids)
+		s.Equal([]int{1, 2, 3}, ids, "rows 1, 2, 3 match; row 3 must appear once")
+	})
+
+	s.Run("or_with_additional_and_condition", func() {
+		// (status = 'open' AND score < 20) OR priority = 'critical'
+		// Row 1: open, score=10 (<20) → matches group 0
+		// Row 2: priority=critical → matches group 1
+		// Row 3: open AND score=30 (not <20), priority=critical → matches group 1
+		rows, err := s.db.Query(
+			`select id from "tickets" where status = 'open' AND score < 20 OR priority = 'critical'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int
+		for rows.Next() {
+			var id int
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		sort.Ints(ids)
+		s.Equal([]int{1, 2, 3}, ids)
+	})
+
+	s.Run("or_no_match_returns_empty", func() {
+		rows, err := s.db.Query(
+			`select id from "tickets" where status = 'pending' OR priority = 'blocker'`)
+		s.Require().NoError(err)
+		defer rows.Close()
+		s.False(rows.Next(), "no tickets have status=pending or priority=blocker")
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("or_with_limit", func() {
+		rows, err := s.db.Query(
+			`select id from "tickets" where status = 'open' OR priority = 'critical' LIMIT 2`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int
+		for rows.Next() {
+			var id int
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(ids, 2, "LIMIT 2 must cap the union scan at 2 rows")
+	})
+
+	s.Run("or_one_group_no_index_sequential_fallback", func() {
+		// score has no index — falls back to sequential scan but must still return correct rows.
+		rows, err := s.db.Query(
+			`select id from "tickets" where status = 'open' OR score = 20`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []int
+		for rows.Next() {
+			var id int
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().NoError(rows.Err())
+		sort.Ints(ids)
+		// Row 1 (open), Row 2 (score=20), Row 3 (open, score=30)
+		s.Equal([]int{1, 2, 3}, ids)
+	})
+}

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -428,6 +428,8 @@ func (t *Table) executeExplainScan(ctx context.Context, plan QueryPlan, scan Sca
 		return t.sequentialScan(ctx, scan, selectedFields, out)
 	case ScanTypeIndexIntersect:
 		return t.indexIntersectScan(ctx, scan, selectedFields, out)
+	case ScanTypeIndexUnion:
+		return t.indexUnionScan(ctx, scan, selectedFields, out)
 	case ScanTypeFullText:
 		return t.fullTextIndexScan(ctx, scan, selectedFields, out)
 	case ScanTypeInverted:
@@ -483,14 +485,22 @@ func scanOperation(scan Scan) string {
 }
 
 func scanDetail(scan Scan) string {
-	if scan.Type == ScanTypeIndexIntersect {
+	if scan.Type == ScanTypeIndexIntersect || scan.Type == ScanTypeIndexUnion {
 		subParts := make([]string, 0, len(scan.SubScans))
 		for _, sub := range scan.SubScans {
-			subParts = append(subParts, sub.IndexName)
+			if sub.IndexName != "" {
+				subParts = append(subParts, sub.IndexName)
+			} else {
+				subParts = append(subParts, sub.Type.String())
+			}
+		}
+		sep := "+"
+		if scan.Type == ScanTypeIndexUnion {
+			sep = "|"
 		}
 		parts := []string{
 			"table=" + scan.TableName,
-			"indexes=" + strings.Join(subParts, "+"),
+			"indexes=" + strings.Join(subParts, sep),
 		}
 		if len(scan.Filters) > 0 {
 			parts = append(parts, fmt.Sprintf("filters=%d", conditionCount(scan.Filters)))

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -28,6 +28,10 @@ const (
 	// memory, then fetches only the surviving rows.  Used for AND conditions where two or
 	// more independent indexes are available.
 	ScanTypeIndexIntersect
+	// ScanTypeIndexUnion runs each sub-scan to collect RowID sets, unions (deduplicates) them
+	// in memory, then fetches only the surviving rows once.  Used for OR conditions where every
+	// OR branch has an index match, avoiding duplicate row emission and redundant scans.
+	ScanTypeIndexUnion
 	// ScanTypeFullText runs an inverted full-text index lookup for MATCH predicates.
 	ScanTypeFullText
 	// ScanTypeInverted runs a JSON inverted index lookup for JSON_CONTAINS predicates.
@@ -50,6 +54,8 @@ func (st ScanType) String() string {
 		return "index_last"
 	case ScanTypeIndexIntersect:
 		return "index_intersect"
+	case ScanTypeIndexUnion:
+		return "index_union"
 	case ScanTypeFullText:
 		return "fulltext"
 	case ScanTypeInverted:
@@ -1203,14 +1209,28 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 	// When all groups fall back to sequential scan (no index usable), keep the
 	// default single sequential scan which already holds the full DNF filter.
 	hasRealIndexScan := false
+	allIndexed := true
 	for _, scan := range indexScans {
 		if scan.Type != ScanTypeSequential {
 			hasRealIndexScan = true
-			break
+		} else {
+			allIndexed = false
 		}
 	}
 	if len(indexScans) > 0 && hasRealIndexScan {
-		p.Scans = indexScans
+		if allIndexed && len(indexScans) > 1 {
+			// Every OR group has an index-backed scan → merge into a single union scan.
+			// The executor collects RowIDs from each sub-scan, deduplicates, then
+			// fetches each surviving row once and re-checks the full WHERE clause.
+			p.Scans = []Scan{{
+				TableName: t.Name,
+				Type:      ScanTypeIndexUnion,
+				SubScans:  indexScans,
+				Filters:   conditions, // full DNF re-check after row fetch
+			}}
+		} else {
+			p.Scans = indexScans
+		}
 	}
 
 	return nil
@@ -1486,6 +1506,8 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 			return t.indexEndpointScan(ctx, p.Scans[0], selectedFields, out, true)
 		case ScanTypeIndexIntersect:
 			return t.indexIntersectScan(ctx, p.Scans[0], selectedFields, out)
+		case ScanTypeIndexUnion:
+			return t.indexUnionScan(ctx, p.Scans[0], selectedFields, out)
 		case ScanTypeFullText:
 			return t.fullTextIndexScan(ctx, p.Scans[0], selectedFields, out)
 		case ScanTypeInverted:

--- a/internal/minisql/query_plan_composite_index_test.go
+++ b/internal/minisql/query_plan_composite_index_test.go
@@ -197,26 +197,40 @@ func TestTable_PlanQuery_CompositeIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    compositePKIndexName,
-						IndexColumns: compositeColumns[1:3],
-						IndexKeys: []any{
-							NewCompositeKey(compositeColumns[1:3], "John", "Doe"),
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    compositePKIndexName,
+							IndexColumns: compositeColumns[1:3],
+							IndexKeys: []any{
+								NewCompositeKey(compositeColumns[1:3], "John", "Doe"),
+							},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    compositePKIndexName,
+							IndexColumns: compositeColumns[1:3],
+							IndexKeys: []any{
+								NewCompositeKey(compositeColumns[1:3], "Jane", "Smith"),
+							},
 						},
 					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    compositePKIndexName,
-						IndexColumns: compositeColumns[1:3],
-						IndexKeys: []any{
-							NewCompositeKey(compositeColumns[1:3], "Jane", "Smith"),
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "first_name"}, OperandQuotedString, NewTextPointer([]byte("John"))),
+							FieldIsEqual(Field{Name: "last_name"}, OperandQuotedString, NewTextPointer([]byte("Doe"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "first_name"}, OperandQuotedString, NewTextPointer([]byte("Jane"))),
+							FieldIsEqual(Field{Name: "last_name"}, OperandQuotedString, NewTextPointer([]byte("Smith"))),
 						},
 					},
-				},
+				}},
 			},
 		},
 		{

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -317,8 +317,8 @@ func planJoinTableScan(t *Table, tableName, tableAlias string, conditions OneOrM
 	if err := tempPlan.setIndexScans(t, conditions); err != nil {
 		return defaultScan
 	}
-	if len(tempPlan.Scans) != 1 {
-		// Multiple OR groups each with an index — keep sequential for simplicity.
+	if len(tempPlan.Scans) != 1 || tempPlan.Scans[0].Type == ScanTypeIndexUnion {
+		// Multiple OR groups each with an index — keep sequential for simplicity in JOIN path.
 		return defaultScan
 	}
 	scan := tempPlan.Scans[0]

--- a/internal/minisql/query_plan_multi_index_test.go
+++ b/internal/minisql/query_plan_multi_index_test.go
@@ -113,22 +113,30 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    pkIndexName,
-						IndexColumns: columns[0:1],
-						IndexKeys:    []any{int64(42)},
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    pkIndexName,
+							IndexColumns: columns[0:1],
+							IndexKeys:    []any{int64(42)},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    uniqueIndexName,
+							IndexColumns: columns[1:2],
+							IndexKeys:    []any{"foo@example.com"},
+						},
 					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    uniqueIndexName,
-						IndexColumns: columns[1:2],
-						IndexKeys:    []any{"foo@example.com"},
+					Filters: OneOrMore{
+						{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42))},
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -145,27 +153,35 @@ func TestTable_PlanQuery_MultipleIndexes(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    uniqueIndexName,
-						IndexColumns: columns[1:2],
-						IndexKeys:    []any{"foo@example.com"},
-					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexRange,
-						IndexName:    secondaryIndexName,
-						IndexColumns: columns[4:5],
-						RangeCondition: RangeCondition{
-							Lower: &RangeBound{
-								Value:     int64(MustParseTimestampMicros("2025-01-01 00:00:00")),
-								Inclusive: true,
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    uniqueIndexName,
+							IndexColumns: columns[1:2],
+							IndexKeys:    []any{"foo@example.com"},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexRange,
+							IndexName:    secondaryIndexName,
+							IndexColumns: columns[4:5],
+							RangeCondition: RangeCondition{
+								Lower: &RangeBound{
+									Value:     int64(MustParseTimestampMicros("2025-01-01 00:00:00")),
+									Inclusive: true,
+								},
 							},
 						},
 					},
-				},
+					Filters: OneOrMore{
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
+						{FieldIsGreaterOrEqual(Field{Name: "created"}, OperandQuotedString, MustParseTimestampMicros("2025-01-01 00:00:00"))},
+					},
+				}},
 			},
 		},
 		{

--- a/internal/minisql/query_plan_or_union_test.go
+++ b/internal/minisql/query_plan_or_union_test.go
@@ -1,0 +1,176 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestPlanQuery_ORUnion verifies that when every OR branch has its own index
+// the planner emits a single ScanTypeIndexUnion scan instead of two independent scans.
+func TestPlanQuery_ORUnion(t *testing.T) {
+	t.Parallel()
+
+	columns := []Column{
+		{Kind: Int8, Size: 8, Name: "id"},
+		{Kind: Varchar, Size: MaxInlineVarchar, Name: "status"},
+		{Kind: Varchar, Size: MaxInlineVarchar, Name: "priority"},
+		{Kind: Int8, Size: 8, Name: "score"},
+	}
+	statusIdx := "idx__items__status"
+	priorityIdx := "idx__items__priority"
+
+	table := NewTable(zap.NewNop(), nil, nil, "items", columns, 0, nil,
+		WithPrimaryKey(NewPrimaryKey("pkey__items", columns[0:1], true)),
+	)
+	table.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: statusIdx, Columns: columns[1:2]}})
+	table.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: priorityIdx, Columns: columns[2:3]}})
+
+	ctx := context.Background()
+
+	t.Run("or_two_indexes_produces_union_scan", func(t *testing.T) {
+		t.Parallel()
+		stmt := Statement{
+			Kind:      Select,
+			TableName: "items",
+			Columns:   columns,
+			Fields:    []Field{{Name: "*"}},
+			Conditions: OneOrMore{
+				{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("open")))},
+				{FieldIsEqual(Field{Name: "priority"}, OperandQuotedString, NewTextPointer([]byte("critical")))},
+			},
+		}
+
+		plan, err := table.PlanQuery(ctx, stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexUnion, plan.Scans[0].Type,
+			"two OR groups each with an index should yield union scan")
+		assert.Len(t, plan.Scans[0].SubScans, 2,
+			"one sub-scan per OR group")
+	})
+
+	t.Run("or_one_group_no_index_falls_back_to_sequential", func(t *testing.T) {
+		t.Parallel()
+		// score has no index → one group is not index-eligible → falls back to sequential.
+		stmt := Statement{
+			Kind:      Select,
+			TableName: "items",
+			Columns:   columns,
+			Fields:    []Field{{Name: "*"}},
+			Conditions: OneOrMore{
+				{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("open")))},
+				{FieldIsEqual(Field{Name: "score"}, OperandInteger, int64(100))},
+			},
+		}
+
+		plan, err := table.PlanQuery(ctx, stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeSequential, plan.Scans[0].Type,
+			"when any OR group lacks an index the plan must fall back to sequential scan")
+	})
+
+	t.Run("single_or_group_no_union", func(t *testing.T) {
+		t.Parallel()
+		// Only one AND group — no OR at the top level — should not produce a union scan.
+		stmt := Statement{
+			Kind:      Select,
+			TableName: "items",
+			Columns:   columns,
+			Fields:    []Field{{Name: "*"}},
+			Conditions: OneOrMore{
+				{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("open")))},
+			},
+		}
+
+		plan, err := table.PlanQuery(ctx, stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.NotEqual(t, ScanTypeIndexUnion, plan.Scans[0].Type,
+			"a single OR group must not be wrapped in a union scan")
+	})
+
+	t.Run("or_three_indexes_all_union", func(t *testing.T) {
+		t.Parallel()
+
+		scoreIdx := "idx__items__score"
+		table3 := NewTable(zap.NewNop(), nil, nil, "items", columns, 0, nil,
+			WithPrimaryKey(NewPrimaryKey("pkey__items", columns[0:1], true)),
+		)
+		table3.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: statusIdx, Columns: columns[1:2]}})
+		table3.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: priorityIdx, Columns: columns[2:3]}})
+		table3.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: scoreIdx, Columns: columns[3:4]}})
+
+		stmt := Statement{
+			Kind:      Select,
+			TableName: "items",
+			Columns:   columns,
+			Fields:    []Field{{Name: "*"}},
+			Conditions: OneOrMore{
+				{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("open")))},
+				{FieldIsEqual(Field{Name: "priority"}, OperandQuotedString, NewTextPointer([]byte("critical")))},
+				{FieldIsEqual(Field{Name: "score"}, OperandInteger, int64(100))},
+			},
+		}
+
+		plan, err := table3.PlanQuery(ctx, stmt)
+		require.NoError(t, err)
+		require.Len(t, plan.Scans, 1)
+		assert.Equal(t, ScanTypeIndexUnion, plan.Scans[0].Type)
+		assert.Len(t, plan.Scans[0].SubScans, 3, "three OR groups → three sub-scans")
+	})
+}
+
+// TestUnionSortedRowIDs verifies the sorted-union helper.
+func TestUnionSortedRowIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		sets [][]RowID
+		want []RowID
+	}{
+		{
+			name: "empty",
+			sets: nil,
+			want: nil,
+		},
+		{
+			name: "single set",
+			sets: [][]RowID{{3, 1, 2}},
+			want: []RowID{1, 2, 3},
+		},
+		{
+			name: "disjoint sets",
+			sets: [][]RowID{{1, 3}, {2, 4}},
+			want: []RowID{1, 2, 3, 4},
+		},
+		{
+			name: "overlapping sets",
+			sets: [][]RowID{{1, 2, 3}, {2, 3, 4}},
+			want: []RowID{1, 2, 3, 4},
+		},
+		{
+			name: "identical sets",
+			sets: [][]RowID{{1, 2, 3}, {1, 2, 3}},
+			want: []RowID{1, 2, 3},
+		},
+		{
+			name: "three sets with overlap",
+			sets: [][]RowID{{1, 4}, {2, 4}, {3, 4}},
+			want: []RowID{1, 2, 3, 4},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := unionSortedRowIDs(tc.sets)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/minisql/query_plan_primary_key_test.go
+++ b/internal/minisql/query_plan_primary_key_test.go
@@ -122,22 +122,30 @@ func TestTable_PlanQuery_PrimaryKey(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(42)},
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(42)},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(69)},
+						},
 					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(69)},
+					Filters: OneOrMore{
+						{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42))},
+						{FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69))},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -156,32 +164,42 @@ func TestTable_PlanQuery_PrimaryKey(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(42)},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(42)},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
-							},
+							}},
 						},
-					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(69)},
-						Filters: OneOrMore{
-							{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(69)},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
-							},
+							}},
 						},
 					},
-				},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
+						},
+					},
+				}},
 			},
 		},
 		{
@@ -199,27 +217,38 @@ func TestTable_PlanQuery_PrimaryKey(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(42)},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(42)},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
-							},
+							}},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							IndexKeys:    []any{int64(69)},
 						},
 					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						IndexKeys:    []any{int64(69)},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
+						},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -438,34 +467,45 @@ func TestTable_PlanQuery_PrimaryKey(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						RangeCondition: RangeCondition{
-							Lower: &RangeBound{
-								Value:     int64(42),
-								Inclusive: true,
+				Scans: []Scan{{
+					TableName: "users",
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							RangeCondition: RangeCondition{
+								Lower: &RangeBound{
+									Value:     int64(42),
+									Inclusive: true,
+								},
 							},
+						},
+						{
+							TableName:    "users",
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: testColumns[0:1],
+							RangeCondition: RangeCondition{
+								Upper: &RangeBound{
+									Value: int64(27),
+								},
+							},
+							Filters: OneOrMore{{
+								FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+							}},
 						},
 					},
-					{
-						TableName:    "users",
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: testColumns[0:1],
-						RangeCondition: RangeCondition{
-							Upper: &RangeBound{
-								Value: int64(27),
-							},
-						},
-						Filters: OneOrMore{{
+					Filters: OneOrMore{
+						{FieldIsGreaterOrEqual(Field{Name: "id"}, OperandInteger, int64(42))},
+						{
+							FieldIsLess(Field{Name: "id"}, OperandInteger, int64(27)),
 							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
-						}},
+						},
 					},
-				},
+				}},
 			},
 		},
 		{

--- a/internal/minisql/query_plan_secondary_index_test.go
+++ b/internal/minisql/query_plan_secondary_index_test.go
@@ -133,22 +133,30 @@ func TestTable_PlanQuery_SingleSecondaryIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"foo@example.com"},
+				Scans: []Scan{{
+					TableName: testTableName2,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"foo@example.com"},
+						},
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"bar@example.com"},
+						},
 					},
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"bar@example.com"},
+					Filters: OneOrMore{
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com")))},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -167,32 +175,42 @@ func TestTable_PlanQuery_SingleSecondaryIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"foo@example.com"},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: testTableName2,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"foo@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-							},
+							}},
 						},
-					},
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"bar@example.com"},
-						Filters: OneOrMore{
-							{
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"bar@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
-							},
+							}},
 						},
 					},
-				},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
+						},
+					},
+				}},
 			},
 		},
 		{
@@ -210,27 +228,38 @@ func TestTable_PlanQuery_SingleSecondaryIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"foo@example.com"},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: testTableName2,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"foo@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-							},
+							}},
+						},
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							IndexKeys:    []any{"bar@example.com"},
 						},
 					},
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						IndexKeys:    []any{"bar@example.com"},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
+						},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -449,34 +478,45 @@ func TestTable_PlanQuery_SingleSecondaryIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						RangeCondition: RangeCondition{
-							Lower: &RangeBound{
-								Value:     "foo@example.com",
-								Inclusive: true,
+				Scans: []Scan{{
+					TableName: testTableName2,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							RangeCondition: RangeCondition{
+								Lower: &RangeBound{
+									Value:     "foo@example.com",
+									Inclusive: true,
+								},
 							},
+						},
+						{
+							TableName:    testTableName2,
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: []Column{secondaryIndexColumn},
+							RangeCondition: RangeCondition{
+								Upper: &RangeBound{
+									Value: "qux@example.com",
+								},
+							},
+							Filters: OneOrMore{{
+								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							}},
 						},
 					},
-					{
-						TableName:    testTableName2,
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: []Column{secondaryIndexColumn},
-						RangeCondition: RangeCondition{
-							Upper: &RangeBound{
-								Value: "qux@example.com",
-							},
-						},
-						Filters: OneOrMore{{
+					Filters: OneOrMore{
+						{FieldIsGreaterOrEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
+						{
+							FieldIsLess(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("qux@example.com"))),
 							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-						}},
+						},
 					},
-				},
+				}},
 			},
 		},
 		{

--- a/internal/minisql/query_plan_unique_index_test.go
+++ b/internal/minisql/query_plan_unique_index_test.go
@@ -127,22 +127,30 @@ func TestTable_PlanQuery_SingleUniqueIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"foo@example.com"},
+				Scans: []Scan{{
+					TableName: testTableName,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"foo@example.com"},
+						},
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"bar@example.com"},
+						},
 					},
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"bar@example.com"},
+					Filters: OneOrMore{
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
+						{FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com")))},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -161,32 +169,42 @@ func TestTable_PlanQuery_SingleUniqueIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"foo@example.com"},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: testTableName,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"foo@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-							},
+							}},
 						},
-					},
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"bar@example.com"},
-						Filters: OneOrMore{
-							{
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"bar@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
-							},
+							}},
 						},
 					},
-				},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(69)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
+						},
+					},
+				}},
 			},
 		},
 		{
@@ -204,27 +222,38 @@ func TestTable_PlanQuery_SingleUniqueIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"foo@example.com"},
-						Filters: OneOrMore{
-							{
+				Scans: []Scan{{
+					TableName: testTableName,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"foo@example.com"},
+							Filters: OneOrMore{{
 								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-							},
+							}},
+						},
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexPoint,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							IndexKeys:    []any{"bar@example.com"},
 						},
 					},
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexPoint,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						IndexKeys:    []any{"bar@example.com"},
+					Filters: OneOrMore{
+						{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com"))),
+						},
+						{
+							FieldIsEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("bar@example.com"))),
+						},
 					},
-				},
+				}},
 			},
 		},
 		{
@@ -443,34 +472,45 @@ func TestTable_PlanQuery_SingleUniqueIndex(t *testing.T) {
 				},
 			},
 			QueryPlan{
-				Scans: []Scan{
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						RangeCondition: RangeCondition{
-							Lower: &RangeBound{
-								Value:     "foo@example.com",
-								Inclusive: true,
+				Scans: []Scan{{
+					TableName: testTableName,
+					Type:      ScanTypeIndexUnion,
+					SubScans: []Scan{
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							RangeCondition: RangeCondition{
+								Lower: &RangeBound{
+									Value:     "foo@example.com",
+									Inclusive: true,
+								},
 							},
+						},
+						{
+							TableName:    testTableName,
+							Type:         ScanTypeIndexRange,
+							IndexName:    indexName,
+							IndexColumns: testColumns[1:2],
+							RangeCondition: RangeCondition{
+								Upper: &RangeBound{
+									Value: "qux@example.com",
+								},
+							},
+							Filters: OneOrMore{{
+								FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
+							}},
 						},
 					},
-					{
-						TableName:    testTableName,
-						Type:         ScanTypeIndexRange,
-						IndexName:    indexName,
-						IndexColumns: testColumns[1:2],
-						RangeCondition: RangeCondition{
-							Upper: &RangeBound{
-								Value: "qux@example.com",
-							},
-						},
-						Filters: OneOrMore{{
+					Filters: OneOrMore{
+						{FieldIsGreaterOrEqual(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("foo@example.com")))},
+						{
+							FieldIsLess(Field{Name: "email"}, OperandQuotedString, NewTextPointer([]byte("qux@example.com"))),
 							FieldIsEqual(Field{Name: "id"}, OperandInteger, int64(42)),
-						}},
+						},
 					},
-				},
+				}},
 			},
 		},
 		{

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -2134,6 +2134,19 @@ func (t *Table) virtualSequentialScan(ctx context.Context, scan Scan, out func(R
 // collectRowIDsFromScan runs a sub-scan and collects all RowIDs it produces without
 // fetching table rows.  Supported sub-scan types: ScanTypeIndexPoint and ScanTypeIndexRange.
 func (t *Table) collectRowIDsFromScan(ctx context.Context, scan Scan) ([]RowID, error) {
+	// Intersect: recursively collect and intersect sub-scan RowID sets.
+	if scan.Type == ScanTypeIndexIntersect {
+		sets := make([][]RowID, 0, len(scan.SubScans))
+		for _, sub := range scan.SubScans {
+			ids, err := t.collectRowIDsFromScan(ctx, sub)
+			if err != nil {
+				return nil, err
+			}
+			sets = append(sets, ids)
+		}
+		return intersectSortedRowIDs(sets), nil
+	}
+
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return nil, fmt.Errorf("no index found for intersect sub-scan: %s", scan.IndexName)
@@ -2290,6 +2303,118 @@ func (t *Table) indexIntersectScan(ctx context.Context, scan Scan, selectedField
 
 		if err := out(row); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// unionTwoSortedSets returns the sorted, deduplicated union of two sorted RowID slices.
+func unionTwoSortedSets(a, b []RowID) []RowID {
+	result := make([]RowID, 0, len(a)+len(b))
+	emit := func(id RowID) {
+		if len(result) == 0 || result[len(result)-1] != id {
+			result = append(result, id)
+		}
+	}
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			emit(a[i])
+			i++
+			j++
+		case a[i] < b[j]:
+			emit(a[i])
+			i++
+		default:
+			emit(b[j])
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		emit(a[i])
+	}
+	for ; j < len(b); j++ {
+		emit(b[j])
+	}
+	return result
+}
+
+// unionSortedRowIDs sorts each input slice and returns their deduplicated union.
+func unionSortedRowIDs(sets [][]RowID) []RowID {
+	if len(sets) == 0 {
+		return nil
+	}
+	for i := range sets {
+		sortRowIDs(sets[i])
+	}
+	result := sets[0]
+	for _, next := range sets[1:] {
+		result = unionTwoSortedSets(result, next)
+	}
+	return result
+}
+
+// indexUnionScan executes a ScanTypeIndexUnion plan:
+//  1. Collect RowID sets from each OR-group sub-scan.
+//  2. Union (deduplicate) all sets in memory.
+//  3. Fetch each surviving row once and re-check the full WHERE clause.
+func (t *Table) indexUnionScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
+	sets := make([][]RowID, 0, len(scan.SubScans))
+	for _, sub := range scan.SubScans {
+		ids, err := t.collectRowIDsFromScan(ctx, sub)
+		if err != nil {
+			return err
+		}
+		sets = append(sets, ids)
+	}
+
+	surviving := unionSortedRowIDs(sets)
+	if len(surviving) == 0 {
+		return nil
+	}
+
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+
+	var emitted int64
+	scanLimit := scan.ScanLimit
+	for _, rowID := range surviving {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var row Row
+		if len(selectedFields) == 0 {
+			row = NewRowWithValues(t.Columns, nil)
+			row.Key = rowID
+		} else {
+			cursor, err := t.Seek(ctx, rowID)
+			if err != nil {
+				return fmt.Errorf("union seek: %w", err)
+			}
+			row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+			if err != nil {
+				return fmt.Errorf("union fetch: %w", err)
+			}
+		}
+
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		if err := out(row); err != nil {
+			return err
+		}
+		emitted++
+		if scanLimit > 0 && emitted >= scanLimit {
+			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION
  Old multi-scan behavior — the Execute loop runs each OR-group scan independently and calls out(row) for every match:                                                                                                                         
  
  for _, scan := range p.Scans {
      t.indexPointScan(ctx, scan, selectedFields, out) // emits rows
  }
  
  If row 3 (status='open' AND priority='critical') satisfies both OR groups, out is called twice for the same row — a duplicate result. The original test comment makes this explicit: // Row 3 must appear exactly once (deduplication).
  
  That was the bug the union scan fixes. Without it, WHERE status = 'open' OR priority = 'critical' would return row 3 twice.
  
  Union scan behavior:
  1. Traverse each index to collect RowID sets (same index I/O as before)
  2. Sorted merge-union the RowID sets → row 3's RowID appears once
  3. Fetch each unique row once from the B-tree heap
  4. Post-filter with the full DNF
  
  So there are two actual wins:
  - Correctness: No duplicate rows when a row satisfies multiple OR branches (this is the primary reason)
  - Perf: Each row is fetched from the B-tree only once, even if N indexes matched it (was N fetches before)
  
  The index traversal cost is the same either way — one scan per OR group regardless. The difference is what happens to the resulting rows.