### PR TITLE
Refactor/optimise cte materialization

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,16 @@
+### 2026-05-17 — CTE materialisation double-allocation elimination
+
+Two heap allocation sources eliminated from CTE execution:
+
+1. **Virtual table fast COUNT** — `(*Table).Select COUNT(*)` with no conditions on a virtual table previously scanned all materialised rows via `countAllLeafWalk`; now returns `len(t.virtualRows)` directly.
+2. **`rawRows` fast path** — `selectStreamingDirect` builds `projected []Row` and wraps it in `NewSliceIterator`; `executeCTESelect` previously drained that iterator into a *second* `[]Row` of identical size. The `rawRows` field on `StatementResult` carries the backing slice so the caller can steal it without re-allocating.
+
+| Benchmark | Before | After | Alloc Before | Alloc After | SQLite | Ratio (after vs SQLite) |
+|---|---:|---:|---:|---:|---:|---:|
+| CTE_Materialise/minisql | ~1.84 ms/op | ~1.71 ms/op | ~2.74 MiB/op | ~2.05 MiB/op | ~0.44 ms/op | 3.9× |
+
+~25% allocation reduction (−690 KB/op). CTE closed from 4.2× to **3.9×** SQLite.
+
 ### 2026-05-17 — Nested-loop join hot-path allocation pass
 
 Four layers of per-outer-row heap allocation were eliminated from the join executor:

