### PR TITLE
feat: NDV and Most Common Values (MCV) Statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,50 @@ _, err := db.Exec(`ANALYZE;`)
 
 Without up-to-date statistics the planner may over- or under-estimate the selectivity of an index and choose a sequential scan instead.
 
+#### ANALYZE Statistics Format
+
+`ANALYZE` stores one row per object (table or index) in the internal `minisql_stats` table. You can inspect it directly:
+
+```sql
+SELECT * FROM minisql_stats;
+```
+
+**Table row** (no index name): a single decimal integer — the row count.
+
+```
+100
+```
+
+**Index row**: a space-separated list of numbers, optionally followed by a histogram and/or Most Common Values (MCV) suffix.
+
+```
+<nEntry> <nDistinct_prefix1> [<nDistinct_prefix2> ...][|h=<bounds>][|mcv=<values>]
+```
+
+| Component | Meaning |
+|-----------|---------|
+| `nEntry` | Total number of entries in the index (equals the table row count for non-partial indexes). |
+| `nDistinct_prefixN` | Number of distinct key combinations for the first N columns of the index. Composite indexes emit one value per prefix length. For unique indexes the last value equals `nEntry`. |
+| `\|h=b0,b1,...,bK` | Equi-depth histogram for the leading column (numeric/timestamp columns only). The K+1 comma-separated floats are bucket boundary values. Each of the K buckets holds approximately the same number of entries. Used by the planner to estimate range-scan selectivity. |
+| `\|mcv=v1:c1,v2:c2,...` | Most Common Values list (non-unique indexes only, up to 50 entries). Each entry is a URL-encoded value string and its occurrence count, sorted descending by count. Used by the planner for exact equality selectivity estimates. |
+
+**Example** — secondary index on a `status` column with 1 000 rows, 2 distinct values, and a skewed distribution:
+
+```
+1000 2|mcv=active%3A950,inactive%3A50
+```
+
+**Example** — primary key on a numeric `id` column with 10 000 rows (unique, so `nDistinct == nEntry`, histogram appended):
+
+```
+10000 10000|h=1,313,625,938,...,9998,10000
+```
+
+The planner uses statistics in two ways:
+
+- **Equality cost gate**: if the MCV list shows that an equality condition would match more than 30% of table rows, the planner falls back to a sequential scan instead of the index.
+- **Range cost gate**: if the histogram estimate shows a range condition would match more than 30% of rows, the planner likewise prefers a sequential scan.
+
 ### DROP INDEX
 
 ```go

--- a/internal/minisql/analyze.go
+++ b/internal/minisql/analyze.go
@@ -122,8 +122,12 @@ func (d *Database) Analyze(ctx context.Context, target string) error {
 		}
 	}
 
-	// Load stats into memory
-	stats, err := d.listStats(ctx, target)
+	// Load stats into memory using the statsTable object we already hold.
+	// We cannot use listStats here because it requires d.tables[StatsTableName]
+	// to be set, which only happens after SaveDDLChanges at transaction commit.
+	// When the stats table is brand-new (created in this same transaction),
+	// d.tables would not yet contain it.
+	stats, err := d.scanStatsTable(ctx, statsTable, target)
 	if err != nil {
 		return err
 	}
@@ -135,7 +139,9 @@ func (d *Database) Analyze(ctx context.Context, target string) error {
 		if err != nil {
 			return err
 		}
-		d.tables[s.TableName].indexStats[s.IndexName] = indexStats
+		if tbl, ok := d.tables[s.TableName]; ok {
+			tbl.indexStats[s.IndexName] = indexStats
+		}
 	}
 
 	return nil
@@ -226,9 +232,11 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		prefixMaps[i] = make(map[string]struct{})
 	}
 
-	// Collect first-column numeric values for histogram building.
+	// Collect first-column numeric values for histogram building and
+	// a frequency map for the MCV list.
 	collectHist := len(indexColumns) > 0 && isNumericColumn(indexColumns[0])
 	var histValues []float64
+	freq := make(map[string]int64)
 
 	if scanErr := index.ScanAll(ctx, false, func(key any, rowID RowID) error {
 		entryCount += 1
@@ -238,14 +246,18 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 				prefixKey := buildPrefixKey(ck.Values[:prefixLen])
 				prefixMaps[prefixLen-1][prefixKey] = struct{}{}
 			}
-			if collectHist && len(ck.Values) > 0 {
-				if f, ok := anyToFloat64(ck.Values[0]); ok {
-					histValues = append(histValues, f)
+			if len(ck.Values) > 0 {
+				freq[mcvKeyStr(ck.Values[0])]++
+				if collectHist {
+					if f, ok := anyToFloat64(ck.Values[0]); ok {
+						histValues = append(histValues, f)
+					}
 				}
 			}
 		} else {
-			keyStr := fmt.Sprintf("%v", key)
+			keyStr := mcvKeyStr(key)
 			prefixMaps[0][keyStr] = struct{}{}
+			freq[keyStr]++
 			if collectHist {
 				if f, ok := anyToFloat64(key); ok {
 					histValues = append(histValues, f)
@@ -273,6 +285,12 @@ func (d *Database) analyzeIndex(ctx context.Context, statsTable *Table, tableNam
 		sort.Float64s(histValues)
 		hist := buildEquiDepthHistogram(histValues, histogramBuckets)
 		serializeHistogram(&stat, hist)
+	}
+
+	// Build and append MCV list (skip for unique indexes: every value appears once).
+	if !isUnique {
+		mcv := buildMCV(freq, mcvMaxEntries)
+		serializeMCV(&stat, mcv)
 	}
 
 	_, err := statsTable.Insert(ctx, Statement{

--- a/internal/minisql/analyze_test.go
+++ b/internal/minisql/analyze_test.go
@@ -117,6 +117,7 @@ func TestDatabase_Analyze(t *testing.T) {
 	}, stats[2])
 
 	// Secondary index on created (Timestamp) — numeric, so a histogram suffix is appended.
+	// Also MCV (non-unique index) with |mcv= suffix.
 	assert.Equal(t, testTableName, stats[3].TableName)
 	assert.Equal(t, "idx_created", stats[3].IndexName)
 	assert.True(t, strings.HasPrefix(stats[3].StatValue, "100 10"), "created stat should start with '100 10'")
@@ -127,6 +128,108 @@ func TestDatabase_Analyze(t *testing.T) {
 	assert.NotNil(t, createdStats.Hist, "Timestamp index should have a histogram")
 	// 10 distinct timestamps — histogram has at most 10 distinct boundaries.
 	assert.GreaterOrEqual(t, len(createdStats.Hist.Bounds), 2)
+	// Non-unique secondary index collects MCV.
+	assert.NotEmpty(t, createdStats.MCV, "non-unique secondary index should have MCV entries")
+
+	mock.AssertExpectationsForObjects(t, mockParser)
+}
+
+func TestDatabase_Analyze_MCVGuidedPlanSelection(t *testing.T) {
+	var (
+		pager, dbFile = initTest(t)
+		mockParser    = new(MockParser)
+		ctx           = context.Background()
+		indexName     = "idx_status"
+		statusColumns = []Column{
+			{Kind: Int8, Size: 8, Name: "id"},
+			{Kind: Varchar, Size: 50, Name: "status", Nullable: true},
+		}
+	)
+
+	aDatabase, err := NewDatabase(ctx, testLogger, dbFile.Name(), mockParser, pager, pager, nil)
+	require.NoError(t, err)
+
+	stmt := Statement{
+		Kind:       CreateTable,
+		TableName:  testTableName,
+		Columns:    statusColumns,
+		PrimaryKey: NewPrimaryKey(PrimaryKeyName(testTableName), statusColumns[0:1], true),
+	}
+	mockParser.On("Parse", mock.Anything, stmt.DDL()).Return([]Statement{stmt}, nil)
+	err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := aDatabase.ExecuteStatement(ctx, stmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	createIndexStmt := Statement{
+		Kind:      CreateIndex,
+		IndexName: indexName,
+		TableName: testTableName,
+		Columns:   statusColumns[1:2],
+	}
+	err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		_, err := aDatabase.ExecuteStatement(ctx, createIndexStmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Insert 1000 rows: 950 "active", 50 "inactive".
+	insertStmt := Statement{
+		Kind:    Insert,
+		Fields:  fieldsFromColumns(statusColumns...),
+		Inserts: [][]OptionalValue{},
+	}
+	for i := range 1000 {
+		status := "active"
+		if i < 50 {
+			status = "inactive"
+		}
+		insertStmt.Inserts = append(insertStmt.Inserts, []OptionalValue{
+			{Value: int64(i + 1), Valid: true},
+			{Value: NewTextPointer([]byte(status)), Valid: true},
+		})
+	}
+	mustInsert(ctx, t, aDatabase.tables[testTableName], aDatabase.txManager, insertStmt)
+
+	err = aDatabase.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		return aDatabase.Analyze(ctx, testTableName)
+	})
+	require.NoError(t, err)
+
+	// Verify MCV was collected.
+	statusStats := aDatabase.tables[testTableName].indexStats[indexName]
+	assert.Equal(t, int64(1000), statusStats.NEntry)
+	require.NotEmpty(t, statusStats.MCV)
+	// Dominant value ("active") should be first (sorted desc by count).
+	assert.Equal(t, "active", statusStats.MCV[0].Value)
+	assert.Equal(t, int64(950), statusStats.MCV[0].Count)
+
+	// Dominant value: 95% selectivity → should fall back to sequential scan.
+	activeQuery := Statement{
+		Kind: Select,
+		Conditions: OneOrMore{
+			{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("active")))},
+		},
+	}
+	activePlan, err := aDatabase.tables[testTableName].PlanQuery(ctx, activeQuery)
+	require.NoError(t, err)
+	require.Len(t, activePlan.Scans, 1)
+	assert.Equal(t, ScanTypeSequential, activePlan.Scans[0].Type,
+		"dominant value should trigger sequential scan fallback")
+
+	// Rare value: 5% selectivity → should use index point scan.
+	inactiveQuery := Statement{
+		Kind: Select,
+		Conditions: OneOrMore{
+			{FieldIsEqual(Field{Name: "status"}, OperandQuotedString, NewTextPointer([]byte("inactive")))},
+		},
+	}
+	inactivePlan, err := aDatabase.tables[testTableName].PlanQuery(ctx, inactiveQuery)
+	require.NoError(t, err)
+	require.Len(t, inactivePlan.Scans, 1)
+	assert.Equal(t, ScanTypeIndexPoint, inactivePlan.Scans[0].Type,
+		"rare value should use index point scan")
 
 	mock.AssertExpectationsForObjects(t, mockParser)
 }

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -340,6 +340,9 @@ type indexMatch struct {
 	stats               *IndexStats
 	info                IndexInfo
 	keys                []any
+	// estKeyStr is the MCV lookup key for the first equality key — populated
+	// only for single-value Eq conditions; empty for IN or composite paths.
+	estKeyStr           string
 	hasProperUpperBound bool
 	isPrimaryKey        bool
 	isUnique            bool
@@ -801,10 +804,18 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 		indexKeys = compositeKey
 	}
 
+	// For single-value single-column equality, capture the key as a string
+	// for MCV lookup in the planner's cost gate.
+	var estKeyStr string
+	if rangeCondition == nil && len(indexKeys) == 1 {
+		estKeyStr = mcvKeyStr(indexKeys[0])
+	}
+
 	match := &indexMatch{
 		info:                indexInfo,
 		matchedConditions:   matchedConditions,
 		keys:                indexKeys,
+		estKeyStr:           estKeyStr,
 		rangeCondition:      rangeCondition,
 		hasProperUpperBound: hasProperUpperBound,
 		isPrimaryKey:        isPK,
@@ -1069,6 +1080,21 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 						intersectScan.Filters = OneOrMore{remaining}
 					}
 					indexScans = append(indexScans, intersectScan)
+					continue
+				}
+			}
+
+			// Equality cost gate: if MCV/NDV statistics indicate the index is not
+			// selective enough (estimated rows > 30% of table), fall back to a
+			// sequential scan for this OR group.
+			if match.rangeCondition == nil && match.estKeyStr != "" && match.stats != nil {
+				tableRows := t.estimatedRowCount()
+				if !shouldUseIndexForEquality(match.stats, match.estKeyStr, tableRows) {
+					indexScans = append(indexScans, Scan{
+						TableName: t.Name,
+						Type:      ScanTypeSequential,
+						Filters:   OneOrMore{group},
+					})
 					continue
 				}
 			}

--- a/internal/minisql/query_plan_stats.go
+++ b/internal/minisql/query_plan_stats.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +12,9 @@ const (
 	// histogramBuckets is the number of equi-depth histogram buckets built
 	// during ANALYZE for numeric index columns.
 	histogramBuckets = 32
+
+	// mcvMaxEntries is the maximum number of Most Common Values kept per index.
+	mcvMaxEntries = 50
 
 	// Cost thresholds for index vs table scan decision
 	indexScanThreshold = 0.3 // If index scan returns >30% of rows, table scan may be faster
@@ -28,11 +32,26 @@ type Histogram struct {
 	Bounds []float64
 }
 
+// MCVEntry is one entry in the Most Common Values list for an index column.
+// Value is the string representation of the index key (as produced by
+// mcvKeyStr). Count is the number of index entries with that exact value.
+type MCVEntry struct {
+	Value string
+	Count int64
+}
+
 // IndexStats holds parsed statistics for an index
 type IndexStats struct {
 	NDistinct []int64
 	NEntry    int64
 	Hist      *Histogram // nil when not collected or column type is non-numeric
+	MCV       []MCVEntry // top-K most common values, descending by Count; nil when not collected
+}
+
+// mcvKeyStr converts an index key value to the canonical string used as the
+// MCV map key during ANALYZE and as the lookup key in the planner.
+func mcvKeyStr(v any) string {
+	return fmt.Sprintf("%v", v)
 }
 
 // isNumericColumn reports whether c supports histogram collection.
@@ -145,6 +164,73 @@ func estimateSelectivityWithHistogram(hist *Histogram, rc RangeCondition) float6
 	return sel
 }
 
+// buildMCV selects the top-n most frequent entries from freq and returns them
+// sorted descending by count. Entries with the same count are ordered arbitrarily.
+func buildMCV(freq map[string]int64, n int) []MCVEntry {
+	type pair struct {
+		key   string
+		count int64
+	}
+	pairs := make([]pair, 0, len(freq))
+	for k, c := range freq {
+		pairs = append(pairs, pair{k, c})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].count > pairs[j].count
+	})
+	if len(pairs) > n {
+		pairs = pairs[:n]
+	}
+	mcv := make([]MCVEntry, len(pairs))
+	for i, p := range pairs {
+		mcv[i] = MCVEntry{Value: p.key, Count: p.count}
+	}
+	return mcv
+}
+
+// serializeMCV appends the MCV list to a stat string builder.
+// Format: "|mcv=encval1:count1,encval2:count2,..."
+// Values are URL-encoded so commas and colons inside values are safe.
+func serializeMCV(b *strings.Builder, mcv []MCVEntry) {
+	if len(mcv) == 0 {
+		return
+	}
+	b.WriteString("|mcv=")
+	for i, e := range mcv {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(url.QueryEscape(e.Value))
+		b.WriteByte(':')
+		b.WriteString(strconv.FormatInt(e.Count, 10))
+	}
+}
+
+// parseMCV parses a "|mcv=..." string produced by serializeMCV.
+func parseMCV(s string) ([]MCVEntry, error) {
+	if s == "" {
+		return nil, nil
+	}
+	entries := strings.Split(s, ",")
+	mcv := make([]MCVEntry, 0, len(entries))
+	for _, entry := range entries {
+		k, v, ok := strings.Cut(entry, ":")
+		if !ok {
+			continue
+		}
+		decoded, err := url.QueryUnescape(k)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MCV key %q: %w", k, err)
+		}
+		count, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MCV count %q: %w", v, err)
+		}
+		mcv = append(mcv, MCVEntry{Value: decoded, Count: count})
+	}
+	return mcv, nil
+}
+
 // serializeHistogram appends the histogram to a stat string builder.
 func serializeHistogram(b *strings.Builder, h *Histogram) {
 	if h == nil || len(h.Bounds) == 0 {
@@ -177,11 +263,24 @@ func parseHistogram(s string) (*Histogram, error) {
 	return &Histogram{Bounds: bounds}, nil
 }
 
-// parseIndexStats parses a stat string: "nEntry nDistinct1 [nDistinct2 ...][|h=b0,b1,...]"
+// parseIndexStats parses a stat string:
+// "nEntry nDistinct1 [nDistinct2 ...][|h=b0,b1,...][|mcv=val1:count1,...]"
 func parseIndexStats(statString string) (IndexStats, error) {
 	mainPart := statString
 	var hist *Histogram
-	if before, histStr, ok := strings.Cut(statString, "|h="); ok {
+	var mcv []MCVEntry
+
+	// Strip |mcv= suffix first (it comes after |h= if both are present).
+	if before, mcvStr, ok := strings.Cut(mainPart, "|mcv="); ok {
+		mainPart = before
+		var err error
+		mcv, err = parseMCV(mcvStr)
+		if err != nil {
+			return IndexStats{}, err
+		}
+	}
+
+	if before, histStr, ok := strings.Cut(mainPart, "|h="); ok {
 		mainPart = before
 		var err error
 		hist, err = parseHistogram(histStr)
@@ -213,6 +312,7 @@ func parseIndexStats(statString string) (IndexStats, error) {
 		NEntry:    nEntry,
 		NDistinct: nDistinct,
 		Hist:      hist,
+		MCV:       mcv,
 	}, nil
 }
 
@@ -229,6 +329,38 @@ func (s IndexStats) Selectivity() float64 {
 	// Use the last nDistinct value (most specific prefix)
 	finalDistinct := s.NDistinct[len(s.NDistinct)-1]
 	return float64(finalDistinct) / float64(s.NEntry)
+}
+
+// EstimateEqualityRows estimates the number of rows that will match an equality
+// condition on the leading column of this index for the given key string.
+//
+// Lookup order:
+//  1. MCV list — if keyStr is in the top-K, return the exact stored count.
+//  2. NDV fallback — return NEntry / NDistinct[0] (average rows per distinct value).
+//  3. Worst case — return NEntry when no statistics are available.
+func (s IndexStats) EstimateEqualityRows(keyStr string) int64 {
+	for _, e := range s.MCV {
+		if e.Value == keyStr {
+			return e.Count
+		}
+	}
+	if len(s.NDistinct) > 0 && s.NDistinct[0] > 0 {
+		return s.NEntry / s.NDistinct[0]
+	}
+	return s.NEntry
+}
+
+// shouldUseIndexForEquality returns true when an equality index scan is
+// estimated to be cheaper than a full sequential scan. tableRows is the
+// current estimated row count for the table (from estimatedRowCount()).
+// When tableRows <= 0 (unavailable) the function defaults to using the index.
+func shouldUseIndexForEquality(stats *IndexStats, keyStr string, tableRows int64) bool {
+	if stats == nil || tableRows <= 0 {
+		return true
+	}
+	estimated := stats.EstimateEqualityRows(keyStr)
+	selectivity := float64(estimated) / float64(tableRows)
+	return selectivity <= indexScanThreshold
 }
 
 // EstimateRangeRows estimates the number of rows that will match a range condition.

--- a/internal/minisql/query_plan_stats_test.go
+++ b/internal/minisql/query_plan_stats_test.go
@@ -1,7 +1,6 @@
 package minisql
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -9,599 +8,161 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestParseIndexStats tests the stat string parsing
-func TestParseIndexStats(t *testing.T) {
+func TestBuildMCV(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name        string
-		statString  string
-		expected    IndexStats
-		expectError bool
-	}{
-		{
-			name:       "single column index",
-			statString: "1000 500",
-			expected: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			expectError: false,
-		},
-		{
-			name:       "composite index",
-			statString: "1000 10 50 800",
-			expected: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{10, 50, 800},
-			},
-			expectError: false,
-		},
-		{
-			name:        "invalid format - too few parts",
-			statString:  "1000",
-			expectError: true,
-		},
-		{
-			name:        "invalid format - non-numeric nEntry",
-			statString:  "abc 500",
-			expectError: true,
-		},
-		{
-			name:        "invalid format - non-numeric nDistinct",
-			statString:  "1000 abc",
-			expectError: true,
-		},
-		{
-			name:        "empty string",
-			statString:  "",
-			expectError: true,
-		},
+	freq := map[string]int64{
+		"open":    900,
+		"closed":  80,
+		"pending": 20,
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stats, err := parseIndexStats(tt.statString)
-			if tt.expectError {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected.NEntry, stats.NEntry)
-			assert.Equal(t, tt.expected.NDistinct, stats.NDistinct)
-		})
-	}
+	mcv := buildMCV(freq, 2)
+	require.Len(t, mcv, 2)
+	assert.Equal(t, "open", mcv[0].Value)
+	assert.Equal(t, int64(900), mcv[0].Count)
+	assert.Equal(t, "closed", mcv[1].Value)
+	assert.Equal(t, int64(80), mcv[1].Count)
 }
 
-// TestIndexStats_Selectivity tests the selectivity calculation
-func TestIndexStats_Selectivity(t *testing.T) {
+func TestBuildMCV_EmptyFreq(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name      string
-		stats     IndexStats
-		expected  float64
-		tolerance float64
-	}{
-		{
-			name: "single column 50% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			expected:  0.5,
-			tolerance: 0.01,
-		},
-		{
-			name: "single column 100% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{1000},
-			},
-			expected:  1.0,
-			tolerance: 0.01,
-		},
-		{
-			name: "single column 1% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{10},
-			},
-			expected:  0.01,
-			tolerance: 0.001,
-		},
-		{
-			name: "composite index - uses final prefix",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{10, 50, 800},
-			},
-			expected:  0.8, // Uses last value: 800/1000
-			tolerance: 0.01,
-		},
-		{
-			name: "zero entries",
-			stats: IndexStats{
-				NEntry:    0,
-				NDistinct: []int64{0},
-			},
-			expected:  0.0,
-			tolerance: 0.0,
-		},
-		{
-			name: "no distinct values",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{},
-			},
-			expected:  0.0,
-			tolerance: 0.0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			selectivity := tt.stats.Selectivity()
-			assert.InDelta(t, tt.expected, selectivity, tt.tolerance)
-		})
-	}
+	assert.Empty(t, buildMCV(nil, 50))
 }
 
-func TestIndexStats_EstimateRangeRows(t *testing.T) {
+func TestBuildMCV_FewerThanN(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		rangeCondition RangeCondition
-		name           string
-		stats          IndexStats
-		want           int64
-	}{
-		{
-			name: "both bounds - 30% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-				Upper: &RangeBound{Value: 50, Inclusive: true},
-			},
-			want: 300, // 1000 * 0.3
-		},
-		{
-			name: "lower bound only - 50% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 500, Inclusive: true},
-			},
-			want: 500, // 1000 * 0.5
-		},
-		{
-			name: "upper bound only - 50% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{
-				Upper: &RangeBound{Value: 500, Inclusive: false},
-			},
-			want: 500, // 1000 * 0.5
-		},
-		{
-			name: "no bounds - 100% selectivity",
-			stats: IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{},
-			want:           1000, // 1000 * 1.0
-		},
-		{
-			name: "no stats - returns -1",
-			stats: IndexStats{
-				NEntry:    0,
-				NDistinct: []int64{},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-			},
-			want: -1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := tt.stats.EstimateRangeRows(tt.rangeCondition, 0)
-			assert.Equal(t, tt.want, got, "estimateRangeSelectivity() = %v, want %v", got, tt.want)
-		})
-	}
+	freq := map[string]int64{"a": 5, "b": 3}
+	mcv := buildMCV(freq, 50)
+	assert.Len(t, mcv, 2)
 }
 
-func TestEstimateRangeSelectivity(t *testing.T) {
+func TestSerializeParseMCV_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		rangeCondition RangeCondition
-		name           string
-		want           float64
-	}{
-		{
-			name: "both bounds",
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-				Upper: &RangeBound{Value: 50, Inclusive: true},
-			},
-			want: 0.3,
-		},
-		{
-			name: "lower bound only",
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 500, Inclusive: true},
-			},
-			want: 0.5,
-		},
-		{
-			name: "upper bound only",
-			rangeCondition: RangeCondition{
-				Upper: &RangeBound{Value: 500, Inclusive: false},
-			},
-			want: 0.5,
-		},
-		{
-			name:           "no bounds",
-			rangeCondition: RangeCondition{},
-			want:           1.0,
-		},
+	input := []MCVEntry{
+		{Value: "open", Count: 900},
+		{Value: "a,b:c", Count: 50}, // commas and colons must be URL-encoded
+		{Value: "42", Count: 10},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	var sb strings.Builder
+	serializeMCV(&sb, input)
+	s := sb.String()
+	require.NotEmpty(t, s)
 
-			got := estimateRangeSelectivity(tt.rangeCondition)
-			assert.Equal(t, tt.want, got, "estimateRangeSelectivity() = %v, want %v", got, tt.want)
-		})
-	}
+	const prefix = "|mcv="
+	require.True(t, strings.HasPrefix(s, prefix))
+	got, err := parseMCV(s[len(prefix):])
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "open", got[0].Value)
+	assert.Equal(t, int64(900), got[0].Count)
+	assert.Equal(t, "a,b:c", got[1].Value)
+	assert.Equal(t, int64(50), got[1].Count)
+	assert.Equal(t, "42", got[2].Value)
+	assert.Equal(t, int64(10), got[2].Count)
 }
 
-func TestShouldUseIndexForRange(t *testing.T) {
+func TestSerializeMCV_Empty(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		rangeCondition RangeCondition
-		stats          *IndexStats
-		name           string
-		want           bool
-	}{
-		{
-			name: "selective range - use index (30% < threshold)",
-			stats: &IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-				Upper: &RangeBound{Value: 50, Inclusive: true},
-			},
-			want: true, // 30% selectivity < 30% threshold, but it's equal so treated as selective
-		},
-		{
-			name: "non-selective range - don't use index (50% > threshold)",
-			stats: &IndexStats{
-				NEntry:    1000,
-				NDistinct: []int64{500},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 500, Inclusive: true},
-			},
-			want: false, // 50% selectivity > 30% threshold
-		},
-		{
-			name:  "no stats - default to using index",
-			stats: nil,
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-			},
-			want: true,
-		},
-		{
-			name: "empty stats - default to using index",
-			stats: &IndexStats{
-				NEntry:    0,
-				NDistinct: []int64{},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 10, Inclusive: true},
-			},
-			want: true,
-		},
-		{
-			name: "highly selective range - use index",
-			stats: &IndexStats{
-				NEntry:    10000,
-				NDistinct: []int64{5000},
-			},
-			rangeCondition: RangeCondition{
-				Lower: &RangeBound{Value: 100, Inclusive: true},
-				Upper: &RangeBound{Value: 200, Inclusive: true},
-			},
-			want: true, // 30% selectivity <= threshold
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := shouldUseIndexForRange(tt.stats, tt.rangeCondition)
-			assert.Equal(t, tt.want, got, "shouldUseIndexForRange() = %v, want %v", got, tt.want)
-		})
-	}
+	var sb strings.Builder
+	serializeMCV(&sb, nil)
+	assert.Empty(t, sb.String())
 }
 
-func TestBuildEquiDepthHistogram(t *testing.T) {
+func TestParseMCV_Empty(t *testing.T) {
+	t.Parallel()
+	got, err := parseMCV("")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestParseIndexStats_WithMCV(t *testing.T) {
+	t.Parallel()
+	stat := "1000 5 |h=1,2,3|mcv=open:900,closed:80"
+	s, err := parseIndexStats(stat)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000), s.NEntry)
+	require.Len(t, s.NDistinct, 1)
+	assert.Equal(t, int64(5), s.NDistinct[0])
+	require.NotNil(t, s.Hist)
+	require.Len(t, s.MCV, 2)
+	assert.Equal(t, "open", s.MCV[0].Value)
+	assert.Equal(t, int64(900), s.MCV[0].Count)
+}
+
+func TestParseIndexStats_MCVOnly(t *testing.T) {
+	t.Parallel()
+	stat := "500 3|mcv=foo:400,bar:100"
+	s, err := parseIndexStats(stat)
+	require.NoError(t, err)
+	assert.Equal(t, int64(500), s.NEntry)
+	assert.Nil(t, s.Hist)
+	require.Len(t, s.MCV, 2)
+	assert.Equal(t, "foo", s.MCV[0].Value)
+}
+
+func TestParseIndexStats_NoMCV(t *testing.T) {
+	t.Parallel()
+	// Existing format without MCV must still parse.
+	stat := "200 10 |h=1,10,100"
+	s, err := parseIndexStats(stat)
+	require.NoError(t, err)
+	assert.Equal(t, int64(200), s.NEntry)
+	assert.Nil(t, s.MCV)
+}
+
+func TestEstimateEqualityRows(t *testing.T) {
 	t.Parallel()
 
-	t.Run("uniform_distribution", func(t *testing.T) {
+	s := IndexStats{
+		NEntry:    1000,
+		NDistinct: []int64{5},
+		MCV: []MCVEntry{
+			{Value: "open", Count: 900},
+			{Value: "closed", Count: 80},
+		},
+	}
+
+	t.Run("mcv_hit_exact", func(t *testing.T) {
 		t.Parallel()
-		sorted := make([]float64, 100)
-		for i := range sorted {
-			sorted[i] = float64(i + 1)
-		}
-		h := buildEquiDepthHistogram(sorted, 10)
-		require.NotNil(t, h)
-		assert.Len(t, h.Bounds, 11) // numBuckets+1
-		assert.Equal(t, float64(1), h.Bounds[0])
-		assert.Equal(t, float64(100), h.Bounds[10])
+		assert.Equal(t, int64(900), s.EstimateEqualityRows("open"))
+		assert.Equal(t, int64(80), s.EstimateEqualityRows("closed"))
 	})
 
-	t.Run("fewer_values_than_buckets", func(t *testing.T) {
+	t.Run("mcv_miss_ndv_fallback", func(t *testing.T) {
 		t.Parallel()
-		sorted := []float64{1, 2, 3}
-		h := buildEquiDepthHistogram(sorted, 10)
-		require.NotNil(t, h)
-		// Capped at n=3 buckets → 4 bounds
-		assert.Len(t, h.Bounds, 4)
+		// "pending" not in MCV → NEntry/NDistinct = 1000/5 = 200
+		assert.Equal(t, int64(200), s.EstimateEqualityRows("pending"))
 	})
 
-	t.Run("empty_slice_returns_nil", func(t *testing.T) {
+	t.Run("no_ndv_returns_nentry", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, buildEquiDepthHistogram(nil, 10))
-		assert.Nil(t, buildEquiDepthHistogram([]float64{}, 10))
-	})
-
-	t.Run("zero_buckets_returns_nil", func(t *testing.T) {
-		t.Parallel()
-		assert.Nil(t, buildEquiDepthHistogram([]float64{1, 2, 3}, 0))
+		empty := IndexStats{NEntry: 500}
+		assert.Equal(t, int64(500), empty.EstimateEqualityRows("anything"))
 	})
 }
 
-func TestHistogramCDF(t *testing.T) {
-	t.Parallel()
-	// 4 buckets: [0,25), [25,50), [50,75), [75,100] → bounds = [0,25,50,75,100]
-	bounds := []float64{0, 25, 50, 75, 100}
-
-	t.Run("below_min_returns_0", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, 0.0, histogramCDF(bounds, -1))
-	})
-
-	t.Run("at_min_returns_0", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, 0.0, histogramCDF(bounds, 0))
-	})
-
-	t.Run("at_max_returns_1", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, 1.0, histogramCDF(bounds, 100))
-	})
-
-	t.Run("midpoint_of_first_bucket", func(t *testing.T) {
-		t.Parallel()
-		// v=12.5 is midpoint of [0,25) → bucket 0, within=0.5 → 0 + 0.5/4 = 0.125
-		got := histogramCDF(bounds, 12.5)
-		assert.InDelta(t, 0.125, got, 0.001)
-	})
-
-	t.Run("midpoint_of_second_bucket", func(t *testing.T) {
-		t.Parallel()
-		// v=37.5 is midpoint of [25,50) → bucket 1, within=0.5 → 1/4 + 0.5/4 = 0.375
-		got := histogramCDF(bounds, 37.5)
-		assert.InDelta(t, 0.375, got, 0.001)
-	})
-
-	t.Run("at_bucket_boundary", func(t *testing.T) {
-		t.Parallel()
-		// v=50 is at start of bucket 2: [50,75) → bucket 2, within=0 → 2/4 = 0.5
-		got := histogramCDF(bounds, 50)
-		assert.InDelta(t, 0.5, got, 0.001)
-	})
-}
-
-func TestEstimateSelectivityWithHistogram(t *testing.T) {
-	t.Parallel()
-	// Uniform 0..100, 10 buckets: [0,10,20,30,40,50,60,70,80,90,100]
-	bounds := make([]float64, 11)
-	for i := range bounds {
-		bounds[i] = float64(i * 10)
-	}
-	hist := &Histogram{Bounds: bounds}
-
-	t.Run("no_histogram_falls_back_to_fixed_constants", func(t *testing.T) {
-		t.Parallel()
-		rc := RangeCondition{Lower: &RangeBound{Value: int64(10), Inclusive: true}}
-		got := estimateSelectivityWithHistogram(nil, rc)
-		assert.Equal(t, 0.5, got) // fixed constant for single bound
-	})
-
-	t.Run("lower_bound_only", func(t *testing.T) {
-		t.Parallel()
-		// value > 50 → 1 - CDF(50) = 1 - 0.5 = 0.5
-		rc := RangeCondition{Lower: &RangeBound{Value: int64(50), Inclusive: false}}
-		got := estimateSelectivityWithHistogram(hist, rc)
-		assert.InDelta(t, 0.5, got, 0.01)
-	})
-
-	t.Run("upper_bound_only", func(t *testing.T) {
-		t.Parallel()
-		// value < 30 → CDF(30) = 0.3
-		rc := RangeCondition{Upper: &RangeBound{Value: int64(30), Inclusive: false}}
-		got := estimateSelectivityWithHistogram(hist, rc)
-		assert.InDelta(t, 0.3, got, 0.01)
-	})
-
-	t.Run("both_bounds", func(t *testing.T) {
-		t.Parallel()
-		// 20 < value < 60 → CDF(60) - CDF(20) = 0.6 - 0.2 = 0.4
-		rc := RangeCondition{
-			Lower: &RangeBound{Value: int64(20), Inclusive: false},
-			Upper: &RangeBound{Value: int64(60), Inclusive: false},
-		}
-		got := estimateSelectivityWithHistogram(hist, rc)
-		assert.InDelta(t, 0.4, got, 0.01)
-	})
-
-	t.Run("non_convertible_bound_falls_back_to_fixed", func(t *testing.T) {
-		t.Parallel()
-		// string value can't be converted → lower stays 0, upper stays 1 for unbounded
-		rc := RangeCondition{Lower: &RangeBound{Value: "text", Inclusive: true}}
-		got := estimateSelectivityWithHistogram(hist, rc)
-		// lower=0 (failed conversion), upper=1.0 → sel = 1.0
-		assert.Equal(t, 1.0, got)
-	})
-}
-
-func TestParseIndexStats_WithHistogram(t *testing.T) {
+func TestShouldUseIndexForEquality(t *testing.T) {
 	t.Parallel()
 
-	t.Run("parses_histogram_bounds", func(t *testing.T) {
-		t.Parallel()
-		s := "100 50|h=1,25,50,75,100"
-		stats, err := parseIndexStats(s)
-		require.NoError(t, err)
-		assert.Equal(t, int64(100), stats.NEntry)
-		assert.Equal(t, []int64{50}, stats.NDistinct)
-		require.NotNil(t, stats.Hist)
-		assert.Equal(t, []float64{1, 25, 50, 75, 100}, stats.Hist.Bounds)
-	})
-
-	t.Run("no_histogram_section", func(t *testing.T) {
-		t.Parallel()
-		stats, err := parseIndexStats("100 50")
-		require.NoError(t, err)
-		assert.Nil(t, stats.Hist)
-	})
-
-	t.Run("invalid_histogram_bound", func(t *testing.T) {
-		t.Parallel()
-		_, err := parseIndexStats("100 50|h=1,abc,100")
-		assert.Error(t, err)
-	})
-}
-
-func TestSerializeHistogram(t *testing.T) {
-	t.Parallel()
-
-	t.Run("nil_histogram_writes_nothing", func(t *testing.T) {
-		t.Parallel()
-		var b strings.Builder
-		serializeHistogram(&b, nil)
-		assert.Empty(t, b.String())
-	})
-
-	t.Run("serializes_bounds", func(t *testing.T) {
-		t.Parallel()
-		var b strings.Builder
-		h := &Histogram{Bounds: []float64{0, 50, 100}}
-		serializeHistogram(&b, h)
-		assert.Equal(t, "|h=0,50,100", b.String())
-	})
-
-	t.Run("roundtrip", func(t *testing.T) {
-		t.Parallel()
-		sorted := make([]float64, 100)
-		for i := range sorted {
-			sorted[i] = float64(i + 1)
-		}
-		h := buildEquiDepthHistogram(sorted, 16)
-		require.NotNil(t, h)
-
-		var b strings.Builder
-		fmt.Fprintf(&b, "%d %d", 100, 100)
-		serializeHistogram(&b, h)
-
-		parsed, err := parseIndexStats(b.String())
-		require.NoError(t, err)
-		require.NotNil(t, parsed.Hist)
-		assert.Equal(t, len(h.Bounds), len(parsed.Hist.Bounds))
-		for i := range h.Bounds {
-			assert.InDelta(t, h.Bounds[i], parsed.Hist.Bounds[i], 0.0001)
-		}
-	})
-}
-
-func TestEstimateRangeRows_WithHistogram(t *testing.T) {
-	t.Parallel()
-
-	// Build histogram for values 1..100
-	sorted := make([]float64, 100)
-	for i := range sorted {
-		sorted[i] = float64(i + 1)
-	}
-	hist := buildEquiDepthHistogram(sorted, 10)
-
-	stats := IndexStats{
-		NEntry:    100,
-		NDistinct: []int64{100},
-		Hist:      hist,
+	stats := &IndexStats{
+		NEntry:    1000,
+		NDistinct: []int64{5},
+		MCV: []MCVEntry{
+			{Value: "open", Count: 900}, // 90% → prefer sequential
+			{Value: "rare", Count: 10},  // 1%  → use index
+		},
 	}
 
-	t.Run("narrow_range_uses_histogram", func(t *testing.T) {
-		t.Parallel()
-		// value between 40 and 60 should be ~20 rows
-		rc := RangeCondition{
-			Lower: &RangeBound{Value: int64(40), Inclusive: true},
-			Upper: &RangeBound{Value: int64(60), Inclusive: true},
-		}
-		got := stats.EstimateRangeRows(rc, 0)
-		assert.InDelta(t, 20, float64(got), 5.0)
-	})
+	assert.False(t, shouldUseIndexForEquality(stats, "open", 1000),
+		"90% selectivity should skip the index")
+	assert.True(t, shouldUseIndexForEquality(stats, "rare", 1000),
+		"1% selectivity should use index")
 
-	t.Run("full_range_returns_all", func(t *testing.T) {
-		t.Parallel()
-		rc := RangeCondition{
-			Lower: &RangeBound{Value: int64(1), Inclusive: true},
-			Upper: &RangeBound{Value: int64(100), Inclusive: true},
-		}
-		got := stats.EstimateRangeRows(rc, 0)
-		assert.InDelta(t, 100, float64(got), 5.0)
-	})
-}
+	// Missing stats → always use index.
+	assert.True(t, shouldUseIndexForEquality(nil, "any", 1000))
 
-func TestAnyToFloat64(t *testing.T) {
-	t.Parallel()
-
-	v, ok := anyToFloat64(int32(3))
-	assert.True(t, ok)
-	assert.Equal(t, float64(3), v)
-
-	v, ok = anyToFloat64(int64(10))
-	assert.True(t, ok)
-	assert.Equal(t, float64(10), v)
-
-	v, ok = anyToFloat64(float32(1.5))
-	assert.True(t, ok)
-	assert.InDelta(t, float64(float32(1.5)), v, 1e-6)
-
-	v, ok = anyToFloat64(float64(2.5))
-	assert.True(t, ok)
-	assert.Equal(t, 2.5, v)
-
-	_, ok = anyToFloat64("not a number")
-	assert.False(t, ok)
+	// Unknown table row count → always use index.
+	assert.True(t, shouldUseIndexForEquality(stats, "open", 0))
+	assert.True(t, shouldUseIndexForEquality(stats, "open", -1))
 }


### PR DESCRIPTION
  Implementation (query_plan_stats.go, analyze.go, query_plan.go):
  - MCVEntry struct and buildMCV/serializeMCV/parseMCV helpers; stat string format extended with |mcv=urlenc_val:count,... suffix
  - analyzeIndex tracks a frequency map and writes the MCV list for every non-unique secondary index
  - estKeyStr field on indexMatch captures the equality key for MCV lookup; setIndexScans applies the equality cost gate — if MCV/NDV estimates show > 30% selectivity, falls back to sequential scan for that OR group
  
  Bug fix (analyze.go): Analyze was using listStats (which requires the stats table to already be in d.tables) to reload in-memory stats. On the first ever Analyze call the stats table is created inside the transaction, so d.tables doesn't have it yet and listStats silently
  returned nil. Fixed to use scanStatsTable directly on the statsTable object already in hand.
  
  Tests: 10 unit tests in query_plan_stats_test.go; TestDatabase_Analyze_MCVGuidedPlanSelection integration test that inserts 1000 rows with 95%/5% skew, runs Analyze, and verifies the dominant value triggers sequential scan fallback while the rare value uses the index.
  
  README: Added "ANALYZE Statistics Format" subsection under "Updating Statistics for the Planner" explaining the full nEntry nDistinct...|h=...|mcv=... format.