### PR TITLE
feat: bloom filter on hash join build side

### DIFF
--- a/internal/minisql/hash_join.go
+++ b/internal/minisql/hash_join.go
@@ -5,15 +5,30 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/RichardKnop/minisql/pkg/bloom"
+)
+
+const (
+	// bloomFPRate is the target false-positive rate for the per-bucket Bloom
+	// filter. At 1%, the filter rejects ~99% of definite misses without a
+	// hash-map probe, while adding negligible memory overhead.
+	bloomFPRate = 0.01
+	// bloomMinN is the minimum expected-element count passed to bloom.New when
+	// the inner table has no row-count estimate. Sized for small tables.
+	bloomMinN = 512
 )
 
 // hashJoinBucket is the in-memory hash table built from the inner (build) side
 // of a single hash join.  The map key is a null-byte-delimited encoding of the
 // join column values; the value is the list of inner rows sharing that key.
 // innerColumns is kept to construct NULL rows for LEFT JOIN misses.
+// filter is a Bloom filter over the same key set used to reject probe keys
+// that are definitely not present, avoiding an unnecessary map lookup.
 type hashJoinBucket struct {
 	rows         map[string][]Row
 	innerColumns []Column
+	filter       *bloom.Filter
 }
 
 // buildHashBuckets scans the build side of every JoinAlgorithmHash join in the
@@ -30,9 +45,16 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 		if !ok {
 			return nil, fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
 		}