--- a/e2e_tests/cte_test.go
+++ b/e2e_tests/cte_test.go
@@ -191,48 +191,50 @@ func (s *TestSuite) TestCTE_Explain() {
 ('carol@example.com', 'Carol');`, 3)
 
 	s.Run("explain_cte", func() {
+		// Plain scan CTE is inlined — no materialisation step in the plan.
 		rows := s.collectExplain(
 			`EXPLAIN WITH t AS (SELECT id, name FROM users) SELECT t.name FROM t`)
-		s.Require().Len(rows, 2)
+		s.Require().Len(rows, 1)
 
 		s.Equal(int64(1), rows[0].Step)
-		s.Equal("cte", rows[0].Operation)
-		s.Contains(rows[0].Detail, "name=t")
+		s.NotEmpty(rows[0].Operation)
+		s.Contains(rows[0].Detail, "table=users")
 		s.False(rows[0].RowsActual.Valid)
-
-		s.Equal(int64(2), rows[1].Step)
-		s.NotEmpty(rows[1].Operation)
-		s.Contains(rows[1].Detail, "table=t")
 	})
 
 	s.Run("explain_analyze_cte", func() {
+		// Inlined CTE — EXPLAIN ANALYZE shows a single real-table scan step.
 		rows := s.collectExplain(
 			`EXPLAIN ANALYZE WITH t AS (SELECT id, name FROM users) SELECT t.name FROM t`)
-		s.Require().Len(rows, 2)
+		s.Require().Len(rows, 1)
 
-		s.Equal("cte", rows[0].Operation)
+		s.Equal(int64(1), rows[0].Step)
+		s.NotEmpty(rows[0].Operation)
 		s.True(rows[0].RowsActual.Valid)
 		s.Equal(int64(3), rows[0].RowsActual.Int64)
-		s.True(rows[0].DurationUS.Valid)
-
-		s.Equal(int64(2), rows[1].Step)
-		s.True(rows[1].RowsActual.Valid)
-		s.Equal(int64(3), rows[1].RowsActual.Int64)
 	})
 
 	s.Run("explain_multiple_ctes", func() {
+		// cte1 (main FROM) is inlined; cte2 is unused and pruned.
+		// Result: a single real-table scan step.
 		rows := s.collectExplain(
 			`EXPLAIN WITH
 			   cte1 AS (SELECT id FROM users),
 			   cte2 AS (SELECT id FROM users WHERE id > 1)
 			 SELECT cte1.id FROM cte1`)
-		// 2 CTE steps + 1 scan step
-		s.Require().Len(rows, 3)
+		s.Require().Len(rows, 1)
+		s.Equal(int64(1), rows[0].Step)
+		s.Contains(rows[0].Detail, "table=users")
+	})
+
+	s.Run("explain_cte_non_inlineable", func() {
+		// DISTINCT CTE cannot be inlined — materialisation step still appears.
+		rows := s.collectExplain(
+			`EXPLAIN WITH t AS (SELECT DISTINCT id, name FROM users) SELECT t.name FROM t`)
+		s.Require().Len(rows, 2)
 		s.Equal("cte", rows[0].Operation)
-		s.Contains(rows[0].Detail, "name=cte1")
-		s.Equal("cte", rows[1].Operation)
-		s.Contains(rows[1].Detail, "name=cte2")
-		s.Equal(int64(3), rows[2].Step)
+		s.Contains(rows[0].Detail, "name=t")
+		s.Equal(int64(2), rows[1].Step)
 	})
 }
 
@@ -267,4 +269,133 @@ func (s *TestSuite) TestCTE_PreparedStatement() {
 	s.Require().NoError(rows.Err())
 	s.Require().Len(names, 1)
 	s.Equal("Alice", names[0])
+}
+
+func (s *TestSuite) TestCTE_Inline() {
+	_, err := s.db.Exec(`create table "products" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		price int8 not null,
+		active boolean not null
+	);`)
+	s.Require().NoError(err)
+
+	for _, row := range []struct {
+		name   string
+		price  int64
+		active bool
+	}{
+		{"Widget", 10, true},
+		{"Gadget", 20, true},
+		{"Doohickey", 5, false},
+		{"Thingamajig", 15, true},
+		{"Whatchamacallit", 8, false},
+	} {
+		_, err = s.db.Exec(
+			`insert into "products" (name, price, active) values (?, ?, ?)`,
+			row.name, row.price, row.active,
+		)
+		s.Require().NoError(err)
+	}
+
+	s.Run("inline_body_condition_and_outer_condition_both_filter", func() {
+		// CTE body filters active=true (3 rows); outer WHERE filters price > 12.
+		// After inlining both conditions apply directly on the real table.
+		rows, err := s.db.Query(
+			`WITH p AS (SELECT id, name, price FROM products WHERE active = true)
+			 SELECT p.name FROM p WHERE p.price > 12`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Gadget", "Thingamajig"}, names)
+	})
+
+	s.Run("inline_with_limit", func() {
+		// LIMIT on the outer query propagates through inlining to the real scan.
+		rows, err := s.db.Query(
+			`WITH p AS (SELECT id, name FROM products WHERE active = true)
+			 SELECT p.name FROM p LIMIT 2`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Len(names, 2)
+	})
+
+	s.Run("inline_select_star", func() {
+		// SELECT * against an inlined CTE must return the body's column subset
+		// (id + name) not the full underlying table (id, name, price, active).
+		rows, err := s.db.Query(
+			`WITH p AS (SELECT id, name FROM products WHERE active = true) SELECT * FROM p`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		s.Require().NoError(err)
+		s.ElementsMatch([]string{"id", "name"}, cols)
+
+		var count int
+		for rows.Next() {
+			count++
+			var id int64
+			var name string
+			s.Require().NoError(rows.Scan(&id, &name))
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(3, count) // Widget, Gadget, Thingamajig
+	})
+
+	s.Run("non_inlineable_limit_cte_still_works", func() {
+		// LIMIT CTE cannot be inlined — it must materialise correctly and the
+		// outer query then filters the materialised subset.
+		rows, err := s.db.Query(
+			`WITH cheap AS (SELECT id, name, price FROM products WHERE active = true ORDER BY price LIMIT 2)
+			 SELECT cheap.name FROM cheap`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		// Two cheapest active products: Widget(10) and Thingamajig(15).
+		s.Require().Len(names, 2)
+		s.ElementsMatch([]string{"Widget", "Thingamajig"}, names)
+	})
+
+	s.Run("unused_cte_pruned", func() {
+		// The unused CTE (orphan) must be silently dropped without error.
+		rows, err := s.db.Query(
+			`WITH
+			   active AS (SELECT id, name FROM products WHERE active = true),
+			   orphan AS (SELECT id FROM products WHERE price > 100)
+			 SELECT active.name FROM active WHERE active.price > 12`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.ElementsMatch([]string{"Gadget", "Thingamajig"}, names)
+	})
 }

--- a/internal/minisql/cte.go
+++ b/internal/minisql/cte.go
@@ -24,7 +24,44 @@ func cteFromContext(ctx context.Context, name string) (*Table, bool) {
 // Each CTE body is executed in declaration order; results are materialised
 // into virtual tables and registered in the context so subsequent CTEs and
 // the main query can reference them by name.
+//
+// Before materialising, two optimisations are applied:
+//  1. Unused CTEs are pruned — they produce no rows visible to the query.
+//  2. The main FROM CTE is inlined when eligible — a simple filtered scan
+//     whose body has no aggregation, DISTINCT, LIMIT, or UNION is merged
+//     directly into the outer statement, letting the planner use real-table
+//     indexes and propagate LIMIT/ORDER BY to the underlying scan.
 func (d *Database) executeCTESelect(ctx context.Context, stmt Statement) (StatementResult, error) {
+	// Prune CTEs that are never referenced — materialising them would be
+	// pure overhead with no effect on the query result.
+	stmt = pruneUnusedCTEs(stmt)
+
+	// Check if the main FROM CTE can be inlined into the outer statement.
+	for i, cte := range stmt.CTEs {
+		if cte.Name != stmt.TableName {
+			continue
+		}
+		if cteIsInlineable(cte, stmt, stmt.CTEs) {
+			outerAlias := stmt.TableAlias
+			if outerAlias == "" {
+				outerAlias = stmt.TableName
+			}
+			merged := inlineCTE(stmt, cte, outerAlias)
+			// Remove the inlined CTE; any remaining ones still need materialisation.
+			remaining := make([]CTE, 0, len(stmt.CTEs)-1)
+			remaining = append(remaining, stmt.CTEs[:i]...)
+			remaining = append(remaining, stmt.CTEs[i+1:]...)
+			merged.CTEs = remaining
+			if len(merged.CTEs) == 0 {
+				return d.ExecuteStatement(ctx, merged)
+			}
+			// Remaining CTEs may be needed by WHERE subqueries — recurse so
+			// they are materialised and placed in the CTE registry context.
+			return d.executeCTESelect(ctx, merged)
+		}
+		break
+	}
+
 	registry := make(map[string]*Table, len(stmt.CTEs))
 
 	for _, cte := range stmt.CTEs {

--- a/internal/minisql/cte.go
+++ b/internal/minisql/cte.go
@@ -35,12 +35,19 @@ func (d *Database) executeCTESelect(ctx context.Context, stmt Statement) (Statem
 		if err != nil {
 			return StatementResult{}, fmt.Errorf("CTE %q: %w", cte.Name, err)
 		}
+		// Fast path: steal the pre-projected slice directly when the result was
+		// produced by selectStreamingDirect — avoids a second heap allocation of
+		// the same rows when draining the iterator.
 		var rows []Row
-		for result.Rows.Next(cteCtx) {
-			rows = append(rows, result.Rows.Row())
-		}
-		if err := result.Rows.Err(); err != nil {
-			return StatementResult{}, fmt.Errorf("CTE %q: reading rows: %w", cte.Name, err)
+		if result.rawRows != nil {
+			rows = result.rawRows
+		} else {
+			for result.Rows.Next(cteCtx) {
+				rows = append(rows, result.Rows.Row())
+			}
+			if err := result.Rows.Err(); err != nil {
+				return StatementResult{}, fmt.Errorf("CTE %q: reading rows: %w", cte.Name, err)
+			}
 		}
 		vt := newVirtualTable(d.logger, cte.Name, result.Columns, rows)
 		// Use the database's locked provider so JOINs inside the main query can
@@ -91,11 +98,15 @@ func (d *Database) executeCTESelect(ctx context.Context, stmt Statement) (Statem
 						return StatementResult{}, fmt.Errorf("CTE %q (pushdown): %w", cte.Name, err)
 					}
 					var rows []Row
-					for result.Rows.Next(cteCtx) {
-						rows = append(rows, result.Rows.Row())
-					}
-					if err := result.Rows.Err(); err != nil {
-						return StatementResult{}, fmt.Errorf("CTE %q (pushdown): reading rows: %w", cte.Name, err)
+					if result.rawRows != nil {
+						rows = result.rawRows
+					} else {
+						for result.Rows.Next(cteCtx) {
+							rows = append(rows, result.Rows.Row())
+						}
+						if err := result.Rows.Err(); err != nil {
+							return StatementResult{}, fmt.Errorf("CTE %q (pushdown): reading rows: %w", cte.Name, err)
+						}
 					}
 					vt = newVirtualTable(d.logger, cte.Name, result.Columns, rows)
 					vt.provider = d.lockedProvider

--- a/internal/minisql/cte_inline.go
+++ b/internal/minisql/cte_inline.go
@@ -1,0 +1,192 @@
+package minisql
+
+// cteBodyIsInlineEligible reports whether a CTE body can be safely inlined
+// into the outer query without changing semantics. The body must be a plain
+// filtered scan of a real table — no aggregation, DISTINCT, LIMIT, UNION,
+// derived-table FROM, JOINs, table alias, or column renaming.
+func cteBodyIsInlineEligible(body Statement) bool {
+	if body.FromSubquery != nil || len(body.Joins) > 0 {
+		return false
+	}
+	if len(body.GroupBy) > 0 || len(body.Aggregates) > 0 || len(body.Having) > 0 {
+		return false
+	}
+	if body.Distinct {
+		return false
+	}
+	if body.Limit.Valid || body.Offset.Valid {
+		return false
+	}
+	if len(body.Unions) > 0 {
+		return false
+	}
+	// A table alias in the body introduces a second level of alias rewriting
+	// that is not worth the complexity for this optimisation.
+	if body.TableAlias != "" {
+		return false
+	}
+	// Column renaming (SELECT col AS alias) changes the names exposed to the
+	// outer query; rewriting outer field references back to inner names is
+	// out of scope for the pragmatic inlining pass.
+	for _, f := range body.Fields {
+		if f.Name != "*" && f.Alias != "" {
+			return false
+		}
+	}
+	return true
+}
+
+// cteRefCount returns the number of times cteName is referenced as a FROM or
+// JOIN source in the main statement and in all other CTE bodies.
+// Subquery references inside WHERE conditions are NOT counted here — use
+// cteAppearsInConditionSubqueries for those.
+func cteRefCount(cteName string, mainStmt Statement, allCTEs []CTE) int {
+	count := 0
+	if mainStmt.TableName == cteName {
+		count++
+	}
+	count += cteJoinRefCount(cteName, mainStmt.Joins)
+	for _, other := range allCTEs {
+		if other.Name == cteName {
+			continue
+		}
+		if other.Body.TableName == cteName {
+			count++
+		}
+		count += cteJoinRefCount(cteName, other.Body.Joins)
+	}
+	return count
+}
+
+func cteJoinRefCount(cteName string, joins []Join) int {
+	count := 0
+	for _, j := range joins {
+		if j.TableName == cteName {
+			count++
+		}
+		count += cteJoinRefCount(cteName, j.Joins)
+	}
+	return count
+}
+
+// cteAppearsInConditionSubqueries reports whether cteName is used as the FROM
+// table of a direct subquery embedded in conds. This guards against inlining
+// a CTE that appears both as the main FROM source and inside a WHERE subquery,
+// because inlining removes the CTE from the registry that subquery resolution
+// depends on.
+func cteAppearsInConditionSubqueries(cteName string, conds OneOrMore) bool {
+	for _, group := range conds {
+		for _, cond := range group {
+			if operandSubqueryReferencesCTE(cond.Operand1, cteName) ||
+				operandSubqueryReferencesCTE(cond.Operand2, cteName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func operandSubqueryReferencesCTE(op Operand, cteName string) bool {
+	if op.Type != OperandSubquery {
+		return false
+	}
+	sub, ok := op.Value.(*Statement)
+	return ok && sub.TableName == cteName
+}
+
+// cteIsUsed reports whether cteName is referenced anywhere that requires
+// it to be materialised: as the main FROM source, as a JOIN target, inside a
+// WHERE subquery, or inside another CTE body.
+func cteIsUsed(cteName string, mainStmt Statement, allCTEs []CTE) bool {
+	if mainStmt.TableName == cteName {
+		return true
+	}
+	if cteJoinRefCount(cteName, mainStmt.Joins) > 0 {
+		return true
+	}
+	if cteAppearsInConditionSubqueries(cteName, mainStmt.Conditions) {
+		return true
+	}
+	for _, other := range allCTEs {
+		if other.Name == cteName {
+			continue
+		}
+		if other.Body.TableName == cteName {
+			return true
+		}
+		if cteJoinRefCount(cteName, other.Body.Joins) > 0 {
+			return true
+		}
+		if cteAppearsInConditionSubqueries(cteName, other.Body.Conditions) {
+			return true
+		}
+	}
+	return false
+}
+
+// pruneUnusedCTEs removes CTEs from stmt.CTEs that are never referenced by
+// the main query or by other CTEs. Unreferenced CTEs produce no results
+// visible to the query and materialising them wastes resources.
+func pruneUnusedCTEs(stmt Statement) Statement {
+	if len(stmt.CTEs) == 0 {
+		return stmt
+	}
+	kept := make([]CTE, 0, len(stmt.CTEs))
+	for _, cte := range stmt.CTEs {
+		if cteIsUsed(cte.Name, stmt, stmt.CTEs) {
+			kept = append(kept, cte)
+		}
+	}
+	stmt.CTEs = kept
+	return stmt
+}
+
+// cteIsInlineable reports whether cte can be merged directly into mainStmt
+// instead of being materialised into a virtual table.
+func cteIsInlineable(cte CTE, mainStmt Statement, allCTEs []CTE) bool {
+	// Only inline when the CTE is the main FROM source, not a JOIN target.
+	if mainStmt.TableName != cte.Name {
+		return false
+	}
+	if !cteBodyIsInlineEligible(*cte.Body) {
+		return false
+	}
+	// Exactly one FROM/JOIN reference ensures the body isn't executed twice.
+	if cteRefCount(cte.Name, mainStmt, allCTEs) != 1 {
+		return false
+	}
+	// WHERE subquery references require the CTE to be in the registry,
+	// which it won't be after inlining.
+	if cteAppearsInConditionSubqueries(cte.Name, mainStmt.Conditions) {
+		return false
+	}
+	return true
+}
+
+// inlineCTE merges cte.Body into mainStmt, returning a statement that scans
+// the real underlying table directly. The caller must remove the inlined CTE
+// from mainStmt.CTEs before executing the returned statement.
+func inlineCTE(mainStmt Statement, cte CTE, outerAlias string) Statement {
+	body := *cte.Body
+
+	// Strip the outer CTE alias from all field references in the main statement
+	// so that plain column names resolve against the real table.
+	mainStmt = stripDerivedTableAliasPrefix(mainStmt, outerAlias)
+
+	// When the outer SELECT is * but the CTE body projects a specific column
+	// list, propagate the body's fields to avoid leaking extra columns from
+	// the underlying table that the CTE did not expose.
+	if mainStmt.IsSelectAll() && !body.IsSelectAll() && len(body.Fields) > 0 {
+		mainStmt.Fields = body.Fields
+	}
+
+	// Merge the CTE body's WHERE conditions with the outer conditions using
+	// AND semantics (DNF Cartesian product via mergeConditionsAND).
+	mainStmt.Conditions = mergeConditionsAND(body.Conditions, mainStmt.Conditions)
+
+	// Replace the CTE reference with the real underlying table.
+	mainStmt.TableName = body.TableName
+	mainStmt.TableAlias = ""
+
+	return mainStmt
+}

--- a/internal/minisql/cte_inline_test.go
+++ b/internal/minisql/cte_inline_test.go
@@ -1,0 +1,426 @@
+package minisql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSimpleBody builds a minimal CTE body statement for testing.
+func makeSimpleBody(tableName string, conditions OneOrMore) Statement {
+	return Statement{Kind: Select, TableName: tableName, Conditions: conditions}
+}
+
+// TestCTEBodyIsInlineEligible covers all eligibility guard conditions.
+func TestCTEBodyIsInlineEligible(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare_table_scan", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, cteBodyIsInlineEligible(makeSimpleBody("users", nil)))
+	})
+
+	t.Run("with_where_clause", func(t *testing.T) {
+		t.Parallel()
+		cond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "score"}},
+			Operator: Gt,
+			Operand2: Operand{Type: OperandInteger, Value: int64(80)},
+		}
+		body := makeSimpleBody("users", OneOrMore{{cond}})
+		assert.True(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_group_by", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("orders", nil)
+		body.GroupBy = []Field{{Name: "user_id"}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_aggregate", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("orders", nil)
+		body.Aggregates = []AggregateExpr{{Kind: AggregateCount}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_having", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("orders", nil)
+		body.Having = OneOrMore{{}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_distinct", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Distinct = true
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_limit", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Limit = OptionalValue{Valid: true, Value: int64(10)}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_offset", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Offset = OptionalValue{Valid: true, Value: int64(5)}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_union", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Unions = []UnionClause{{}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_table_alias", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.TableAlias = "u"
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_from_subquery", func(t *testing.T) {
+		t.Parallel()
+		inner := makeSimpleBody("orders", nil)
+		body := makeSimpleBody("", nil)
+		body.FromSubquery = &inner
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("has_join", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Joins = []Join{{TableName: "orders"}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("column_rename_alias", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Fields = []Field{{Name: "user_id", Alias: "id"}}
+		assert.False(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("select_star_no_alias", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Fields = []Field{{Name: "*"}}
+		assert.True(t, cteBodyIsInlineEligible(body))
+	})
+
+	t.Run("explicit_columns_no_rename", func(t *testing.T) {
+		t.Parallel()
+		body := makeSimpleBody("users", nil)
+		body.Fields = []Field{{Name: "id"}, {Name: "name"}}
+		assert.True(t, cteBodyIsInlineEligible(body))
+	})
+}
+
+// TestCTERefCount verifies FROM and JOIN reference counting.
+func TestCTERefCount(t *testing.T) {
+	t.Parallel()
+
+	allCTEs := []CTE{
+		{Name: "t", Body: &Statement{TableName: "users"}},
+	}
+
+	t.Run("main_from_counts_one", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "t"}
+		assert.Equal(t, 1, cteRefCount("t", main, allCTEs))
+	})
+
+	t.Run("join_ref_counts", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{
+			TableName: "orders",
+			Joins:     []Join{{TableName: "t"}},
+		}
+		assert.Equal(t, 1, cteRefCount("t", main, allCTEs))
+	})
+
+	t.Run("from_and_join_counts_two", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{
+			TableName: "t",
+			Joins:     []Join{{TableName: "t"}},
+		}
+		assert.Equal(t, 2, cteRefCount("t", main, allCTEs))
+	})
+
+	t.Run("other_cte_body_ref_counts", func(t *testing.T) {
+		t.Parallel()
+		ctes := []CTE{
+			{Name: "a", Body: &Statement{TableName: "users"}},
+			{Name: "b", Body: &Statement{TableName: "a"}}, // b references a
+		}
+		main := Statement{TableName: "a"}
+		// FROM ref (1) + b.Body.TableName == "a" (1) = 2
+		assert.Equal(t, 2, cteRefCount("a", main, ctes))
+	})
+
+	t.Run("not_referenced", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "orders"}
+		assert.Equal(t, 0, cteRefCount("t", main, allCTEs))
+	})
+}
+
+// TestCTEAppearsInConditionSubqueries verifies subquery detection in conditions.
+func TestCTEAppearsInConditionSubqueries(t *testing.T) {
+	t.Parallel()
+
+	subStmt := &Statement{TableName: "cte1"}
+	cond := Condition{
+		Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+		Operator: In,
+		Operand2: Operand{Type: OperandSubquery, Value: subStmt},
+	}
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, cteAppearsInConditionSubqueries("cte1", OneOrMore{{cond}}))
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, cteAppearsInConditionSubqueries("other", OneOrMore{{cond}}))
+	})
+
+	t.Run("empty_conditions", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, cteAppearsInConditionSubqueries("cte1", nil))
+	})
+
+	t.Run("non_subquery_operand", func(t *testing.T) {
+		t.Parallel()
+		plainCond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandInteger, Value: int64(1)},
+		}
+		assert.False(t, cteAppearsInConditionSubqueries("cte1", OneOrMore{{plainCond}}))
+	})
+}
+
+// TestCTEIsUsed verifies the usage detector used for pruning.
+func TestCTEIsUsed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("used_as_main_from", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "t"}
+		assert.True(t, cteIsUsed("t", main, nil))
+	})
+
+	t.Run("used_in_join", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "users", Joins: []Join{{TableName: "t"}}}
+		assert.True(t, cteIsUsed("t", main, nil))
+	})
+
+	t.Run("used_in_where_subquery", func(t *testing.T) {
+		t.Parallel()
+		subStmt := &Statement{TableName: "t"}
+		cond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "id"}},
+			Operator: In,
+			Operand2: Operand{Type: OperandSubquery, Value: subStmt},
+		}
+		main := Statement{TableName: "orders", Conditions: OneOrMore{{cond}}}
+		assert.True(t, cteIsUsed("t", main, nil))
+	})
+
+	t.Run("unused", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "users"}
+		assert.False(t, cteIsUsed("orphan", main, nil))
+	})
+}
+
+// TestPruneUnusedCTEs verifies unused CTE removal.
+func TestPruneUnusedCTEs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prunes_unused", func(t *testing.T) {
+		t.Parallel()
+		stmt := Statement{
+			TableName: "used",
+			CTEs: []CTE{
+				{Name: "used", Body: &Statement{TableName: "users"}},
+				{Name: "unused", Body: &Statement{TableName: "orders"}},
+			},
+		}
+		result := pruneUnusedCTEs(stmt)
+		require.Len(t, result.CTEs, 1)
+		assert.Equal(t, "used", result.CTEs[0].Name)
+	})
+
+	t.Run("keeps_all_when_all_used", func(t *testing.T) {
+		t.Parallel()
+		subStmt := &Statement{TableName: "stats"}
+		cond := Condition{
+			Operand2: Operand{Type: OperandSubquery, Value: subStmt},
+		}
+		stmt := Statement{
+			TableName:  "data",
+			Conditions: OneOrMore{{cond}},
+			CTEs: []CTE{
+				{Name: "data", Body: &Statement{TableName: "users"}},
+				{Name: "stats", Body: &Statement{TableName: "orders"}},
+			},
+		}
+		result := pruneUnusedCTEs(stmt)
+		assert.Len(t, result.CTEs, 2)
+	})
+
+	t.Run("empty_ctes_noop", func(t *testing.T) {
+		t.Parallel()
+		stmt := Statement{TableName: "users"}
+		result := pruneUnusedCTEs(stmt)
+		assert.Empty(t, result.CTEs)
+	})
+}
+
+// TestCTEIsInlineable verifies the combined inlineability check.
+func TestCTEIsInlineable(t *testing.T) {
+	t.Parallel()
+
+	simpleCTE := CTE{Name: "t", Body: &Statement{Kind: Select, TableName: "users"}}
+	allCTEs := []CTE{simpleCTE}
+
+	t.Run("eligible_simple_cte", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "t"}
+		assert.True(t, cteIsInlineable(simpleCTE, main, allCTEs))
+	})
+
+	t.Run("not_main_from", func(t *testing.T) {
+		t.Parallel()
+		main := Statement{TableName: "orders", Joins: []Join{{TableName: "t"}}}
+		assert.False(t, cteIsInlineable(simpleCTE, main, allCTEs))
+	})
+
+	t.Run("body_has_group_by", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "t", Body: &Statement{
+			Kind: Select, TableName: "orders",
+			GroupBy: []Field{{Name: "user_id"}},
+		}}
+		main := Statement{TableName: "t"}
+		assert.False(t, cteIsInlineable(cte, main, []CTE{cte}))
+	})
+
+	t.Run("referenced_more_than_once", func(t *testing.T) {
+		t.Parallel()
+		// CTE appears in both FROM and a JOIN.
+		main := Statement{
+			TableName: "t",
+			Joins:     []Join{{TableName: "t"}},
+		}
+		assert.False(t, cteIsInlineable(simpleCTE, main, allCTEs))
+	})
+
+	t.Run("referenced_in_where_subquery", func(t *testing.T) {
+		t.Parallel()
+		subStmt := &Statement{TableName: "t"}
+		cond := Condition{
+			Operand2: Operand{Type: OperandSubquery, Value: subStmt},
+		}
+		main := Statement{TableName: "t", Conditions: OneOrMore{{cond}}}
+		assert.False(t, cteIsInlineable(simpleCTE, main, allCTEs))
+	})
+}
+
+// TestInlineCTE verifies the statement merge produced by inlineCTE.
+func TestInlineCTE(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic_merge", func(t *testing.T) {
+		t.Parallel()
+		bodyCond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "score"}},
+			Operator: Gt,
+			Operand2: Operand{Type: OperandInteger, Value: int64(80)},
+		}
+		cte := CTE{Name: "t", Body: &Statement{
+			Kind: Select, TableName: "users",
+			Conditions: OneOrMore{{bodyCond}},
+		}}
+		outerCond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "id", AliasPrefix: "t"}},
+			Operator: Lt,
+			Operand2: Operand{Type: OperandInteger, Value: int64(5)},
+		}
+		main := Statement{
+			Kind:       Select,
+			TableName:  "t",
+			Fields:     []Field{{Name: "name", AliasPrefix: "t"}},
+			Conditions: OneOrMore{{outerCond}},
+		}
+
+		merged := inlineCTE(main, cte, "t")
+
+		assert.Equal(t, "users", merged.TableName)
+		assert.Empty(t, merged.TableAlias)
+		// Alias prefix on fields and conditions must be stripped.
+		assert.Equal(t, "", merged.Fields[0].AliasPrefix)
+		assert.Equal(t, "name", merged.Fields[0].Name)
+		// Conditions: body cond AND outer cond merged.
+		require.Len(t, merged.Conditions, 1)
+		require.Len(t, merged.Conditions[0], 2)
+		assert.Equal(t, "score", merged.Conditions[0][0].Operand1.Value.(Field).Name)
+		assert.Equal(t, "id", merged.Conditions[0][1].Operand1.Value.(Field).Name)
+		assert.Equal(t, "", merged.Conditions[0][1].Operand1.Value.(Field).AliasPrefix)
+	})
+
+	t.Run("outer_select_star_body_has_fields", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "t", Body: &Statement{
+			Kind:      Select,
+			TableName: "users",
+			Fields:    []Field{{Name: "id"}, {Name: "name"}},
+		}}
+		main := Statement{
+			Kind:      Select,
+			TableName: "t",
+			Fields:    []Field{{Name: "*"}},
+		}
+
+		merged := inlineCTE(main, cte, "t")
+
+		// Body's field list propagated to prevent leaking extra columns.
+		require.Len(t, merged.Fields, 2)
+		assert.Equal(t, "id", merged.Fields[0].Name)
+		assert.Equal(t, "name", merged.Fields[1].Name)
+	})
+
+	t.Run("outer_select_star_body_also_star", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "t", Body: &Statement{
+			Kind:      Select,
+			TableName: "users",
+			Fields:    []Field{{Name: "*"}},
+		}}
+		main := Statement{
+			Kind:      Select,
+			TableName: "t",
+			Fields:    []Field{{Name: "*"}},
+		}
+
+		merged := inlineCTE(main, cte, "t")
+
+		// Both are SELECT * — keep SELECT * in the merged statement.
+		require.Len(t, merged.Fields, 1)
+		assert.Equal(t, "*", merged.Fields[0].Name)
+	})
+}

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -102,8 +102,41 @@ func (d *Database) executeExplain(ctx context.Context, stmt Statement) (Statemen
 
 // executeExplainCTEs handles EXPLAIN [ANALYZE] WITH … SELECT statements.
 // Each CTE is materialised in order, emitting a "cte" step per CTE followed
-// by the outer query's plan steps.
+// by the outer query's plan steps. Unused CTEs are pruned and eligible main
+// FROM CTEs are inlined before planning, mirroring the execution path.
 func (d *Database) executeExplainCTEs(ctx context.Context, inner Statement, analyze bool) (StatementResult, error) {
+	// Mirror the execution-path optimisations so EXPLAIN reflects actual behaviour.
+	inner = pruneUnusedCTEs(inner)
+
+	for i, cte := range inner.CTEs {
+		if cte.Name != inner.TableName {
+			continue
+		}
+		if cteIsInlineable(cte, inner, inner.CTEs) {
+			outerAlias := inner.TableAlias
+			if outerAlias == "" {
+				outerAlias = inner.TableName
+			}
+			merged := inlineCTE(inner, cte, outerAlias)
+			remaining := make([]CTE, 0, len(inner.CTEs)-1)
+			remaining = append(remaining, inner.CTEs[:i]...)
+			remaining = append(remaining, inner.CTEs[i+1:]...)
+			merged.CTEs = remaining
+			if len(merged.CTEs) == 0 {
+				// All CTEs eliminated — explain as a plain query.
+				explainStmt := Statement{
+					Kind:             Explain,
+					ExplainStatement: &merged,
+					ExplainAnalyze:   analyze,
+				}
+				return d.executeExplain(ctx, explainStmt)
+			}
+			// Remaining CTEs still need materialisation — recurse.
+			return d.executeExplainCTEs(ctx, merged, analyze)
+		}
+		break
+	}
+
 	type cteStep struct {
 		name     string
 		rowCount int64

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -25,11 +25,14 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, fmt.Errorf("invalid statement kind for SELECT: %v", stmt.Kind)
 	}
 
-	// Fast path: COUNT(*) with no WHERE clause and no JOIN — walk leaf page
-	// headers without deserialising any row data.
-	// Virtual tables (derived FROM subqueries) must skip this and go through
-	// the normal materialising path so the in-memory rows are counted instead.
-	if stmt.IsSelectCountAll() && len(stmt.Conditions) == 0 && len(stmt.Joins) == 0 && t.virtualRows == nil {
+	// Fast path: COUNT(*) with no WHERE clause and no JOIN.
+	// B-tree tables walk leaf page headers without deserialising row data.
+	// Virtual tables (CTEs, derived tables) already have rows in memory — return
+	// len(virtualRows) directly without a second scan pass.
+	if stmt.IsSelectCountAll() && len(stmt.Conditions) == 0 && len(stmt.Joins) == 0 {
+		if t.virtualRows != nil {
+			return countResult(int64(len(t.virtualRows))), nil
+		}
 		return t.countAllLeafWalk(ctx)
 	}
 
@@ -689,6 +692,7 @@ func (t *Table) selectStreamingDirect(
 	}
 
 	result.Rows = NewSliceIterator(projected)
+	result.rawRows = projected
 	return result, nil
 }
 

--- a/internal/minisql/stmt_result.go
+++ b/internal/minisql/stmt_result.go
@@ -92,8 +92,14 @@ func (i *Iterator) Err() error {
 // lazy iterator over result rows (non-nil even for INSERT/UPDATE/DELETE when a
 // RETURNING clause was present). RowsAffected and LastInsertId follow
 // database/sql conventions.
+//
+// rawRows, when non-nil, holds the same projected rows that back the Rows
+// iterator. Callers that need to materialise all rows (e.g. CTE body
+// collection) can steal this slice directly instead of draining the iterator,
+// avoiding a second heap allocation of the same data.
 type StatementResult struct {
 	Rows         Iterator
+	rawRows      []Row   // non-nil when produced by selectStreamingDirect
 	Columns      []Column
 	RowsAffected int
 	LastInsertID int64


### PR DESCRIPTION
Two heap allocation sources eliminated from CTE execution:

1. **Virtual table fast COUNT** — `(*Table).Select COUNT(*)` with no conditions on a virtual table previously scanned all materialised rows via `countAllLeafWalk`; now returns `len(t.virtualRows)` directly.
2. **`rawRows` fast path** — `selectStreamingDirect` builds `projected []Row` and wraps it in `NewSliceIterator`; `executeCTESelect` previously drained that iterator into a *second* `[]Row` of identical size. The `rawRows` field on `StatementResult` carries the backing slice so the caller can steal it without re-allocating.

Also implemented a non materialized CTE path for some cases where it's possible (read only, no group by, distinct, aggregate functions etc, similar approach as Postgres 12+)