### PR TITLE
feat: greedy join order optimisation

### DIFF
--- a/e2e_tests/explain_join_test.go
+++ b/e2e_tests/explain_join_test.go
@@ -85,7 +85,11 @@ func (s *TestSuite) TestExplainJoin() {
 		_, err = s.db.Exec(`insert into "ej_tags" (user_id, tag) values (1, 'vip'), (2, 'new')`)
 		s.Require().NoError(err)
 
-		// ej_tags has NO index on user_id → join from ej_users → ej_tags uses hash join.
+		// ej_tags (2 rows) < ej_users (3 rows): greedy join reordering promotes
+		// ej_tags to the outer/base position and ej_users to the inner position.
+		// ej_users has a PK on user_id, so the planner uses indexed nested-loop —
+		// strictly better than the hash join the user-specified order would have
+		// produced.
 		rows := s.collectExplain(`
 			EXPLAIN SELECT u.name, t.tag
 			FROM "ej_users" AS u
@@ -93,8 +97,10 @@ func (s *TestSuite) TestExplainJoin() {
 
 		joinRow := s.findExplainRow(rows, "join")
 		s.Require().NotNil(joinRow, "expected a 'join' row")
-		s.Contains(joinRow.Detail, "algorithm=hash")
 		s.Contains(joinRow.Detail, "type=inner")
+		s.Contains(joinRow.Detail, "algorithm=nested_loop")
+		s.Contains(joinRow.Detail, "left=t")
+		s.Contains(joinRow.Detail, "right=u")
 	})
 
 	s.Run("left_join", func() {

--- a/e2e_tests/join_reorder_test.go
+++ b/e2e_tests/join_reorder_test.go
@@ -1,0 +1,149 @@
+package e2etests
+
+import (
+	"fmt"
+	"sort"
+)
+
+// TestGreedyJoinReorder verifies that the greedy join-reorder optimisation
+// produces correct query results when it changes the join order, and that the
+// EXPLAIN plan reflects the new order.
+//
+// The test creates two tables where the user writes the larger table first in
+// FROM/JOIN but the planner should swap them so the smaller table is the outer
+// (base) loop.
+func (s *TestSuite) TestGreedyJoinReorder() {
+	// "categories" — small reference table (3 rows).
+	_, err := s.db.Exec(`create table "gr_categories" (
+		cat_id   int8 primary key autoincrement,
+		label    varchar(50) not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "gr_categories" (label) values
+		('alpha'), ('beta'), ('gamma')`)
+	s.Require().NoError(err)
+
+	// "items" — larger fact table (30 rows), each referencing a category.
+	_, err = s.db.Exec(`create table "gr_items" (
+		item_id  int8 primary key autoincrement,
+		cat_id   int8 not null,
+		name     varchar(50) not null
+	)`)
+	s.Require().NoError(err)
+
+	for i := 1; i <= 30; i++ {
+		catID := ((i - 1) % 3) + 1
+		_, err = s.db.Exec(
+			`insert into "gr_items" (cat_id, name) values (?, ?)`,
+			catID, fmt.Sprintf("item-%02d", i),
+		)
+		s.Require().NoError(err)
+	}
+
+	s.Run("results_correct_after_reorder", func() {
+		// User writes items (larger, 30 rows) as the base, categories (smaller, 3 rows)
+		// as the join.  Greedy reordering should swap them: categories (3) becomes
+		// the outer loop, items (30) is joined via its PK.
+		// The result set must be the same regardless of execution order.
+		rows, err := s.db.Query(`
+			select i.name, c.label
+			from   "gr_items"      AS i
+			inner join "gr_categories" AS c ON i.cat_id = c.cat_id
+			order by i.name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct{ name, label string }
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.name, &r.label))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 30, "all 30 items must appear in the result")
+
+		// Collect all item names per label and sort.
+		byLabel := make(map[string][]string)
+		for _, r := range got {
+			byLabel[r.label] = append(byLabel[r.label], r.name)
+		}
+		s.Require().Len(byLabel, 3, "all 3 categories should appear")
+		for _, names := range byLabel {
+			s.Require().Len(names, 10, "each category has exactly 10 items")
+		}
+	})
+
+	s.Run("plan_reflects_reorder", func() {
+		// EXPLAIN should show categories (c, 3 rows) as the left (base) side and
+		// items (i, 30 rows) as the right side after greedy reordering.
+		rows := s.collectExplain(`
+			EXPLAIN SELECT i.name, c.label
+			FROM "gr_items" AS i
+			INNER JOIN "gr_categories" AS c ON i.cat_id = c.cat_id`)
+
+		joinRow := s.findExplainRow(rows, "join")
+		s.Require().NotNil(joinRow, "expected a join row in EXPLAIN output")
+		s.Contains(joinRow.Detail, "type=inner")
+		// Greedy: categories (3) < items (30) → c is left, i is right.
+		// items has a PK on item_id but NOT on cat_id.
+		// categories has a PK on cat_id → items joins categories via PK → nested_loop.
+		s.Contains(joinRow.Detail, "left=c")
+		s.Contains(joinRow.Detail, "right=i")
+	})
+
+	s.Run("three_table_chain_correct", func() {
+		// Add a third table: "gr_tags" (2 rows per category = 6 rows total).
+		_, err := s.db.Exec(`create table "gr_tags" (
+			tag_id  int8 primary key autoincrement,
+			cat_id  int8 not null,
+			tag     varchar(20) not null
+		)`)
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`insert into "gr_tags" (cat_id, tag) values
+			(1,'t1'),(1,'t2'),(2,'t3'),(2,'t4'),(3,'t5'),(3,'t6')`)
+		s.Require().NoError(err)
+
+		// User writes: items (30) JOIN categories (3) JOIN tags (6).
+		// Greedy should reorder to: categories (3) JOIN items (30) JOIN tags (6)
+		// or categories (3) JOIN tags (6) JOIN items (30), depending on reachability.
+		// Either way the result count must be correct.
+		rows, err := s.db.Query(`
+			select i.name, c.label, t.tag
+			from   "gr_items"      AS i
+			inner join "gr_categories" AS c ON i.cat_id = c.cat_id
+			inner join "gr_tags"       AS t ON c.cat_id = t.cat_id
+			order by i.name, t.tag`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct{ name, label, tag string }
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.name, &r.label, &r.tag))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		// 30 items × 2 tags per category = 60 rows.
+		s.Require().Len(got, 60, "30 items × 2 tags per category = 60 rows")
+
+		// Every item name should appear exactly twice (once per tag for its category).
+		nameCount := make(map[string]int)
+		for _, r := range got {
+			nameCount[r.name]++
+		}
+		for name, cnt := range nameCount {
+			s.Equal(2, cnt, "item %s should appear twice (once per tag)", name)
+		}
+
+		// Collect distinct item names — should be 30.
+		names := make([]string, 0, len(nameCount))
+		for n := range nameCount {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		s.Len(names, 30)
+	})
+}

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -25,7 +25,18 @@ func chanRowCallback(ctx context.Context, ch chan<- Row) func(Row) error {
 // 1. Use index on inner table join column when available (index nested loop join).
 // 2. Push single-table WHERE conditions into individual table scans.
 // 3. Use index scans for pushed-down conditions when a matching index exists.
+// 4. Greedy join reordering: when all tables have ANALYZE statistics and all
+//    joins are INNER, reorders the join sequence so the smallest tables are
+//    processed first, minimising intermediate result sizes.
 func (t *Table) planJoinQuery(ctx context.Context, stmt Statement) (QueryPlan, error) {
+	// Attempt greedy join reordering when statistics are available.
+	if plan, ok, err := t.planJoinQueryGreedy(ctx, stmt); err != nil {
+		return QueryPlan{}, err
+	} else if ok {
+		return plan, nil
+	}
+
+	// Fallback: user-specified order.
 	baseTableFilters, joinTableFilters := pushDownFilters(stmt.Conditions, stmt.TableAlias, stmt.Joins)
 
 	plan := QueryPlan{
@@ -45,6 +56,316 @@ func (t *Table) planJoinQuery(ctx context.Context, stmt Statement) (QueryPlan, e
 
 	return plan, nil
 }
+
+// joinGraphNode is one participant (table) in the join graph used for greedy reordering.
+type joinGraphNode struct {
+	tableName  string
+	tableAlias string
+	table      *Table
+	rows       int64 // estimated row count from ANALYZE; -1 if unknown
+}
+
+// joinGraphEdge is an undirected edge in the join graph: the ON conditions
+// connecting two aliases, plus the join type.  Conditions are stored verbatim
+// from the parser — they identify both endpoints by alias prefix so they
+// remain correct regardless of which end is treated as "left" vs "right".
+type joinGraphEdge struct {
+	alias1     string
+	alias2     string
+	conditions Conditions
+	joinType   JoinType
+}
+
+// collectJoinGraph walks the join tree rooted at stmt and returns the set of
+// joinGraphNodes (one per table, including the base) and joinGraphEdges (one
+// per Join clause).  Returns (nil, nil, false) when the tree contains a join
+// whose FromTableAlias cannot be resolved — indicating a topology too complex
+// for greedy reordering.
+func (t *Table) collectJoinGraph(ctx context.Context, stmt Statement) ([]joinGraphNode, []joinGraphEdge, bool) {
+	nodes := []joinGraphNode{{
+		tableName:  t.Name,
+		tableAlias: stmt.TableAlias,
+		table:      t,
+		rows:       t.estimatedRowCount(),
+	}}
+	aliasSet := map[string]struct{}{stmt.TableAlias: {}}
+	var edges []joinGraphEdge
+
+	var walk func(joins []Join) bool
+	walk = func(joins []Join) bool {
+		for _, j := range joins {
+			fromAlias := j.FromTableAlias()
+			if fromAlias == "" {
+				return false // cannot determine connectivity — abort
+			}
+			jTable, ok := t.provider.GetTable(ctx, j.TableName)
+			if !ok {
+				return false
+			}
+			nodes = append(nodes, joinGraphNode{
+				tableName:  j.TableName,
+				tableAlias: j.TableAlias,
+				table:      jTable,
+				rows:       jTable.estimatedRowCount(),
+			})
+			aliasSet[j.TableAlias] = struct{}{}
+			edges = append(edges, joinGraphEdge{
+				alias1:     fromAlias,
+				alias2:     j.TableAlias,
+				conditions: j.Conditions,
+				joinType:   j.Type,
+			})
+			if !walk(j.Joins) {
+				return false
+			}
+		}
+		return true
+	}
+	if !walk(stmt.Joins) {
+		return nil, nil, false
+	}
+	return nodes, edges, true
+}
+
+// greedyJoinOrder returns a reordered sequence of joinGraphNodes and, for each
+// node beyond the first (the new base), the edge that connects it to the
+// already-processed set.  The algorithm is greedy nearest-neighbour: start with
+// the node with the fewest estimated rows, then at each step extend with the
+// cheapest reachable node.
+//
+// Returns (nil, nil, false) when:
+//   - any estimated row count is -1 (no ANALYZE data),
+//   - any join is not INNER (outer joins are order-sensitive), or
+//   - the graph is disconnected (should never happen for a valid SQL JOIN).
+func greedyJoinOrder(nodes []joinGraphNode, edges []joinGraphEdge) ([]joinGraphNode, []joinGraphEdge, bool) {
+	// Eligibility: all INNER, all rows known.
+	for _, e := range edges {
+		if e.joinType != Inner {
+			return nil, nil, false
+		}
+	}
+	for _, n := range nodes {
+		if n.rows < 0 {
+			return nil, nil, false
+		}
+	}
+
+	// Build adjacency: alias → list of incident edges.
+	adj := make(map[string][]int, len(nodes)) // alias → edge indices
+	for i, e := range edges {
+		adj[e.alias1] = append(adj[e.alias1], i)
+		adj[e.alias2] = append(adj[e.alias2], i)
+	}
+
+	// Find the node with fewest rows to start.
+	startIdx := 0
+	for i, n := range nodes {
+		if n.rows < nodes[startIdx].rows {
+			startIdx = i
+		}
+	}
+
+	done := make(map[string]struct{}, len(nodes))
+	remaining := make(map[string]int, len(nodes)) // alias → nodes index
+	for i, n := range nodes {
+		remaining[n.tableAlias] = i
+	}
+
+	orderedNodes := make([]joinGraphNode, 0, len(nodes))
+	orderedEdges := make([]joinGraphEdge, 0, len(nodes)-1) // one per join (excludes base)
+
+	start := nodes[startIdx]
+	orderedNodes = append(orderedNodes, start)
+	done[start.tableAlias] = struct{}{}
+	delete(remaining, start.tableAlias)
+
+	for len(remaining) > 0 {
+		// Find the cheapest node reachable from any done node.
+		bestNodeIdx := -1
+		bestEdgeIdx := -1
+		bestRows := int64(-1)
+
+		for doneAlias := range done {
+			for _, edgeIdx := range adj[doneAlias] {
+				e := edges[edgeIdx]
+				// Determine the other endpoint.
+				var otherAlias string
+				if e.alias1 == doneAlias {
+					otherAlias = e.alias2
+				} else {
+					otherAlias = e.alias1
+				}
+				nodeIdx, stillPending := remaining[otherAlias]
+				if !stillPending {
+					continue
+				}
+				n := nodes[nodeIdx]
+				if bestNodeIdx == -1 || n.rows < bestRows {
+					bestNodeIdx = nodeIdx
+					bestEdgeIdx = edgeIdx
+					bestRows = n.rows
+				}
+			}
+		}
+
+		if bestNodeIdx == -1 {
+			// Graph is disconnected — cannot reorder safely.
+			return nil, nil, false
+		}
+
+		chosen := nodes[bestNodeIdx]
+		orderedNodes = append(orderedNodes, chosen)
+		orderedEdges = append(orderedEdges, edges[bestEdgeIdx])
+		done[chosen.tableAlias] = struct{}{}
+		delete(remaining, chosen.tableAlias)
+	}
+
+	return orderedNodes, orderedEdges, true
+}
+
+// planJoinQueryGreedy attempts greedy join reordering. Returns (plan, true, nil)
+// when reordering is applied; (QueryPlan{}, false, nil) when the plan falls
+// back to user order; (QueryPlan{}, false, err) on a hard error.
+func (t *Table) planJoinQueryGreedy(ctx context.Context, stmt Statement) (QueryPlan, bool, error) {
+	nodes, edges, ok := t.collectJoinGraph(ctx, stmt)
+	if !ok {
+		return QueryPlan{}, false, nil
+	}
+
+	orderedNodes, orderedEdges, ok := greedyJoinOrder(nodes, edges)
+	if !ok {
+		return QueryPlan{}, false, nil
+	}
+
+	// If the greedy order matches the user order exactly, fall through to the
+	// normal path so existing test expectations are not perturbed.
+	if orderedNodes[0].tableAlias == stmt.TableAlias {
+		userOrderPreserved := true
+		for i, j := range stmt.Joins {
+			if i+1 >= len(orderedNodes) || orderedNodes[i+1].tableAlias != j.TableAlias {
+				userOrderPreserved = false
+				break
+			}
+		}
+		if userOrderPreserved {
+			return QueryPlan{}, false, nil
+		}
+	}
+
+	// Build per-alias filters (push-down regardless of which table is base).
+	allFilters := make(map[string]OneOrMore, len(nodes))
+	{
+		baseFilters, joinFilters := pushDownFilters(stmt.Conditions, stmt.TableAlias, stmt.Joins)
+		allFilters[stmt.TableAlias] = baseFilters
+		for alias, f := range joinFilters {
+			allFilters[alias] = f
+		}
+	}
+
+	plan := QueryPlan{
+		OrderBy:      stmt.OrderBy,
+		SortInMemory: len(stmt.OrderBy) > 0,
+		Joins:        make([]JoinPlan, 0, len(orderedNodes)-1),
+		Scans:        make([]Scan, 0, len(orderedNodes)),
+	}
+
+	newBase := orderedNodes[0]
+	plan.Scans = append(plan.Scans, planJoinTableScan(
+		newBase.table, newBase.tableName, newBase.tableAlias,
+		allFilters[newBase.tableAlias],
+	))
+	scanIndexByAlias := map[string]int{newBase.tableAlias: 0}
+
+	for i, node := range orderedNodes[1:] {
+		edge := orderedEdges[i]
+
+		// Determine from-alias: the endpoint of this edge that is already done.
+		fromAlias := edge.alias1
+		if _, done := scanIndexByAlias[fromAlias]; !done {
+			fromAlias = edge.alias2
+		}
+		leftScanIndex := scanIndexByAlias[fromAlias]
+
+		var fromTable *Table
+		if leftScanIndex == 0 {
+			fromTable = newBase.table
+		} else {
+			fromTableName := plan.Scans[leftScanIndex].TableName
+			ft, ftOk := t.provider.GetTable(ctx, fromTableName)
+			if !ftOk {
+				return QueryPlan{}, false, fmt.Errorf("%w: %s", errTableDoesNotExist, fromTableName)
+			}
+			fromTable = ft
+		}
+
+		joinColumnPairs, err := extractJoinColumnPairs(
+			edge.conditions, fromAlias, node.tableAlias,
+			fromTable, node.table,
+		)
+		if err != nil {
+			return QueryPlan{}, false, err
+		}
+
+		joinTableColumns := make([]string, len(joinColumnPairs))
+		for j, pair := range joinColumnPairs {
+			joinTableColumns[j] = pair.JoinTableColumn.Name
+		}
+		joinTableIndex := node.table.findIndexOnColumns(joinTableColumns)
+
+		var (
+			innerScanType  ScanType
+			innerIndexInfo *IndexInfo
+			algorithm      JoinAlgorithm
+		)
+		if joinTableIndex != nil {
+			innerScanType = ScanTypeIndexPoint
+			innerIndexInfo = joinTableIndex
+			algorithm = JoinAlgorithmNestedLoop
+		} else {
+			innerScanType = ScanTypeSequential
+			buildRows := node.rows
+			if buildRows < 0 || buildRows <= hashJoinMaxBuildRows {
+				algorithm = JoinAlgorithmHash
+			} else {
+				algorithm = JoinAlgorithmNestedLoop
+			}
+		}
+
+		var joinScan Scan
+		if innerScanType == ScanTypeSequential {
+			joinScan = planJoinTableScan(node.table, node.tableName, node.tableAlias, allFilters[node.tableAlias])
+		} else {
+			joinScan = Scan{
+				TableName:  node.tableName,
+				TableAlias: node.tableAlias,
+				Type:       innerScanType,
+				Filters:    allFilters[node.tableAlias],
+			}
+			if innerIndexInfo != nil {
+				joinScan.IndexName = innerIndexInfo.Name
+				joinScan.IndexColumns = innerIndexInfo.Columns
+			}
+		}
+
+		plan.Scans = append(plan.Scans, joinScan)
+		rightScanIndex := len(plan.Scans) - 1
+		scanIndexByAlias[node.tableAlias] = rightScanIndex
+
+		plan.Joins = append(plan.Joins, JoinPlan{
+			Type:            Inner,
+			LeftScanIndex:   leftScanIndex,
+			RightScanIndex:  rightScanIndex,
+			Conditions:      edge.conditions,
+			OuterJoinColumn: joinColumnPairs[0].BaseTableColumn.Name,
+			InnerJoinColumn: joinColumnPairs[0].JoinTableColumn.Name,
+			JoinColumnPairs: joinColumnPairs,
+			Algorithm:       algorithm,
+		})
+	}
+
+	return plan, true, nil
+}
+
 
 // flattenJoinTree recursively walks the join tree in DFS order and appends one
 // Scan and one JoinPlan entry per join node. LeftScanIndex is set to the scan

--- a/internal/minisql/query_plan_join_test.go
+++ b/internal/minisql/query_plan_join_test.go
@@ -640,3 +640,108 @@ func TestFindIndexOnColumns(t *testing.T) {
 		assert.Nil(t, info)
 	})
 }
+
+func TestGreedyJoinOrder_StarSchema(t *testing.T) {
+	t.Parallel()
+
+	// Three tables: A (1000 rows), B (10 rows), C (500 rows).
+	// Greedy should start with B, then pick C before A.
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: 1000},
+		{tableAlias: "b", rows: 10},
+		{tableAlias: "c", rows: 500},
+	}
+	// Star schema: all join to "a".
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Inner},
+		{alias1: "a", alias2: "c", joinType: Inner},
+	}
+
+	orderedNodes, orderedEdges, ok := greedyJoinOrder(nodes, edges)
+	require.True(t, ok)
+	require.Len(t, orderedNodes, 3)
+	require.Len(t, orderedEdges, 2)
+
+	// B is smallest → first.
+	assert.Equal(t, "b", orderedNodes[0].tableAlias)
+	// Next reachable from B via edges: A (via edge a-b). C is NOT reachable from B directly
+	// (edge a-c connects a and c, neither of which is done). So A must come before C.
+	assert.Equal(t, "a", orderedNodes[1].tableAlias)
+	// Once A is done, C becomes reachable.
+	assert.Equal(t, "c", orderedNodes[2].tableAlias)
+}
+
+func TestGreedyJoinOrder_ChainSchema(t *testing.T) {
+	t.Parallel()
+
+	// Chain: A → B → C, row counts A=1000, B=5, C=200.
+	// Connectivity: edge a-b and edge b-c.
+	// Greedy: start B (5), then A (1000, reachable via a-b) or C (200, reachable via b-c).
+	// C (200) < A (1000) → pick C next, then A.
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: 1000},
+		{tableAlias: "b", rows: 5},
+		{tableAlias: "c", rows: 200},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Inner},
+		{alias1: "b", alias2: "c", joinType: Inner},
+	}
+
+	orderedNodes, orderedEdges, ok := greedyJoinOrder(nodes, edges)
+	require.True(t, ok)
+	require.Len(t, orderedNodes, 3)
+	require.Len(t, orderedEdges, 2)
+
+	assert.Equal(t, "b", orderedNodes[0].tableAlias)
+	assert.Equal(t, "c", orderedNodes[1].tableAlias)
+	assert.Equal(t, "a", orderedNodes[2].tableAlias)
+}
+
+func TestGreedyJoinOrder_FallbackOnOuterJoin(t *testing.T) {
+	t.Parallel()
+
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: 100},
+		{tableAlias: "b", rows: 5},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Left}, // non-INNER → ineligible
+	}
+
+	_, _, ok := greedyJoinOrder(nodes, edges)
+	assert.False(t, ok, "should fall back when any join is not INNER")
+}
+
+func TestGreedyJoinOrder_FallbackOnUnknownRowCount(t *testing.T) {
+	t.Parallel()
+
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: -1}, // unknown
+		{tableAlias: "b", rows: 50},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Inner},
+	}
+
+	_, _, ok := greedyJoinOrder(nodes, edges)
+	assert.False(t, ok, "should fall back when any table has unknown row count")
+}
+
+func TestGreedyJoinOrder_UserOrderPreservedWhenAlreadyOptimal(t *testing.T) {
+	t.Parallel()
+
+	// A (10 rows) is already smallest — greedy produces same order as user.
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: 10},
+		{tableAlias: "b", rows: 500},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Inner},
+	}
+
+	orderedNodes, _, ok := greedyJoinOrder(nodes, edges)
+	require.True(t, ok)
+	assert.Equal(t, "a", orderedNodes[0].tableAlias)
+	assert.Equal(t, "b", orderedNodes[1].tableAlias)
+}


### PR DESCRIPTION
Join order was fixed to the user-specified order before. For a 3-table join where table sizes differ by orders of magnitude, this can produce poor plans. The fix is a greedy nearest-neighbor algorithm: start with the smallest table, then greedily add the next join whose left-side table is already "done", preferring the smallest remaining table.