+		// Size the Bloom filter using the inner table's row-count estimate.
+		// Fall back to bloomMinN when no statistics are available.
+		n := innerTable.estimatedRowCount()
+		if n <= 0 {
+			n = bloomMinN
+		}
 		bucket := &hashJoinBucket{
 			rows:         make(map[string][]Row),
 			innerColumns: innerTable.Columns,
+			filter:       bloom.New(uint(n), bloomFPRate),
 		}
 		innerFields := fieldsFromColumns(innerTable.Columns...)
 		if err := runTableScan(ctx, plan, innerTable, innerScan, innerFields, func(row Row) error {
@@ -41,6 +63,7 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 				return nil // NULL join key — never matches
 			}
 			bucket.rows[key] = append(bucket.rows[key], row)
+			bucket.filter.Add([]byte(key))
 			return nil
 		}); err != nil {
 			return nil, fmt.Errorf("hash join build phase (join %d): %w", i, err)

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -977,7 +977,11 @@ func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, jo
 	probeKey := probeSideHashKey(join, currentRow, fromAlias, joinIndex)
 	var matchingRows []Row
 	if probeKey != "" && bucket != nil {
-		matchingRows = bucket.rows[probeKey]
+		// Check the Bloom filter before touching the hash map: if the filter
+		// says the key is definitely absent, skip the map probe entirely.
+		if bucket.filter.MayContain([]byte(probeKey)) {
+			matchingRows = bucket.rows[probeKey]
+		}
 	}
 
 	matched := false

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -1,0 +1,114 @@
+// Package bloom provides a space-efficient probabilistic set-membership filter.
+// MayContain returns false only when an element is definitely absent; it may
+// return true for elements never added (false positives). No false negatives
+// are possible.
+//
+// The filter uses the enhanced double-hashing scheme from Kirsch & Mitzenmacher
+// (2006): two base FNV hashes produce k independent bit positions per element
+// without needing k separate hash functions.
+package bloom
+
+import (
+	"hash/fnv"
+	"math"
+)
+
+// Filter is a Bloom filter backed by a compact bit array.
+type Filter struct {
+	bits []uint64 // bit array, len = ceil(m/64)
+	m    uint64   // total number of bits
+	k    uint     // number of hash functions
+}
+
+// New returns a Filter sized for n expected elements at false-positive
+// probability p. p must be in (0,1); n must be > 0.
+func New(n uint, p float64) *Filter {
+	if n == 0 {
+		n = 1
+	}
+	if p <= 0 || p >= 1 {
+		p = 0.01
+	}
+	m := optimalM(n, p)
+	return &Filter{
+		bits: make([]uint64, m/64),
+		m:    m,
+		k:    optimalK(m, n),
+	}
+}
+
+// Add inserts data into the filter.
+func (f *Filter) Add(data []byte) {
+	h1, h2 := baseHashes(data)
+	for i := uint(0); i < f.k; i++ {
+		bit := (h1 + uint64(i)*h2) % f.m
+		f.bits[bit>>6] |= 1 << (bit & 63)
+	}
+}
+
+// MayContain reports whether data might be in the set. Returns false only when
+// data is definitely absent.
+func (f *Filter) MayContain(data []byte) bool {
+	h1, h2 := baseHashes(data)
+	for i := uint(0); i < f.k; i++ {
+		bit := (h1 + uint64(i)*h2) % f.m
+		if f.bits[bit>>6]&(1<<(bit&63)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// M returns the total number of bits in the filter.
+func (f *Filter) M() uint64 { return f.m }
+
+// K returns the number of hash functions used.
+func (f *Filter) K() uint { return f.k }
+
+// baseHashes returns two independent 64-bit hashes of data. h1 is FNV-1a;
+// h2 is derived via the Murmur3 64-bit finalizer to ensure good bit diffusion
+// and avoid the h2≈0 collapse that degrades double-hashing to a single function.
+func baseHashes(data []byte) (uint64, uint64) {
+	h := fnv.New64a()
+	h.Write(data)
+	h1 := h.Sum64()
+	h2 := mix64(h1)
+	if h2 == 0 {
+		h2 = 1 // prevent all k positions from collapsing to h1%m
+	}
+	return h1, h2
+}
+
+// mix64 applies the Murmur3 64-bit finalizer to diffuse all bits of h.
+func mix64(h uint64) uint64 {
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	h *= 0xc4ceb9fe1a85ec53
+	h ^= h >> 33
+	return h
+}
+
+// optimalM computes the optimal bit-array size for n elements at false-positive
+// probability p, rounded up to the nearest multiple of 64.
+func optimalM(n uint, p float64) uint64 {
+	// Optimal bit count: -n·ln(p) / ln(2)².
+	raw := math.Ceil(-float64(n) * math.Log(p) / (math.Ln2 * math.Ln2))
+	// Round up to a multiple of 64 so the []uint64 slice has no wasted slots.
+	words := uint64(math.Ceil(raw / 64))
+	if words == 0 {
+		words = 1
+	}
+	return words * 64
+}
+
+// optimalK computes the optimal number of hash functions for a filter of m bits
+// and n expected elements.
+func optimalK(m uint64, n uint) uint {
+	// Optimal hash-function count: (m/n)·ln(2).
+	k := math.Round(float64(m) / float64(n) * math.Ln2)
+	if k < 1 {
+		return 1
+	}
+	return uint(k)
+}

--- a/pkg/bloom/bloom_test.go
+++ b/pkg/bloom/bloom_test.go
@@ -1,0 +1,153 @@
+package bloom
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_OptimalSizing(t *testing.T) {
+	t.Parallel()
+	f := New(1000, 0.01)
+	require.NotNil(t, f)
+	// m must be a multiple of 64.
+	assert.Equal(t, uint64(0), f.M()%64)
+	// k must be at least 1.
+	assert.GreaterOrEqual(t, f.K(), uint(1))
+}
+
+func TestNew_ZeroN_Clamped(t *testing.T) {
+	t.Parallel()
+	// n=0 should be clamped to 1, not panic.
+	f := New(0, 0.01)
+	require.NotNil(t, f)
+	assert.Greater(t, f.M(), uint64(0))
+}
+
+func TestNew_BadFPRate_Clamped(t *testing.T) {
+	t.Parallel()
+	// Invalid p values fall back to 0.01.
+	f1 := New(100, 0)
+	f2 := New(100, 1.0)
+	f3 := New(100, -0.5)
+	fRef := New(100, 0.01)
+	assert.Equal(t, fRef.M(), f1.M())
+	assert.Equal(t, fRef.M(), f2.M())
+	assert.Equal(t, fRef.M(), f3.M())
+}
+
+func TestMayContain_EmptyFilter(t *testing.T) {
+	t.Parallel()
+	f := New(100, 0.01)
+	assert.False(t, f.MayContain([]byte("hello")))
+	assert.False(t, f.MayContain([]byte("world")))
+	assert.False(t, f.MayContain([]byte("")))
+}
+
+func TestAdd_MayContain_NoFalseNegatives(t *testing.T) {
+	t.Parallel()
+	f := New(200, 0.01)
+	keys := make([]string, 200)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key-%d", i)
+		f.Add([]byte(keys[i]))
+	}
+	for _, k := range keys {
+		assert.True(t, f.MayContain([]byte(k)), "key %q must be present", k)
+	}
+}
+
+func TestAdd_EmptyKey(t *testing.T) {
+	t.Parallel()
+	f := New(10, 0.01)
+	f.Add([]byte(""))
+	assert.True(t, f.MayContain([]byte("")))
+}
+
+func TestFalsePositiveRate_WithinBounds(t *testing.T) {
+	t.Parallel()
+	const n = 10_000
+	const targetFP = 0.01
+	f := New(n, targetFP)
+
+	for i := range n {
+		f.Add(fmt.Appendf(nil, "item-%d", i))
+	}
+
+	// Probe with keys that were never added.
+	fp := 0
+	const probeCount = 100_000
+	for i := n; i < n+probeCount; i++ {
+		if f.MayContain(fmt.Appendf(nil, "item-%d", i)) {
+			fp++
+		}
+	}
+	fpRate := float64(fp) / probeCount
+	// Allow 5× the target rate to account for double-hashing overhead vs.
+	// the theoretical k-independent-function bound.
+	assert.LessOrEqual(t, fpRate, targetFP*5,
+		"false positive rate %.4f exceeds 5× target %.4f", fpRate, targetFP)
+}
+
+func TestOptimalM(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		n    uint
+		p    float64
+		wantAtLeast uint64
+	}{
+		{1000, 0.01, 9000},   // theoretical ~9585 bits
+		{1000, 0.001, 14000}, // theoretical ~14378 bits
+		{100, 0.05, 600},     // theoretical ~623 bits
+	}
+	for _, tt := range tests {
+		m := optimalM(tt.n, tt.p)
+		assert.Equal(t, uint64(0), m%64, "m must be multiple of 64")
+		assert.GreaterOrEqual(t, m, tt.wantAtLeast,
+			"n=%d p=%.3f: m=%d too small (want >= %d)", tt.n, tt.p, m, tt.wantAtLeast)
+	}
+}
+
+func TestOptimalK(t *testing.T) {
+	t.Parallel()
+	// k should be approximately (m/n)*ln(2).
+	n := uint(1000)
+	m := optimalM(n, 0.01)
+	k := optimalK(m, n)
+	expected := math.Round(float64(m) / float64(n) * math.Ln2)
+	assert.Equal(t, uint(expected), k)
+	assert.GreaterOrEqual(t, k, uint(1))
+}
+
+func TestOptimalK_MinimumOne(t *testing.T) {
+	t.Parallel()
+	// Even for a tiny m/n ratio, k must be >= 1.
+	k := optimalK(64, 1_000_000)
+	assert.GreaterOrEqual(t, k, uint(1))
+}
+
+func TestMayContain_DistinctKeys(t *testing.T) {
+	t.Parallel()
+	f := New(3, 0.001)
+	f.Add([]byte("alpha"))
+	f.Add([]byte("beta"))
+
+	assert.True(t, f.MayContain([]byte("alpha")))
+	assert.True(t, f.MayContain([]byte("beta")))
+	// "gamma" was never added — very unlikely to be a false positive at 0.1% FP.
+	// We can't assert false with certainty but with 0.1% FP and only 2 elements
+	// it's overwhelmingly likely to be false.
+	_ = f.MayContain([]byte("gamma")) // result is non-deterministic; just must not panic
+}
+
+func TestFilter_LargeN(t *testing.T) {
+	t.Parallel()
+	// Should not panic or OOM for a million-element filter.
+	f := New(1_000_000, 0.01)
+	require.NotNil(t, f)
+	f.Add([]byte("stress-test"))
+	assert.True(t, f.MayContain([]byte("stress-test")))
+}


### PR DESCRIPTION
Before probing the hash table in `executeHashJoinForRow`, check a Bloom filter constructed during the build phase. Non-matching probe rows are rejected in O(1) without touching the hash map, avoiding cache pressure for low-selectivity joins.