### PR TITLE
perf: eliminate per-outer-row allocations in nested-loop join hot path

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,19 @@
+### 2026-05-17 — Nested-loop join hot-path allocation pass
+
+Four layers of per-outer-row heap allocation were eliminated from the join executor:
+
+1. **`joinMemo` precomputation** — inner table lookup, `fieldsFromColumns`, combined column schema, and join filter compiled once per join level instead of once per outer row.
+2. **`indexPointGetAll`** — replaces a callback closure (which escaped to the heap even when never invoked) with a plain `[]Row` return; returns `nil` for zero matches.
+3. **Inlined `processInnerRow`** — the shared closure captured a mutable `joinFilter` variable, causing a heap allocation per outer row; inlined at both call sites.
+4. **Goroutine argument passing** — `Scan` struct (~200 B) was captured by reference in the goroutine closure, forcing it to the heap; changed to an explicit argument.
+
+| Benchmark | Before | After | Alloc Before | Alloc After | SQLite | Ratio (after vs SQLite) |
+|---|---:|---:|---:|---:|---:|---:|
+| Join_Inner_SmallLarge/minisql | ~12.6 ms/op | ~8.6 ms/op | ~16.9 MiB/op | ~11.7 MiB/op | ~4.9 ms/op | 1.8× |
+| Join_Left_UnmatchedRows/minisql | ~42.9 ms/op | ~11.9 ms/op | ~86.3 MiB/op | ~12.3 MiB/op | ~4.2 ms/op | 2.9× |
+
+INNER JOIN closed from 2.5× to **1.8×** SQLite. LEFT JOIN closed from 10.7× to **2.9×** SQLite (7× allocation reduction).
+
 ### 2026-05-16 00:32 UTC
 
 Targeted JSON indexed `COUNT(*)` pass. MiniSQL now counts exact JSON inverted

--- a/internal/minisql/database_test.go
+++ b/internal/minisql/database_test.go
@@ -598,6 +598,26 @@ func TestWithMaxCachedStatements(t *testing.T) {
 	})
 }
 
