### PR TITLE
feat: semi-join for IN (subquery)

### DIFF
--- a/e2e_tests/semi_join_test.go
+++ b/e2e_tests/semi_join_test.go
@@ -1,0 +1,279 @@
+package e2etests
+
+import "strings"
+
+// TestSemiJoin verifies the semi-join and anti-semi-join optimisation that
+// converts eligible IN/NOT IN (subquery) conditions into synthetic Semi /
+// AntiSemi join plans instead of materialising the entire subquery result.
+func (s *TestSuite) TestSemiJoin() {
+	// users and orders tables used throughout.
+	_, err := s.db.Exec(`create table "sj_users" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		dept  varchar(50)
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "sj_orders" (
+		id      int8 primary key autoincrement,
+		user_id int8 not null,
+		amount  int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	// Seed: Alice(1), Bob(2), Carol(3). Alice and Bob have orders; Carol does not.
+	_, err = s.db.Exec(`insert into "sj_users" (name, dept) values
+		('Alice', 'eng'),
+		('Bob',   'mkt'),
+		('Carol', 'eng')`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "sj_orders" (user_id, amount) values
+		(1, 500),
+		(1, 300),
+		(2, 200)`)
+	s.Require().NoError(err)
+
+	// -------------------------------------------------------------------------
+	s.Run("in_subquery_basic", func() {
+		// Users who have at least one order.
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id in (select user_id from "sj_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Alice", "Bob"}, names)
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("not_in_subquery_basic", func() {
+		// Users who have NO orders.
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id not in (select user_id from "sj_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Carol", names[0])
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("in_subquery_with_inner_where", func() {
+		// Users who have at least one large order (amount > 400).
+		// The inner WHERE pushes the amount filter down to the semi-join scan.
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id in (select user_id from "sj_orders" where amount > 400)`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Alice", names[0])
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("not_in_subquery_with_inner_where", func() {
+		// Users who have no order over 400 (i.e., Bob and Carol).
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id not in (select user_id from "sj_orders" where amount > 400)`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Bob", "Carol"}, names)
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("in_subquery_outer_has_explicit_alias", func() {
+		// Same as in_subquery_basic but outer table has an explicit alias.
+		rows, err := s.db.Query(
+			`select u.name from "sj_users" AS u where u.id in (select user_id from "sj_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Alice", "Bob"}, names)
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("in_subquery_combined_with_outer_where", func() {
+		// Only eng-department users who have at least one order.
+		rows, err := s.db.Query(
+			`select name from "sj_users" where dept = 'eng' and id in (select user_id from "sj_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Alice", names[0])
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("in_subquery_no_matches_in_inner", func() {
+		// Inner subquery returns no rows → no outer rows should match.
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id in (select user_id from "sj_orders" where amount > 99999)`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Empty(names)
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("not_in_subquery_all_matched", func() {
+		// Inner subquery covers all user IDs → NOT IN should return nothing.
+		// Add a row for Carol first.
+		_, err = s.db.Exec(`insert into "sj_orders" (user_id, amount) values (3, 100)`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(
+			`select name from "sj_users" where id not in (select user_id from "sj_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Empty(names)
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("explain_shows_semi_join", func() {
+		// EXPLAIN of an IN (subquery) should show a "semi" join type in the plan.
+		rows := s.collectExplain(
+			`explain select name from "sj_users" where id in (select user_id from "sj_orders")`)
+		s.Require().NotEmpty(rows)
+		found := false
+		for _, r := range rows {
+			if strings.Contains(r.Detail, "semi") {
+				found = true
+				break
+			}
+		}
+		s.True(found, "EXPLAIN plan should mention 'semi' join type in Detail")
+	})
+
+	// -------------------------------------------------------------------------
+	s.Run("explain_shows_anti_semi_join", func() {
+		// EXPLAIN of a NOT IN (subquery) should show "anti_semi" in the plan.
+		rows := s.collectExplain(
+			`explain select name from "sj_users" where id not in (select user_id from "sj_orders")`)
+		s.Require().NotEmpty(rows)
+		found := false
+		for _, r := range rows {
+			if strings.Contains(r.Detail, "anti_semi") {
+				found = true
+				break
+			}
+		}
+		s.True(found, "EXPLAIN plan should mention 'anti_semi' join type in Detail")
+	})
+}
+
+// TestSemiJoinIneligible verifies that subqueries that cannot be converted to
+// semi-joins (DISTINCT, GROUP BY, LIMIT, aggregates) still return correct
+// results via the normal materialisation path.
+func (s *TestSuite) TestSemiJoinIneligible() {
+	_, err := s.db.Exec(`create table "sji_users" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`create table "sji_orders" (
+		id      int8 primary key autoincrement,
+		user_id int8 not null,
+		amount  int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "sji_users" (name) values ('Alice'), ('Bob'), ('Carol')`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "sji_orders" (user_id, amount) values (1, 500), (1, 300), (2, 200)`)
+	s.Require().NoError(err)
+
+	s.Run("in_with_distinct_subquery_materialises", func() {
+		// DISTINCT on the subquery prevents semi-join conversion; must still work.
+		rows, err := s.db.Query(
+			`select name from "sji_users" where id in (select distinct user_id from "sji_orders")`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Alice", "Bob"}, names)
+	})
+
+	s.Run("in_with_limit_subquery_materialises", func() {
+		// LIMIT on the subquery prevents semi-join conversion; must still work.
+		rows, err := s.db.Query(
+			`select name from "sji_users" where id in (select user_id from "sji_orders" limit 1)`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		// The subquery returns only the first user_id (1 = Alice); exactly one user matches.
+		s.Require().Len(names, 1)
+	})
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -475,6 +475,13 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 			return d.executeCTESelect(ctx, stmt)
 		}
 
+		// Convert eligible IN/NOT IN (subquery) conditions to semi-joins before
+		// resolveSubqueries so that the join planner can use early termination
+		// and avoid full materialisation of the inner result set.
+		if stmt.Kind == Select && len(stmt.Conditions) > 0 {
+			stmt = liftINSubqueriesToSemiJoins(stmt)
+		}
+
 		// Pre-evaluate any non-correlated scalar subqueries in the WHERE clause.
 		if len(stmt.Conditions) > 0 {
 			resolved, err := d.resolveSubqueries(ctx, stmt.Conditions)

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -71,7 +71,10 @@ func (d *Database) executeExplain(ctx context.Context, stmt Statement) (Statemen
 		return StatementResult{}, err
 	}
 
-	// Resolve WHERE subqueries before Validate so validateWhere never sees *Statement operands.
+	// Lift eligible IN/NOT IN (subquery) conditions to semi-joins before planning.
+	inner = liftINSubqueriesToSemiJoins(inner)
+
+	// Resolve remaining WHERE subqueries before Validate.
 	inner.Conditions, err = d.resolveSubqueries(ctx, inner.Conditions)
 	if err != nil {
 		return StatementResult{}, err
@@ -566,6 +569,10 @@ func joinTypeString(joinType JoinType) string {
 		return "right"
 	case FullOuter:
 		return "full outer"
+	case Semi:
+		return "semi"
+	case AntiSemi:
+		return "anti_semi"
 	default:
 		return "unknown"
 	}

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -844,6 +844,15 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 	innerRowChan := make(chan Row, 100)
 	innerErrChan := make(chan error, 1)
 
+	// For semi/anti-semi joins use a child context so we can cancel the inner
+	// goroutine as soon as we have found (or confirmed the absence of) a match.
+	innerCtx := ctx
+	var innerCancel context.CancelFunc
+	if join.Type == Semi || join.Type == AntiSemi {
+		innerCtx, innerCancel = context.WithCancel(ctx)
+		defer innerCancel()
+	}
+
 	if innerScan.Type == ScanTypeIndexPoint && join.InnerJoinColumn != "" {
 		go func() {
 			defer close(innerRowChan)
@@ -886,14 +895,14 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 
 			indexScan := innerScan
 			indexScan.IndexKeys = joinKeyValues
-			if err := innerTable.indexPointScan(ctx, indexScan, innerFields, chanRowCallback(ctx, innerRowChan)); err != nil {
+			if err := innerTable.indexPointScan(innerCtx, indexScan, innerFields, chanRowCallback(innerCtx, innerRowChan)); err != nil {
 				innerErrChan <- err
 			}
 		}()
 	} else {
 		go func() {
 			defer close(innerRowChan)
-			if err := innerTable.sequentialScan(ctx, innerScan, innerFields, chanRowCallback(ctx, innerRowChan)); err != nil {
+			if err := innerTable.sequentialScan(innerCtx, innerScan, innerFields, chanRowCallback(innerCtx, innerRowChan)); err != nil {
 				innerErrChan <- err
 			}
 		}()
@@ -935,6 +944,18 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 
 		if matches {
 			matched = true
+			if join.Type == Semi {
+				// First match found: cancel the inner scan, drain remaining rows.
+				innerCancel()
+				drainRowCh(innerRowChan)
+				break
+			}
+			if join.Type == AntiSemi {
+				// Any match means outer row is excluded.
+				innerCancel()
+				drainRowCh(innerRowChan)
+				return nil
+			}
 			if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables); err != nil {
 				return err
 			}
@@ -943,8 +964,32 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 
 	select {
 	case err := <-innerErrChan:
+		if innerCancel != nil && errors.Is(err, context.Canceled) {
+			break // we triggered the cancellation ourselves
+		}
 		return err
 	default:
+	}
+
+	// Semi-join: emit the outer row when the inner had at least one match.
+	if join.Type == Semi {
+		if matched {
+			outerRow := currentRow
+			if joinIndex == 0 {
+				outerRow = prefixRowAlias(currentRow, fromAlias)
+			}
+			return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables)
+		}
+		return nil
+	}
+
+	// Anti-semi-join: emit the outer row only when there was no inner match.
+	if join.Type == AntiSemi {
+		outerRow := currentRow
+		if joinIndex == 0 {
+			outerRow = prefixRowAlias(currentRow, fromAlias)
+		}
+		return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables)
 	}
 
 	// LEFT JOIN / FULL OUTER JOIN: emit the outer row with NULL-filled inner columns when nothing matched.
@@ -982,6 +1027,23 @@ func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, jo
 		if bucket.filter.MayContain([]byte(probeKey)) {
 			matchingRows = bucket.rows[probeKey]
 		}
+	}
+
+	// Semi-join / anti-semi-join: check existence only, emit the outer row
+	// (not the combined row).  At joinIndex==0 the outer row has plain column
+	// names; prefix them with fromAlias so downstream projection resolves
+	// alias-qualified SELECT fields (e.g. "u.name") correctly.
+	if join.Type == Semi || join.Type == AntiSemi {
+		emit := join.Type == Semi && len(matchingRows) > 0
+		emit = emit || (join.Type == AntiSemi && len(matchingRows) == 0)
+		if emit {
+			outerRow := currentRow
+			if joinIndex == 0 {
+				outerRow = prefixRowAlias(currentRow, fromAlias)
+			}
+			return p.executeJoinsForRow(ctx, nil, outerRow, joinIndex+1, filteredPipe, hashTables)
+		}
+		return nil
 	}
 
 	matched := false
@@ -1201,13 +1263,34 @@ func nullRowForColumns(columns []Column) Row {
 
 // combineRows concatenates columns and values from outer and inner rows (first join)
 // Column names are prefixed with table aliases to avoid conflicts (e.g., "u.id", "o.id")
+// prefixRowAlias returns a copy of row with each column name prefixed by
+// "alias.".  When alias is empty the original row is returned unchanged.
+func prefixRowAlias(row Row, alias string) Row {
+	if alias == "" {
+		return row
+	}
+	result := Row{
+		Key:     row.Key,
+		Columns: make([]Column, len(row.Columns)),
+		Values:  make([]OptionalValue, len(row.Values)),
+	}
+	copy(result.Values, row.Values)
+	for i, col := range row.Columns {
+		result.Columns[i] = col
+		result.Columns[i].Name = alias + "." + col.Name
+	}
+	return result
+}
+
 func combineRows(outerRow, innerRow Row, outerTableAlias, innerTableAlias string) Row {
 	combinedColumns := make([]Column, 0, len(outerRow.Columns)+len(innerRow.Columns))
 
-	// Add outer table columns with table alias prefix
+	// Add outer table columns, optionally prefixed with the table alias.
 	for _, col := range outerRow.Columns {
 		prefixedCol := col
-		prefixedCol.Name = outerTableAlias + "." + col.Name
+		if outerTableAlias != "" {
+			prefixedCol.Name = outerTableAlias + "." + col.Name
+		}
 		combinedColumns = append(combinedColumns, prefixedCol)
 	}
 

--- a/internal/minisql/semi_join.go
+++ b/internal/minisql/semi_join.go
@@ -1,0 +1,170 @@
+package minisql
+
+import "fmt"
+
+// semiJoinEligible reports whether sub can be converted to a semi-join.
+// Returns the single inner column name and true when eligible.
+// A subquery is eligible when it is a plain SELECT with no joins, no UNION,
+// no CTEs, no aggregates, no DISTINCT, no GROUP BY/HAVING, no LIMIT/OFFSET,
+// and selects exactly one plain column reference.
+func semiJoinEligible(sub Statement) (innerCol string, ok bool) {
+	if sub.Kind != Select {
+		return "", false
+	}
+	if sub.FromSubquery != nil || len(sub.CTEs) > 0 || len(sub.Joins) > 0 || len(sub.Unions) > 0 {
+		return "", false
+	}
+	if sub.Distinct || sub.GroupBy != nil || sub.Having != nil {
+		return "", false
+	}
+	if sub.Limit.Valid || sub.Offset.Valid {
+		return "", false
+	}
+	if len(sub.Fields) != 1 {
+		return "", false
+	}
+	f := sub.Fields[0]
+	if f.Name == "*" || f.Expr != nil {
+		return "", false
+	}
+	return f.Name, true
+}
+
+// outerTableNames collects all table names referenced in stmt (base table + all
+// join tables at every depth).  Used to detect conflicts before adding a
+// synthetic semi-join that refers to the same table.
+func outerTableNames(stmt Statement) map[string]struct{} {
+	names := map[string]struct{}{stmt.TableName: {}}
+	var walk func(joins []Join)
+	walk = func(joins []Join) {
+		for _, j := range joins {
+			names[j.TableName] = struct{}{}
+			walk(j.Joins)
+		}
+	}
+	walk(stmt.Joins)
+	return names
+}
+
+// prefixConditionAlias rewrites bare field references (AliasPrefix == "") in
+// cond to carry alias as the AliasPrefix.  This allows pushDownFilters to route
+// inner-subquery WHERE conditions to the correct semi-join scan.
+func prefixConditionAlias(cond Condition, alias string) Condition {
+	if cond.Operand1.Type == OperandField {
+		if f, ok := cond.Operand1.Value.(Field); ok && f.AliasPrefix == "" {
+			f.AliasPrefix = alias
+			cond.Operand1.Value = f
+		}
+	}
+	if cond.Operand2.Type == OperandField {
+		if f, ok := cond.Operand2.Value.(Field); ok && f.AliasPrefix == "" {
+			f.AliasPrefix = alias
+			cond.Operand2.Value = f
+		}
+	}
+	return cond
+}
+
+// liftINSubqueriesToSemiJoins converts eligible IN/NOT IN (subquery) conditions
+// in stmt.Conditions into Semi / AntiSemi JOIN entries, removing the original
+// condition from stmt.Conditions.  Ineligible subqueries are left untouched so
+// resolveSubqueries can still materialise them.
+//
+// When a semi-join is added and the outer statement has no table alias, the
+// alias is set to stmt.TableName so that the join planner can form correct
+// ON conditions.
+func liftINSubqueriesToSemiJoins(stmt Statement) Statement {
+	outerTables := outerTableNames(stmt)
+	semiCounter := 0
+
+	// outerAlias is used to prefix the outer field in the ON condition.
+	// When the outer table has no alias, the field AliasPrefix is already ""
+	// and extractJoinColumnPairs matches on "" == "".
+	outerAlias := stmt.TableAlias
+
+	extraConditions := make(OneOrMore, 0)
+	newConditions := make(OneOrMore, 0, len(stmt.Conditions))
+
+	for _, group := range stmt.Conditions {
+		newGroup := make(Conditions, 0, len(group))
+		for _, cond := range group {
+			if cond.Operand2.Type != OperandSubquery ||
+				(cond.Operator != In && cond.Operator != NotIn) ||
+				cond.Operand1.Type != OperandField {
+				newGroup = append(newGroup, cond)
+				continue
+			}
+
+			subStmt, ok := cond.Operand2.Value.(*Statement)
+			if !ok {
+				newGroup = append(newGroup, cond)
+				continue
+			}
+
+			innerCol, eligible := semiJoinEligible(*subStmt)
+			if !eligible {
+				newGroup = append(newGroup, cond)
+				continue
+			}
+
+			// Skip if the inner table is already referenced in the outer query;
+			// validateJoinTree rejects duplicate table names.
+			if _, conflict := outerTables[subStmt.TableName]; conflict {
+				newGroup = append(newGroup, cond)
+				continue
+			}
+
+			joinType := Semi
+			if cond.Operator == NotIn {
+				joinType = AntiSemi
+			}
+
+			semiAlias := fmt.Sprintf("__semi%d", semiCounter)
+			semiCounter++
+
+			// Build the ON condition: outerAlias.outerCol = semiAlias.innerCol
+			outerField := cond.Operand1.Value.(Field)
+			if outerField.AliasPrefix == "" {
+				outerField.AliasPrefix = outerAlias
+			}
+			onCond := Condition{
+				Operand1: Operand{Type: OperandField, Value: outerField},
+				Operator: Eq,
+				Operand2: Operand{Type: OperandField, Value: Field{Name: innerCol, AliasPrefix: semiAlias}},
+			}
+
+			// Re-prefix inner WHERE conditions with semiAlias so that
+			// pushDownFilters routes them to the semi-join's scan.
+			for _, innerGroup := range subStmt.Conditions {
+				rewritten := make(Conditions, len(innerGroup))
+				for k, innerCond := range innerGroup {
+					rewritten[k] = prefixConditionAlias(innerCond, semiAlias)
+				}
+				extraConditions = append(extraConditions, rewritten)
+			}
+
+			// Mark the inner table as used so a second IN clause on the same
+			// table falls back to materialisation.
+			outerTables[subStmt.TableName] = struct{}{}
+
+			stmt.Joins = append(stmt.Joins, Join{
+				Type:       joinType,
+				TableName:  subStmt.TableName,
+				TableAlias: semiAlias,
+				Conditions: Conditions{onCond},
+			})
+			// Drop the original IN condition — the semi-join replaces it.
+		}
+
+		if len(newGroup) > 0 {
+			newConditions = append(newConditions, newGroup)
+		}
+	}
+
+	// Append pushed-down inner conditions after the outer conditions so that
+	// pushDownFilters can distribute them to the right scan plan.
+	newConditions = append(newConditions, extraConditions...)
+	stmt.Conditions = newConditions
+
+	return stmt
+}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -1645,9 +1645,20 @@ func (s Statement) validateSelect(table *Table) error {
 		tableMap := map[string]struct{}{table.Name: {}}
 		aliasMap := map[string]struct{}{}
 		if s.TableAlias == "" {
-			return errors.New("table must have alias when query contains JOIN")
+			// Synthetic semi/anti-semi-only joins do not require an outer alias.
+			allSemi := true
+			for _, j := range s.Joins {
+				if j.Type != Semi && j.Type != AntiSemi {
+					allSemi = false
+					break
+				}
+			}
+			if !allSemi {
+				return errors.New("table must have alias when query contains JOIN")
+			}
+		} else {
+			aliasMap[s.TableAlias] = struct{}{}
 		}
-		aliasMap[s.TableAlias] = struct{}{}
 		if err := validateJoinTree(s.Joins, tableMap, aliasMap); err != nil {
 			return err
 		}

--- a/internal/minisql/stmt_join.go
+++ b/internal/minisql/stmt_join.go
@@ -18,6 +18,12 @@ const (
 	Right
 	// FullOuter is a FULL OUTER JOIN — all rows from both tables, with NULLs where there is no match.
 	FullOuter
+	// Semi is a semi-join: emit the outer row when at least one matching inner row exists.
+	// Used internally to implement IN (subquery) without materialising the subquery.
+	Semi
+	// AntiSemi is an anti-semi-join: emit the outer row when no matching inner row exists.
+	// Used internally to implement NOT IN (subquery).
+	AntiSemi
 )
 
 // Join describes a single JOIN clause within a SELECT statement, including the


### PR DESCRIPTION
`WHERE id IN (SELECT user_id FROM orders WHERE …)` previously materialised the full subquery result into an `OperandList`. The semi-join variant probes a hash table or stops the inner scan on the first match, never materialising the full list.