+func TestWithMaxCachedPlans(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("positive value replaces default cache", func(t *testing.T) {
+		pager, dbFile := initTest(t)
+		aDatabase, err := NewDatabase(ctx, testLogger, dbFile.Name(), nil, pager, pager, nil,
+			WithMaxCachedPlans(50))
+		require.NoError(t, err)
+		assert.NotNil(t, aDatabase.planCache)
+	})
+
+	t.Run("zero is ignored, cache still allocated by default", func(t *testing.T) {
+		pager, dbFile := initTest(t)
+		aDatabase, err := NewDatabase(ctx, testLogger, dbFile.Name(), nil, pager, pager, nil,
+			WithMaxCachedPlans(0))
+		require.NoError(t, err)
+		assert.NotNil(t, aDatabase.planCache)
+	})
+}
+
 func TestDatabase_Accessors(t *testing.T) {
 	pager, dbFile := initTest(t)
 	ctx := context.Background()

--- a/internal/minisql/fold_test.go
+++ b/internal/minisql/fold_test.go
@@ -259,6 +259,141 @@ func TestFoldConditions_ColumnExprNotFolded(t *testing.T) {
 	assert.Equal(t, OperandExpr, result[0][0].Operand1.Type)
 }
 
+// TestEvalConstCond exercises all branches of evalConstCond directly.
+func TestEvalConstCond(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NULL = NULL", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandNull},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandNull},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.True(t, canEval)
+		assert.True(t, result)
+	})
+
+	t.Run("NULL = non-null", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandNull},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.True(t, canEval)
+		assert.False(t, result)
+	})
+
+	t.Run("NULL != non-null", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandNull},
+			Operator: Ne,
+			Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.True(t, canEval)
+		assert.True(t, result)
+	})
+
+	t.Run("NULL > non-null (unsupported for null)", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandNull},
+			Operator: Gt,
+			Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.False(t, canEval)
+		assert.False(t, result)
+	})
+
+	t.Run("non-null = NULL", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandInteger, Value: int64(5)},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandNull},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.True(t, canEval)
+		assert.False(t, result)
+	})
+
+	t.Run("non-null != NULL", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandInteger, Value: int64(5)},
+			Operator: Ne,
+			Operand2: Operand{Type: OperandNull},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.True(t, canEval)
+		assert.True(t, result)
+	})
+
+	t.Run("non-null > NULL (unsupported for null)", func(t *testing.T) {
+		cond := Condition{
+			Operand1: Operand{Type: OperandInteger, Value: int64(5)},
+			Operator: Gt,
+			Operand2: Operand{Type: OperandNull},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.False(t, canEval)
+		assert.False(t, result)
+	})
+
+	t.Run("unsupported operand type returns canEval=false", func(t *testing.T) {
+		// struct{}{} is not a recognised scalar type → compareScalarToOperand errors.
+		cond := Condition{
+			Operand1: Operand{Type: OperandInteger, Value: struct{}{}},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+		}
+		result, canEval := evalConstCond(cond)
+		assert.False(t, canEval)
+		assert.False(t, result)
+	})
+}
+
+// TestIsConstExpr_CaseClauses exercises the CASE-clause branches of isConstExpr.
+func TestIsConstExpr_CaseClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("searched CASE with non-nil Cond is non-const", func(t *testing.T) {
+		expr := &Expr{
+			CaseClauses: []CaseWhen{
+				{Cond: &ConditionNode{}, When: &Expr{Literal: int64(1)}, Then: &Expr{Literal: int64(2)}},
+			},
+		}
+		assert.False(t, isConstExpr(expr))
+	})
+
+	t.Run("simple CASE with non-const When is non-const", func(t *testing.T) {
+		expr := &Expr{
+			CaseClauses: []CaseWhen{
+				{When: &Expr{Column: "status"}, Then: &Expr{Literal: int64(1)}},
+			},
+		}
+		assert.False(t, isConstExpr(expr))
+	})
+
+	t.Run("simple CASE with all-const clauses is const", func(t *testing.T) {
+		expr := &Expr{
+			CaseClauses: []CaseWhen{
+				{When: &Expr{Literal: int64(1)}, Then: &Expr{Literal: int64(2)}},
+			},
+		}
+		assert.True(t, isConstExpr(expr))
+	})
+}
+
+// TestAnyToOperand_Default verifies that an unrecognised type returns OperandExpr.
+func TestAnyToOperand_Default(t *testing.T) {
+	t.Parallel()
+
+	type myType struct{}
+	got := anyToOperand(myType{})
+	assert.Equal(t, OperandExpr, got.Type)
+}
+
 // TestFoldConditions_MixedGroups verifies OR group semantics: if one AND group is
 // always false it is pruned, but other groups survive.
 func TestFoldConditions_MixedGroups(t *testing.T) {

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -6,6 +6,68 @@ import (
 	"fmt"
 )
 
+// joinMemo holds precomputed, per-join-level state that is constant across all
+// outer rows. Computing these once in executeNestedLoopJoin instead of per outer
+// row eliminates repeated slice allocations in the hot join path.
+type joinMemo struct {
+	innerTable      *Table
+	innerFields     []Field
+	combinedColumns []Column // alias-prefixed combined columns for this join level
+	joinFilter      func(Row) (bool, error)
+	nullInnerCount  int // len(innerTable.Columns), for LEFT/FULL OUTER null padding
+}
+
+// buildCombinedColumns returns the alias-prefixed column list for the first join
+// level (joinIndex == 0).
+func buildCombinedColumns(outerCols []Column, outerAlias string, innerCols []Column, innerAlias string) []Column {
+	combined := make([]Column, 0, len(outerCols)+len(innerCols))
+	for _, col := range outerCols {
+		c := col
+		if outerAlias != "" {
+			c.Name = outerAlias + "." + col.Name
+		}
+		combined = append(combined, c)
+	}
+	for _, col := range innerCols {
+		c := col
+		c.Name = innerAlias + "." + col.Name
+		combined = append(combined, c)
+	}
+	return combined
+}
+
+// buildCombinedColumnsProgressive appends alias-prefixed inner columns to an
+// already-combined outer column list (joinIndex > 0).
+func buildCombinedColumnsProgressive(existingCols []Column, innerCols []Column, innerAlias string) []Column {
+	combined := make([]Column, 0, len(existingCols)+len(innerCols))
+	combined = append(combined, existingCols...)
+	for _, col := range innerCols {
+		c := col
+		c.Name = innerAlias + "." + col.Name
+		combined = append(combined, c)
+	}
+	return combined
+}
+
+// combineRowsWithSchema concatenates outer and inner row values using a
+// precomputed combined column slice. Avoids the per-row Column slice allocation
+// that combineRows performs.
+func combineRowsWithSchema(outerRow, innerRow Row, combinedColumns []Column) Row {
+	combined := make([]OptionalValue, len(outerRow.Values)+len(innerRow.Values))
+	copy(combined, outerRow.Values)
+	copy(combined[len(outerRow.Values):], innerRow.Values)
+	return NewRowWithValues(combinedColumns, combined)
+}
+
+// combineRowWithNullInner combines outerRow with nullCount NULL-valued inner
+// columns using a precomputed combined column schema. Avoids a separate
+// nullRowForColumns allocation for the LEFT/FULL OUTER JOIN miss path.
+func combineRowWithNullInner(outerRow Row, nullCount int, combinedColumns []Column) Row {
+	combined := make([]OptionalValue, len(outerRow.Values)+nullCount)
+	copy(combined, outerRow.Values)
+	return NewRowWithValues(combinedColumns, combined)
+}
+
 // chanRowCallback wraps a buffered channel as a row callback.
 // The goroutine sending to the channel must close it when done.
 func chanRowCallback(ctx context.Context, ch chan<- Row) func(Row) error {
@@ -761,6 +823,38 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 		return fmt.Errorf("%w: %s", errTableDoesNotExist, baseScan.TableName)
 	}
 
+	// Precompute per-join-level state that is constant across all outer rows.
+	// This eliminates repeated table lookups, fieldsFromColumns calls, column
+	// schema allocations, and filter compilation in the hot per-row path.
+	joinMemos := make([]joinMemo, len(p.Joins))
+	for i, join := range p.Joins {
+		innerScan := p.Scans[join.RightScanIndex]
+		innerTable, innerOK := provider.GetTable(ctx, innerScan.TableName)
+		if !innerOK {
+			return fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+		}
+
+		var combinedCols []Column
+		if i == 0 {
+			combinedCols = buildCombinedColumns(baseTable.Columns, baseScan.TableAlias, innerTable.Columns, innerScan.TableAlias)
+		} else {
+			combinedCols = buildCombinedColumnsProgressive(joinMemos[i-1].combinedColumns, innerTable.Columns, innerScan.TableAlias)
+		}
+
+		joinConditions := OneOrMore{}
+		if len(join.Conditions) > 0 {
+			joinConditions = append(joinConditions, join.Conditions)
+		}
+
+		joinMemos[i] = joinMemo{
+			innerTable:      innerTable,
+			innerFields:     fieldsFromColumns(innerTable.Columns...),
+			combinedColumns: combinedCols,
+			joinFilter:      compileRowFilterForColumns(combinedCols, joinConditions),
+			nullInnerCount:  len(innerTable.Columns),
+		}
+	}
+
 	baseRowChan := make(chan Row, 100)
 	baseErrChan := make(chan error, 1)
 	baseFields := fieldsFromColumns(baseTable.Columns...)
@@ -778,7 +872,7 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 			return err
 		default:
 		}
-		if err := p.executeJoinsForRow(ctx, provider, baseRow, 0, filteredPipe, hashTables); err != nil {
+		if err := p.executeJoinsForRow(ctx, provider, baseRow, 0, filteredPipe, hashTables, joinMemos); err != nil {
 			return err
 		}
 	}
@@ -814,7 +908,8 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 // each join is resolved from p.Scans[join.LeftScanIndex].TableAlias, enabling
 // correct key lookup for both star-schema and chain joins.
 // hashTables holds the pre-built hash buckets for JoinAlgorithmHash joins.
-func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvider, currentRow Row, joinIndex int, filteredPipe chan<- Row, hashTables map[int]*hashJoinBucket) error {
+// memos holds per-join-level state precomputed once by executeNestedLoopJoin.
+func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvider, currentRow Row, joinIndex int, filteredPipe chan<- Row, hashTables map[int]*hashJoinBucket, memos []joinMemo) error {
 	if joinIndex >= len(p.Joins) {
 		select {
 		case filteredPipe <- currentRow:
@@ -828,147 +923,156 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 
 	// Hash join: probe the pre-built hash table instead of scanning the inner table.
 	if join.Algorithm == JoinAlgorithmHash {
-		return p.executeHashJoinForRow(ctx, currentRow, joinIndex, filteredPipe, hashTables)
+		return p.executeHashJoinForRow(ctx, currentRow, joinIndex, filteredPipe, hashTables, memos)
 	}
 
 	// Nested-loop join (index point or sequential).
+	// Use precomputed per-join-level state from memos to avoid repeated allocations.
+	memo := memos[joinIndex]
 	innerScan := p.Scans[join.RightScanIndex]
 	fromAlias := p.Scans[join.LeftScanIndex].TableAlias
 
-	innerTable, ok := provider.GetTable(ctx, innerScan.TableName)
-	if !ok {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
-	}
-
-	innerFields := fieldsFromColumns(innerTable.Columns...)
-	innerRowChan := make(chan Row, 100)
-	innerErrChan := make(chan error, 1)
-
-	// For semi/anti-semi joins use a child context so we can cancel the inner
-	// goroutine as soon as we have found (or confirmed the absence of) a match.
-	innerCtx := ctx
-	var innerCancel context.CancelFunc
-	if join.Type == Semi || join.Type == AntiSemi {
-		innerCtx, innerCancel = context.WithCancel(ctx)
-		defer innerCancel()
-	}
+	matched := false
 
 	if innerScan.Type == ScanTypeIndexPoint && join.InnerJoinColumn != "" {
-		go func() {
-			defer close(innerRowChan)
-
-			var joinKeyValues []any
-
-			if len(join.JoinColumnPairs) > 0 {
-				joinKeyValues = make([]any, len(join.JoinColumnPairs))
-				for i, pair := range join.JoinColumnPairs {
-					var (
-						keyValue OptionalValue
-						ok       bool
-					)
-					if joinIndex == 0 {
-						// currentRow is the unmodified base-table row — no alias prefix yet.
-						keyValue, ok = currentRow.GetValue(pair.BaseTableColumn.Name)
-					} else {
-						keyValue, ok = currentRow.GetValue(fromAlias + "." + pair.BaseTableColumn.Name)
-					}
-					if !ok || !keyValue.Valid {
-						return
-					}
-					joinKeyValues[i] = keyValue.Value
-				}
-			} else {
+		// Synchronous index point-scan: no goroutine or channel needed.
+		// An index point lookup returns a small number of rows (0 or 1 for unique
+		// indexes); spawning a goroutine + 100-slot buffered channel per outer row
+		// is far more expensive than the lookup itself.
+		var joinKeyValues []any
+		if len(join.JoinColumnPairs) > 0 {
+			joinKeyValues = make([]any, len(join.JoinColumnPairs))
+			for i, pair := range join.JoinColumnPairs {
 				var (
 					keyValue OptionalValue
 					ok       bool
 				)
 				if joinIndex == 0 {
-					keyValue, ok = currentRow.GetValue(join.OuterJoinColumn)
+					keyValue, ok = currentRow.GetValue(pair.BaseTableColumn.Name)
 				} else {
-					keyValue, ok = currentRow.GetValue(fromAlias + "." + join.OuterJoinColumn)
+					keyValue, ok = currentRow.GetValue(fromAlias + "." + pair.BaseTableColumn.Name)
 				}
 				if !ok || !keyValue.Valid {
-					return
+					joinKeyValues = nil
+					break
 				}
+				joinKeyValues[i] = keyValue.Value
+			}
+		} else {
+			var (
+				keyValue OptionalValue
+				ok       bool
+			)
+			if joinIndex == 0 {
+				keyValue, ok = currentRow.GetValue(join.OuterJoinColumn)
+			} else {
+				keyValue, ok = currentRow.GetValue(fromAlias + "." + join.OuterJoinColumn)
+			}
+			if ok && keyValue.Valid {
 				joinKeyValues = []any{keyValue.Value}
 			}
+		}
 
+		if len(joinKeyValues) > 0 {
 			indexScan := innerScan
 			indexScan.IndexKeys = joinKeyValues
-			if err := innerTable.indexPointScan(innerCtx, indexScan, innerFields, chanRowCallback(innerCtx, innerRowChan)); err != nil {
-				innerErrChan <- err
-			}
-		}()
-	} else {
-		go func() {
-			defer close(innerRowChan)
-			if err := innerTable.sequentialScan(innerCtx, innerScan, innerFields, chanRowCallback(innerCtx, innerRowChan)); err != nil {
-				innerErrChan <- err
-			}
-		}()
-	}
-
-	joinConditions := OneOrMore{}
-	if len(join.Conditions) > 0 {
-		joinConditions = append(joinConditions, join.Conditions)
-	}
-	var joinFilter func(Row) (bool, error)
-
-	matched := false
-	for innerRow := range innerRowChan {
-		select {
-		case err := <-innerErrChan:
-			return err
-		default:
-		}
-
-		var combinedRow Row
-		if joinIndex == 0 {
-			combinedRow = combineRows(currentRow, innerRow, fromAlias, innerScan.TableAlias)
-		} else {
-			combinedRow = combineRowsProgressive(currentRow, innerRow, innerScan.TableAlias)
-		}
-
-		if joinFilter == nil {
-			joinFilter = compileRowFilterForColumns(combinedRow.Columns, joinConditions)
-		}
-
-		matches := true
-		if joinFilter != nil {
-			var err error
-			matches, err = joinFilter(combinedRow)
+			// Use indexPointGetAll instead of indexPointScan so that no callback
+			// closure is created at this call site.  The closure would otherwise
+			// escape to the heap once per outer row, producing large allocations
+			// even in the unmatched LEFT JOIN case where it is never called.
+			innerRows, err := memo.innerTable.indexPointGetAll(ctx, indexScan, memo.innerFields)
 			if err != nil {
 				return err
 			}
+			for _, innerRow := range innerRows {
+				if (join.Type == Semi || join.Type == AntiSemi) && matched {
+					break // already decided
+				}
+				if join.Type == Semi || join.Type == AntiSemi {
+					matched = true
+					break
+				}
+				combinedRow := combineRowsWithSchema(currentRow, innerRow, memo.combinedColumns)
+				matches := true
+				if memo.joinFilter != nil {
+					var filterErr error
+					matches, filterErr = memo.joinFilter(combinedRow)
+					if filterErr != nil {
+						return filterErr
+					}
+				}
+				if matches {
+					matched = true
+					if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables, memos); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	} else {
+		// Async sequential scan: run in a goroutine so the outer loop and inner
+		// scan can pipeline. Use a modest buffer to limit memory per join.
+		innerCtx := ctx
+		var innerCancel context.CancelFunc
+		if join.Type == Semi || join.Type == AntiSemi {
+			innerCtx, innerCancel = context.WithCancel(ctx)
+			defer innerCancel()
 		}
 
-		if matches {
-			matched = true
-			if join.Type == Semi {
-				// First match found: cancel the inner scan, drain remaining rows.
+		innerRowChan := make(chan Row, 16)
+		innerErrChan := make(chan error, 1)
+
+		// Pass innerScan by value as a goroutine argument rather than capturing
+		// it in the closure.  Capture causes the Scan struct (~200 B) to escape
+		// to the heap for every outer row — even rows that take the index-scan
+		// branch never reach this goroutine.  Argument-passing keeps innerScan
+		// on the stack for the calling frame.
+		go func(scan Scan) {
+			defer close(innerRowChan)
+			if err := memo.innerTable.sequentialScan(innerCtx, scan, memo.innerFields, chanRowCallback(innerCtx, innerRowChan)); err != nil {
+				innerErrChan <- err
+			}
+		}(innerScan)
+
+		for innerRow := range innerRowChan {
+			select {
+			case err := <-innerErrChan:
+				return err
+			default:
+			}
+
+			if join.Type == Semi || join.Type == AntiSemi {
+				matched = true
 				innerCancel()
 				drainRowCh(innerRowChan)
 				break
 			}
-			if join.Type == AntiSemi {
-				// Any match means outer row is excluded.
-				innerCancel()
-				drainRowCh(innerRowChan)
-				return nil
-			}
-			if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables); err != nil {
-				return err
-			}
-		}
-	}
 
-	select {
-	case err := <-innerErrChan:
-		if innerCancel != nil && errors.Is(err, context.Canceled) {
-			break // we triggered the cancellation ourselves
+			combinedRow := combineRowsWithSchema(currentRow, innerRow, memo.combinedColumns)
+			matches := true
+			if memo.joinFilter != nil {
+				var err error
+				matches, err = memo.joinFilter(combinedRow)
+				if err != nil {
+					return err
+				}
+			}
+			if matches {
+				matched = true
+				if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables, memos); err != nil {
+					return err
+				}
+			}
 		}
-		return err
-	default:
+
+		select {
+		case err := <-innerErrChan:
+			if innerCancel != nil && errors.Is(err, context.Canceled) {
+				break // we triggered the cancellation ourselves
+			}
+			return err
+		default:
+		}
 	}
 
 	// Semi-join: emit the outer row when the inner had at least one match.
@@ -978,7 +1082,7 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 			if joinIndex == 0 {
 				outerRow = prefixRowAlias(currentRow, fromAlias)
 			}
-			return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables)
+			return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables, memos)
 		}
 		return nil
 	}
@@ -989,19 +1093,13 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 		if joinIndex == 0 {
 			outerRow = prefixRowAlias(currentRow, fromAlias)
 		}
-		return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables)
+		return p.executeJoinsForRow(ctx, provider, outerRow, joinIndex+1, filteredPipe, hashTables, memos)
 	}
 
 	// LEFT JOIN / FULL OUTER JOIN: emit the outer row with NULL-filled inner columns when nothing matched.
 	if !matched && (join.Type == Left || join.Type == FullOuter) {
-		nullInner := nullRowForColumns(innerTable.Columns)
-		var combinedRow Row
-		if joinIndex == 0 {
-			combinedRow = combineRows(currentRow, nullInner, fromAlias, innerScan.TableAlias)
-		} else {
-			combinedRow = combineRowsProgressive(currentRow, nullInner, innerScan.TableAlias)
-		}
-		if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables); err != nil {
+		combinedRow := combineRowWithNullInner(currentRow, memo.nullInnerCount, memo.combinedColumns)
+		if err := p.executeJoinsForRow(ctx, provider, combinedRow, joinIndex+1, filteredPipe, hashTables, memos); err != nil {
 			return err
 		}
 	}
@@ -1012,9 +1110,9 @@ func (p QueryPlan) executeJoinsForRow(ctx context.Context, provider TableProvide
 // executeHashJoinForRow probes the pre-built hash table for joinIndex and
 // recurses for matching inner rows.  Handles LEFT JOIN miss by emitting a
 // NULL-padded combined row when the probe finds no matches.
-func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, joinIndex int, filteredPipe chan<- Row, hashTables map[int]*hashJoinBucket) error {
+func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, joinIndex int, filteredPipe chan<- Row, hashTables map[int]*hashJoinBucket, memos []joinMemo) error {
 	join := p.Joins[joinIndex]
-	innerScan := p.Scans[join.RightScanIndex]
+	memo := memos[joinIndex]
 	fromAlias := p.Scans[join.LeftScanIndex].TableAlias
 
 	bucket := hashTables[joinIndex]
@@ -1041,39 +1139,24 @@ func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, jo
 			if joinIndex == 0 {
 				outerRow = prefixRowAlias(currentRow, fromAlias)
 			}
-			return p.executeJoinsForRow(ctx, nil, outerRow, joinIndex+1, filteredPipe, hashTables)
+			return p.executeJoinsForRow(ctx, nil, outerRow, joinIndex+1, filteredPipe, hashTables, memos)
 		}
 		return nil
 	}
 
 	matched := false
 	for _, innerRow := range matchingRows {
-		var combinedRow Row
-		if joinIndex == 0 {
-			combinedRow = combineRows(currentRow, innerRow, fromAlias, innerScan.TableAlias)
-		} else {
-			combinedRow = combineRowsProgressive(currentRow, innerRow, innerScan.TableAlias)
-		}
+		combinedRow := combineRowsWithSchema(currentRow, innerRow, memo.combinedColumns)
 		matched = true
-		if err := p.executeJoinsForRow(ctx, nil, combinedRow, joinIndex+1, filteredPipe, hashTables); err != nil {
+		if err := p.executeJoinsForRow(ctx, nil, combinedRow, joinIndex+1, filteredPipe, hashTables, memos); err != nil {
 			return err
 		}
 	}
 
 	// LEFT JOIN / FULL OUTER JOIN: no matching inner row — emit outer row with NULL inner columns.
 	if !matched && (join.Type == Left || join.Type == FullOuter) {
-		var innerColumns []Column
-		if bucket != nil {
-			innerColumns = bucket.innerColumns
-		}
-		nullInner := nullRowForColumns(innerColumns)
-		var combinedRow Row
-		if joinIndex == 0 {
-			combinedRow = combineRows(currentRow, nullInner, fromAlias, innerScan.TableAlias)
-		} else {
-			combinedRow = combineRowsProgressive(currentRow, nullInner, innerScan.TableAlias)
-		}
-		if err := p.executeJoinsForRow(ctx, nil, combinedRow, joinIndex+1, filteredPipe, hashTables); err != nil {
+		combinedRow := combineRowWithNullInner(currentRow, memo.nullInnerCount, memo.combinedColumns)
+		if err := p.executeJoinsForRow(ctx, nil, combinedRow, joinIndex+1, filteredPipe, hashTables, memos); err != nil {
 			return err
 		}
 	}

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -38,7 +38,7 @@ func buildCombinedColumns(outerCols []Column, outerAlias string, innerCols []Col
 
 // buildCombinedColumnsProgressive appends alias-prefixed inner columns to an
 // already-combined outer column list (joinIndex > 0).
-func buildCombinedColumnsProgressive(existingCols []Column, innerCols []Column, innerAlias string) []Column {
+func buildCombinedColumnsProgressive(existingCols, innerCols []Column, innerAlias string) []Column {
 	combined := make([]Column, 0, len(existingCols)+len(innerCols))
 	combined = append(combined, existingCols...)
 	for _, col := range innerCols {
@@ -84,12 +84,12 @@ func chanRowCallback(ctx context.Context, ch chan<- Row) func(Row) error {
 // planJoinQuery creates an optimized query plan for JOINs.
 // Supports arbitrary join topologies (star schema, chain joins, and mixed).
 // Optimizations:
-// 1. Use index on inner table join column when available (index nested loop join).
-// 2. Push single-table WHERE conditions into individual table scans.
-// 3. Use index scans for pushed-down conditions when a matching index exists.
-// 4. Greedy join reordering: when all tables have ANALYZE statistics and all
-//    joins are INNER, reorders the join sequence so the smallest tables are
-//    processed first, minimising intermediate result sizes.
+//  1. Use index on inner table join column when available (index nested loop join).
+//  2. Push single-table WHERE conditions into individual table scans.
+//  3. Use index scans for pushed-down conditions when a matching index exists.
+//  4. Greedy join reordering: when all tables have ANALYZE statistics and all
+//     joins are INNER, reorders the join sequence so the smallest tables are
+//     processed first, minimising intermediate result sizes.
 func (t *Table) planJoinQuery(ctx context.Context, stmt Statement) (QueryPlan, error) {
 	// Attempt greedy join reordering when statistics are available.
 	if plan, ok, err := t.planJoinQueryGreedy(ctx, stmt); err != nil {
@@ -427,7 +427,6 @@ func (t *Table) planJoinQueryGreedy(ctx context.Context, stmt Statement) (QueryP
 
 	return plan, true, nil
 }
-
 
 // flattenJoinTree recursively walks the join tree in DFS order and appends one
 // Scan and one JoinPlan entry per join node. LeftScanIndex is set to the scan

--- a/internal/minisql/query_plan_join_test.go
+++ b/internal/minisql/query_plan_join_test.go
@@ -559,6 +559,135 @@ func TestCombineRowsProgressive(t *testing.T) {
 	assert.True(t, v.Valid)
 }
 
+func TestBuildCombinedColumns(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "name", Kind: Varchar, Size: 50},
+	}
+	innerCols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "amount", Kind: Int8, Size: 8},
+	}
+
+	t.Run("with aliases", func(t *testing.T) {
+		cols := buildCombinedColumns(outerCols, "u", innerCols, "o")
+		require.Len(t, cols, 4)
+		assert.Equal(t, "u.id", cols[0].Name)
+		assert.Equal(t, "u.name", cols[1].Name)
+		assert.Equal(t, "o.id", cols[2].Name)
+		assert.Equal(t, "o.amount", cols[3].Name)
+		assert.Equal(t, Int8, cols[0].Kind)
+		assert.Equal(t, Varchar, cols[1].Kind)
+	})
+
+	t.Run("outer alias empty", func(t *testing.T) {
+		cols := buildCombinedColumns(outerCols, "", innerCols, "o")
+		require.Len(t, cols, 4)
+		// outer columns keep original names when alias is empty
+		assert.Equal(t, "id", cols[0].Name)
+		assert.Equal(t, "name", cols[1].Name)
+		assert.Equal(t, "o.id", cols[2].Name)
+		assert.Equal(t, "o.amount", cols[3].Name)
+	})
+}
+
+func TestBuildCombinedColumnsProgressive(t *testing.T) {
+	t.Parallel()
+
+	existingCols := []Column{
+		{Name: "u.id", Kind: Int8, Size: 8},
+		{Name: "o.amount", Kind: Int8, Size: 8},
+	}
+	innerCols := []Column{
+		{Name: "code", Kind: Varchar, Size: 10},
+	}
+
+	cols := buildCombinedColumnsProgressive(existingCols, innerCols, "s")
+
+	require.Len(t, cols, 3)
+	assert.Equal(t, "u.id", cols[0].Name)
+	assert.Equal(t, "o.amount", cols[1].Name)
+	assert.Equal(t, "s.code", cols[2].Name)
+	assert.Equal(t, Int8, cols[0].Kind)
+	assert.Equal(t, Varchar, cols[2].Kind)
+}
+
+func TestCombineRowsWithSchema(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "name", Kind: Varchar, Size: 50},
+	}
+	innerCols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "amount", Kind: Int8, Size: 8},
+	}
+	combinedCols := buildCombinedColumns(outerCols, "u", innerCols, "o")
+
+	outerRow := NewRowWithValues(outerCols, []OptionalValue{
+		{Value: int64(1), Valid: true},
+		{Value: NewTextPointer([]byte("Alice")), Valid: true},
+	})
+	innerRow := NewRowWithValues(innerCols, []OptionalValue{
+		{Value: int64(10), Valid: true},
+		{Value: int64(200), Valid: true},
+	})
+
+	combined := combineRowsWithSchema(outerRow, innerRow, combinedCols)
+
+	require.Len(t, combined.Columns, 4)
+	assert.Equal(t, "u.id", combined.Columns[0].Name)
+	assert.Equal(t, "o.amount", combined.Columns[3].Name)
+
+	v, ok := combined.GetValue("u.id")
+	require.True(t, ok)
+	assert.Equal(t, int64(1), v.Value)
+
+	v, ok = combined.GetValue("o.amount")
+	require.True(t, ok)
+	assert.Equal(t, int64(200), v.Value)
+}
+
+func TestCombineRowWithNullInner(t *testing.T) {
+	t.Parallel()
+
+	outerCols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+	}
+	innerCols := []Column{
+		{Name: "user_id", Kind: Int8, Size: 8},
+		{Name: "total", Kind: Int8, Size: 8},
+	}
+	combinedCols := buildCombinedColumns(outerCols, "u", innerCols, "o")
+
+	outer := NewRowWithValues(outerCols, []OptionalValue{
+		{Value: int64(42), Valid: true},
+	})
+
+	combined := combineRowWithNullInner(outer, len(innerCols), combinedCols)
+
+	require.Len(t, combined.Columns, 3)
+	require.Len(t, combined.Values, 3)
+
+	// Outer value is preserved.
+	v, ok := combined.GetValue("u.id")
+	require.True(t, ok)
+	assert.Equal(t, int64(42), v.Value)
+	assert.True(t, v.Valid)
+
+	// Inner values are zero-value (NULL).
+	v, ok = combined.GetValue("o.user_id")
+	require.True(t, ok)
+	assert.False(t, v.Valid)
+
+	v, ok = combined.GetValue("o.total")
+	require.True(t, ok)
+	assert.False(t, v.Valid)
+}
+
 func TestCompileJoinConditions(t *testing.T) {
 	t.Parallel()
 
@@ -911,4 +1040,140 @@ func TestCollectJoinGraph_NoFromAlias_ReturnsFalse(t *testing.T) {
 
 	_, _, ok := tblA.collectJoinGraph(t.Context(), stmt)
 	assert.False(t, ok)
+}
+
+func TestChanRowCallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends row to channel", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan Row, 1)
+		cb := chanRowCallback(ctx, ch)
+
+		row := NewRowWithValues([]Column{{Name: "id", Kind: Int8, Size: 8}}, []OptionalValue{{Value: int64(1), Valid: true}})
+		err := cb(row)
+		require.NoError(t, err)
+
+		received := <-ch
+		assert.Equal(t, row.Values, received.Values)
+	})
+
+	t.Run("returns ctx.Err when context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+		ch := make(chan Row) // unbuffered — send would block
+		cb := chanRowCallback(ctx, ch)
+
+		row := NewRowWithValues([]Column{{Name: "id", Kind: Int8, Size: 8}}, []OptionalValue{{Value: int64(1), Valid: true}})
+		err := cb(row)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestDrainRowCh(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan Row, 3)
+	ch <- NewRowWithValues(nil, nil)
+	ch <- NewRowWithValues(nil, nil)
+	close(ch)
+
+	// Should return without blocking after draining all values.
+	drainRowCh(ch)
+}
+
+func TestDrainParallelScanCh(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan parallelScanResult, 2)
+	ch <- parallelScanResult{row: NewRowWithValues(nil, nil)}
+	close(ch)
+
+	drainParallelScanCh(ch)
+}
+
+func TestPushDownFilters_UnknownAlias(t *testing.T) {
+	t.Parallel()
+
+	// WHERE x.foo = 1 where 'x' is not the base table alias and not a join alias.
+	// The condition should fall through to the base group.
+	conditions := OneOrMore{
+		{
+			FieldIsEqual(Field{AliasPrefix: "x", Name: "foo"}, OperandInteger, int64(1)),
+		},
+	}
+	joins := []Join{
+		{TableName: "profiles", TableAlias: "p"},
+	}
+
+	baseFilters, joinFilters := pushDownFilters(conditions, "u", joins)
+
+	assert.Len(t, baseFilters, 1, "Unknown alias condition falls back to base group")
+	assert.Len(t, baseFilters[0], 1)
+	assert.Len(t, joinFilters["p"], 0)
+}
+
+func TestExtractJoinColumnPairs_NonFieldOperand(t *testing.T) {
+	t.Parallel()
+
+	baseTable := &Table{
+		Name:        "a",
+		Columns:     []Column{{Name: "id", Kind: Int8, Size: 8}},
+		columnCache: map[string]int{"id": 0},
+	}
+	joinTable := &Table{
+		Name:        "b",
+		Columns:     []Column{{Name: "a_id", Kind: Int8, Size: 8}},
+		columnCache: map[string]int{"a_id": 0},
+	}
+
+	// Condition with a non-field operand on the left — must be skipped.
+	conditions := Conditions{
+		{
+			Operand1: Operand{Type: OperandInteger, Value: int64(1)},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandField, Value: Field{AliasPrefix: "b", Name: "a_id"}},
+		},
+	}
+
+	pairs, err := extractJoinColumnPairs(conditions, "a", "b", baseTable, joinTable)
+	assert.Error(t, err)
+	assert.Nil(t, pairs)
+}
+
+func TestFindIndexOnColumns_SkipNonBTreeAndPartial(t *testing.T) {
+	t.Parallel()
+
+	tbl := &Table{
+		Name: "docs",
+		PrimaryKey: PrimaryKey{
+			IndexInfo: IndexInfo{
+				Name:    "pk",
+				Columns: []Column{{Name: "other_col", Kind: Int8, Size: 8}},
+			},
+		},
+		UniqueIndexes: map[string]UniqueIndex{},
+		SecondaryIndexes: map[string]SecondaryIndex{
+			"ft_idx": {
+				IndexInfo: IndexInfo{
+					Name:    "ft_idx",
+					Columns: []Column{{Name: "title", Kind: Varchar, Size: 255}},
+					Method:  IndexMethodFullText, // non-BTree → should be skipped
+				},
+			},
+			"partial_idx": {
+				IndexInfo: IndexInfo{
+					Name:        "partial_idx",
+					Columns:     []Column{{Name: "title", Kind: Varchar, Size: 255}},
+					Method:      IndexMethodBTree,
+					WhereClause: "active = true", // partial → should be skipped
+				},
+			},
+		},
+	}
+
+	// Searching for "title" column — neither the FTS nor the partial index should match.
+	result := tbl.findIndexOnColumns([]string{"title"})
+	assert.Nil(t, result, "non-BTree and partial indexes should be skipped")
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1092,6 +1092,78 @@ func (t *Table) indexPointScan(ctx context.Context, scan Scan, selectedFields []
 	return nil
 }
 
+// indexPointGetAll collects all rows matching the index keys in scan and
+// returns them as a slice.  Returns nil when no rows match (zero allocation).
+// Unlike indexPointScan, no callback closure is required from the caller,
+// which eliminates per-outer-row heap allocations in hot join paths where
+// indexPointScan's callback closure would otherwise escape.
+func (t *Table) indexPointGetAll(ctx context.Context, scan Scan, selectedFields []Field) ([]Row, error) {
+	idx, ok := t.IndexByName(scan.IndexName)
+	if !ok {
+		return nil, fmt.Errorf("no index found for point scan: %s", scan.IndexName)
+	}
+	selectedMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+	coveringFilter := compileScanFilter(scan.IndexColumns, scan.Filters)
+	// Extract fields used inside the inner closure so scan does not escape to
+	// the heap through the closure — the compiler can then keep scan on the stack.
+	isCovering := scan.CoveringIndex
+	idxColumns := scan.IndexColumns
+	nSelected := len(selectedFields)
+
+	var rows []Row
+	for _, indexValue := range scan.IndexKeys {
+		if err := idx.VisitRowIDs(ctx, indexValue, func(rowID RowID) error {
+			var row Row
+			switch {
+			case isCovering:
+				row = rowFromIndexKey(indexValue, idxColumns, rowID)
+			case nSelected == 0:
+				row = NewRowWithValues(t.Columns, nil)
+				row.Key = rowID
+			default:
+				cursor, err := t.Seek(ctx, rowID)
+				if err != nil {
+					return fmt.Errorf("find row failed: %w", err)
+				}
+				row, err = cursor.fetchRowWithMask(ctx, false, selectedMask)
+				if err != nil {
+					return fmt.Errorf("fetch row failed: %w", err)
+				}
+				if tableFilter != nil {
+					ok, err := tableFilter(row)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil
+					}
+				}
+			}
+			if isCovering && coveringFilter != nil {
+				ok, err := coveringFilter(row)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return nil
+				}
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			rows = append(rows, row)
+			return nil
+		}); err != nil {
+			if errors.Is(err, ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("index lookup failed: %w", err)
+		}
+	}
+	return rows, nil
+}
+
 func (t *Table) fullTextIndexScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {
 	secondaryIndex, ok := t.SecondaryIndexes[scan.IndexName]
 	if !ok || secondaryIndex.Method != IndexMethodFullText || secondaryIndex.InvertedIndex == nil {


### PR DESCRIPTION
Four targeted optimizations to the join execution path:

1. Precompute joinMemo per join level in executeNestedLoopJoin
   - Moves inner table lookup, fieldsFromColumns, combined column schema computation, and join filter compilation out of the per-outer-row path
   - Adds buildCombinedColumns / buildCombinedColumnsProgressive helpers
   - Adds combineRowsWithSchema (values-only allocation, reuses column slice)
   - Adds combineRowWithNullInner (LEFT JOIN miss without allocating null Row)

2. Replace indexPointScan callback with indexPointGetAll
   - The func(Row)error closure passed to indexPointScan escaped to the heap once per outer row, costing ~623 MB per benchmark run even when the inner table had no matching rows (closure created but never called)
   - indexPointGetAll returns a []Row slice; returns nil for unmatched rows with zero allocation in the common empty-result case

3. Inline processInnerRow closure
   - Removed the shared closure that was heap-allocated once per outer row
   - Logic is now inlined at both call sites (index and sequential paths)

4. Pass innerScan as goroutine argument instead of capturing it
   - Static escape analysis caused the Scan struct (~200 B) to be heap-allocated for every outer row, even rows taking the index-scan branch (which never starts the goroutine)
   - Passing by value as a goroutine argument allows the calling frame's copy to stay on the stack

Benchmark results (Apple M1 Max):
  LEFT JOIN unmatched:  42.9 ms → 11.9 ms (3.6× faster), 90 MB → 12.9 MB (7× less)
  INNER JOIN:           12.6 ms →  8.6 ms (1.5× faster), 17 MB → 12.0 MB (1.4× less)
  vs SQLite ratio:      LEFT JOIN 10.7× → 2.9×, INNER JOIN 2.5× → 1.8×