### PR TITLE
perf: eliminate per-row allocations in GROUP BY aggregation hot path

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,22 @@
+### 2026-05-17 — GROUP BY allocation pass
+
+Five allocation sources eliminated from the GROUP BY aggregation hot path:
+
+1. **Pre-computed column indices** — `groupByColIdx` and `aggColIdx` resolve GROUP BY field and aggregate column positions once before the row loop, replacing O(n) name scans (`GetValue` / `OnlyFields`) with O(1) index reads per row.
+2. **Eliminated `OnlyFields` + `rowDistinctKey` per row** — replaced with `buildGroupKey`, which builds the key directly from pre-computed indices into a reusable `[]byte` buffer reset each row. The Go compiler optimises `map[string][string([]byte)]` to avoid allocation on lookup for existing groups.
+3. **Flat `aggStatePool`** — one `[]aggState` slice amortises all per-group accumulator allocations. Index-based access (`aggStatePool[aggBase+i]`) remains safe across pool reallocations because Go copies pool contents on grow.
+4. **Flat `groupValPool`** — same pattern for per-group GROUP BY column values, eliminating a `make([]OptionalValue, numGroupBy)` per group.
+5. **Flat result-values block** — one `make([]OptionalValue, nGroups*nFields)` covers every group's result row, replacing a `make` per group during result emission.
+
+Pre-computed `fieldToGroupByIdx` also removes the `groupByIdx map[string]int` lookup during result emission.
+
+| Benchmark | Before | After | Alloc Before | Alloc After | SQLite | Ratio (after vs SQLite) |
+|---|---:|---:|---:|---:|---:|---:|
+| GroupBy_Aggregate/minisql | ~3.47 ms/op | ~2.19 ms/op | ~5.16 MiB/op | ~3.83 MiB/op | ~2.18 ms/op | **1.0×** |
+| Having_Filter/minisql | — | ~2.15 ms/op | — | ~3.75 MiB/op | ~1.94 ms/op | 1.1× |
+
+77% allocation reduction (−40,306 allocs/op). GROUP BY latency now **at parity with SQLite** (2.19ms vs 2.18ms).
+
 ### 2026-05-17 — CTE materialisation double-allocation elimination
 
 Two heap allocation sources eliminated from CTE execution:

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -259,18 +260,38 @@ func (t *Table) selectAggregate(ctx context.Context, stmt Statement, rows []Row)
 		}
 	}
 
+	// Pre-compute column index for each aggregate's source column to avoid
+	// per-row linear scans through column names.
+	aggColIdx := make([]int, len(stmt.Aggregates))
+	for i, agg := range stmt.Aggregates {
+		aggColIdx[i] = -1
+		if agg.Column == "" {
+			continue
+		}
+		for j, col := range stmt.Columns {
+			if col.Name == agg.Column {
+				aggColIdx[i] = j
+				break
+			}
+		}
+	}
+
 	for _, row := range rows {
 		for i, agg := range stmt.Aggregates {
 			switch agg.Kind {
 			case AggregateCount:
-				states[i].count += 1
+				states[i].count++
 
 			case AggregateSum, AggregateAvg:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
-					continue // SQL aggregate functions ignore NULLs
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
+					continue
 				}
-				states[i].count += 1
+				val := row.Values[colIdx]
+				if !val.Valid {
+					continue
+				}
+				states[i].count++
 				states[i].hasValue = true
 				if states[i].useIntSum {
 					switch v := val.Value.(type) {
@@ -289,8 +310,12 @@ func (t *Table) selectAggregate(ctx context.Context, stmt Statement, rows []Row)
 				}
 
 			case AggregateMin:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
+					continue
+				}
+				val := row.Values[colIdx]
+				if !val.Valid {
 					continue
 				}
 				if !states[i].hasValue || compareValues(val, states[i].min) < 0 {
@@ -299,8 +324,12 @@ func (t *Table) selectAggregate(ctx context.Context, stmt Statement, rows []Row)
 				}
 
 			case AggregateMax:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
+					continue
+				}
+				val := row.Values[colIdx]
+				if !val.Valid {
 					continue
 				}
 				if !states[i].hasValue || compareValues(val, states[i].max) > 0 {
@@ -371,15 +400,21 @@ func (t *Table) selectAggregate(ctx context.Context, stmt Statement, rows []Row)
 	}, nil
 }
 
-// groupState holds per-group accumulators for a GROUP BY query.
-type groupState struct {
-	groupValues []OptionalValue // values of the GROUP BY columns for this group
-	aggStates   []aggState
+// groupEntry holds per-group state offsets into the shared flat pools.
+// Using flat pools eliminates one heap allocation per group for aggStates and
+// groupValues slices. Index-based access remains safe across pool reallocations
+// because Go copies pool contents on grow.
+type groupEntry struct {
+	aggStateStart int32
+	groupValStart int32
 }
 
 func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (StatementResult, error) {
+	numAggs := len(stmt.Aggregates)
+	numGroupBy := len(stmt.GroupBy)
+
 	// Determine integer vs float accumulation mode for SUM/AVG per aggregate.
-	useIntSum := make([]bool, len(stmt.Aggregates))
+	useIntSum := make([]bool, numAggs)
 	for i, agg := range stmt.Aggregates {
 		if agg.Kind != AggregateSum && agg.Kind != AggregateAvg {
 			continue
@@ -389,92 +424,164 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 		}
 	}
 
-	// Build a name→index map for GROUP BY fields (for looking up values after scan).
-	groupByIdx := make(map[string]int, len(stmt.GroupBy))
+	// Pre-compute column index for each GROUP BY field (avoids per-row linear scans).
+	groupByColIdx := make([]int, numGroupBy)
 	for i, f := range stmt.GroupBy {
-		groupByIdx[f.Name] = i
+		groupByColIdx[i] = groupByColumnIndex(stmt.Columns, f)
 	}
 
-	// groups maps a group key string to its accumulated state.
-	// groupOrder preserves insertion order so output is deterministic.
-	groups := make(map[string]*groupState)
-	groupOrder := make([]string, 0)
+	// Pre-compute column index for each aggregate's source column.
+	aggColIdx := make([]int, numAggs)
+	for i, agg := range stmt.Aggregates {
+		aggColIdx[i] = -1
+		if agg.Column == "" || agg.Kind == 0 || agg.Kind == AggregateCount {
+			continue
+		}
+		for j, col := range stmt.Columns {
+			if col.Name == agg.Column {
+				aggColIdx[i] = j
+				break
+			}
+		}
+	}
+
+	// Pre-compute field → GROUP BY index for result emission (avoids map lookup per group per field).
+	fieldToGroupByIdx := make([]int, numAggs)
+	for i := range stmt.Fields {
+		fieldToGroupByIdx[i] = -1
+		if stmt.Aggregates[i].Kind != 0 {
+			continue
+		}
+		for j, gf := range stmt.GroupBy {
+			if gf.Name == stmt.Fields[i].Name {
+				fieldToGroupByIdx[i] = j
+				break
+			}
+		}
+	}
+
+	// Estimate initial group count for pool sizing — avoids repeated small reallocations
+	// in the common case where groups fit within the initial capacity.
+	estGroups := len(rows) / 10
+	if estGroups < 16 {
+		estGroups = 16
+	} else if estGroups > 4096 {
+		estGroups = 4096
+	}
+
+	var (
+		groupMap     = make(map[string]int32, estGroups)
+		groupEntries = make([]groupEntry, 0, estGroups)
+		groupOrder   = make([]string, 0, estGroups)
+		// Flat pools: one allocation amortises across all groups.
+		aggStatePool = make([]aggState, 0, estGroups*numAggs)
+		groupValPool = make([]OptionalValue, 0, estGroups*numGroupBy)
+	)
+
+	// keyBuf is reused across rows; string(keyBuf) for map lookup is optimised by
+	// the Go compiler to avoid allocation when the key already exists in the map.
+	var keyBuf []byte
 
 	for _, row := range rows {
-		// Compute group key from the GROUP BY columns.
-		groupRow := row.OnlyFields(stmt.GroupBy...)
-		key := groupRow.rowDistinctKey()
+		keyBuf = buildGroupKey(keyBuf[:0], row, groupByColIdx)
 
-		gs, exists := groups[key]
+		gsIdx, exists := groupMap[string(keyBuf)]
 		if !exists {
-			states := make([]aggState, len(stmt.Aggregates))
-			for i := range states {
-				states[i].useIntSum = useIntSum[i]
+			key := string(keyBuf) // one alloc per new group
+
+			aggStart := int32(len(aggStatePool))
+			for i := range numAggs {
+				aggStatePool = append(aggStatePool, aggState{useIntSum: useIntSum[i]})
 			}
-			gs = &groupState{
-				groupValues: make([]OptionalValue, len(stmt.GroupBy)),
-				aggStates:   states,
+
+			gvStart := int32(len(groupValPool))
+			for _, colIdx := range groupByColIdx {
+				if colIdx >= 0 && colIdx < len(row.Values) {
+					groupValPool = append(groupValPool, row.Values[colIdx])
+				} else {
+					groupValPool = append(groupValPool, OptionalValue{})
+				}
 			}
-			// Record the group column values from this first row.
-			copy(gs.groupValues, groupRow.Values)
-			groups[key] = gs
+
+			gsIdx = int32(len(groupEntries))
+			groupEntries = append(groupEntries, groupEntry{
+				aggStateStart: aggStart,
+				groupValStart: gvStart,
+			})
+			groupMap[key] = gsIdx
 			groupOrder = append(groupOrder, key)
 		}
 
-		// Accumulate aggregates for this group.
+		// Accumulate aggregates using pool indices — no pointer indirection through groupState.
+		aggBase := int(groupEntries[gsIdx].aggStateStart)
 		for i, agg := range stmt.Aggregates {
 			switch agg.Kind {
 			case 0:
 				// Non-aggregate GROUP BY column — no accumulation needed.
 			case AggregateCount:
-				gs.aggStates[i].count += 1
+				aggStatePool[aggBase+i].count++
 			case AggregateSum, AggregateAvg:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
 					continue
 				}
-				gs.aggStates[i].count += 1
-				gs.aggStates[i].hasValue = true
-				if gs.aggStates[i].useIntSum {
+				val := row.Values[colIdx]
+				if !val.Valid {
+					continue
+				}
+				aggStatePool[aggBase+i].count++
+				aggStatePool[aggBase+i].hasValue = true
+				if aggStatePool[aggBase+i].useIntSum {
 					switch v := val.Value.(type) {
 					case int64:
-						gs.aggStates[i].sumI += v
+						aggStatePool[aggBase+i].sumI += v
 					case int32:
-						gs.aggStates[i].sumI += int64(v)
+						aggStatePool[aggBase+i].sumI += int64(v)
 					}
 				} else {
 					switch v := val.Value.(type) {
 					case float64:
-						gs.aggStates[i].sumF += v
+						aggStatePool[aggBase+i].sumF += v
 					case float32:
-						gs.aggStates[i].sumF += float64(v)
+						aggStatePool[aggBase+i].sumF += float64(v)
 					}
 				}
 			case AggregateMin:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
 					continue
 				}
-				if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].min) < 0 {
-					gs.aggStates[i].min = val
-					gs.aggStates[i].hasValue = true
+				val := row.Values[colIdx]
+				if !val.Valid {
+					continue
+				}
+				if !aggStatePool[aggBase+i].hasValue || compareValues(val, aggStatePool[aggBase+i].min) < 0 {
+					aggStatePool[aggBase+i].min = val
+					aggStatePool[aggBase+i].hasValue = true
 				}
 			case AggregateMax:
-				val, ok := row.GetValue(agg.Column)
-				if !ok || !val.Valid {
+				colIdx := aggColIdx[i]
+				if colIdx < 0 || colIdx >= len(row.Values) {
 					continue
 				}
-				if !gs.aggStates[i].hasValue || compareValues(val, gs.aggStates[i].max) > 0 {
-					gs.aggStates[i].max = val
-					gs.aggStates[i].hasValue = true
+				val := row.Values[colIdx]
+				if !val.Valid {
+					continue
+				}
+				if !aggStatePool[aggBase+i].hasValue || compareValues(val, aggStatePool[aggBase+i].max) > 0 {
+					aggStatePool[aggBase+i].max = val
+					aggStatePool[aggBase+i].hasValue = true
 				}
 			}
 		}
 	}
 	_ = ctx // ctx kept for signature compat; no blocking ops remain
 
+	nFields := len(stmt.Fields)
+	nGroups := len(groupOrder)
+
 	// Build result column metadata.
-	resultColumns := make([]Column, len(stmt.Fields))
+	resultColumns := make([]Column, nFields)
 	for i, field := range stmt.Fields {
 		agg := stmt.Aggregates[i]
 		colName := field.OutputName() // respects AS alias
@@ -502,22 +609,27 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 		}
 	}
 
-	// Build one result row per group, applying HAVING filter.
-	resultRows := make([]Row, 0, len(groupOrder))
-	for _, key := range groupOrder {
-		gs := groups[key]
-		values := make([]OptionalValue, len(stmt.Fields))
+	// Preallocate one flat block for all result values — one alloc covers every group.
+	allResultValues := make([]OptionalValue, nGroups*nFields)
+	resultRows := make([]Row, 0, nGroups)
+
+	for gi, key := range groupOrder {
+		gsIdx := groupMap[key]
+		aggBase := int(groupEntries[gsIdx].aggStateStart)
+		gvBase := int(groupEntries[gsIdx].groupValStart)
+
+		values := allResultValues[gi*nFields : (gi+1)*nFields]
+
 		for i, agg := range stmt.Aggregates {
 			switch agg.Kind {
 			case 0:
-				// Look up the group column value by field name.
-				if idx, ok := groupByIdx[stmt.Fields[i].Name]; ok {
-					values[i] = gs.groupValues[idx]
+				if j := fieldToGroupByIdx[i]; j >= 0 {
+					values[i] = groupValPool[gvBase+j]
 				}
 			case AggregateCount:
-				values[i] = OptionalValue{Valid: true, Value: gs.aggStates[i].count}
+				values[i] = OptionalValue{Valid: true, Value: aggStatePool[aggBase+i].count}
 			case AggregateSum:
-				st := gs.aggStates[i]
+				st := aggStatePool[aggBase+i]
 				if st.hasValue {
 					if st.useIntSum {
 						values[i] = OptionalValue{Valid: true, Value: st.sumI}
@@ -526,7 +638,7 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 					}
 				}
 			case AggregateAvg:
-				st := gs.aggStates[i]
+				st := aggStatePool[aggBase+i]
 				if st.hasValue && st.count > 0 {
 					if st.useIntSum {
 						values[i] = OptionalValue{Valid: true, Value: float64(st.sumI) / float64(st.count)}
@@ -535,12 +647,12 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 					}
 				}
 			case AggregateMin:
-				if gs.aggStates[i].hasValue {
-					values[i] = gs.aggStates[i].min
+				if aggStatePool[aggBase+i].hasValue {
+					values[i] = aggStatePool[aggBase+i].min
 				}
 			case AggregateMax:
-				if gs.aggStates[i].hasValue {
-					values[i] = gs.aggStates[i].max
+				if aggStatePool[aggBase+i].hasValue {
+					values[i] = aggStatePool[aggBase+i].max
 				}
 			}
 		}
@@ -1853,6 +1965,70 @@ func appendOperandSourceFields(fields []Field, operand Operand) []Field {
 		}
 	}
 	return fields
+}
+
+// buildGroupKey appends a collision-free group key to buf using pre-computed column indices.
+// The encoding matches rowDistinctKey so the two functions are interchangeable for the same values.
+// buf must be reset (zero-length) by the caller before each call; the returned slice is buf grown in place.
+func buildGroupKey(buf []byte, row Row, colIndices []int) []byte {
+	for i, colIdx := range colIndices {
+		if i > 0 {
+			buf = append(buf, '\x1f')
+		}
+		if colIdx < 0 || colIdx >= len(row.Values) {
+			buf = append(buf, "null"...)
+			continue
+		}
+		v := row.Values[colIdx]
+		if !v.Valid {
+			buf = append(buf, "null"...)
+			continue
+		}
+		switch val := v.Value.(type) {
+		case TextPointer:
+			buf = append(buf, 't')
+			buf = strconv.AppendInt(buf, int64(val.Length), 10)
+			buf = append(buf, ':')
+			buf = append(buf, val.Data...)
+		case bool:
+			buf = append(buf, "b:"...)
+			buf = strconv.AppendBool(buf, val)
+		case int64:
+			buf = append(buf, "i64:"...)
+			buf = strconv.AppendInt(buf, val, 10)
+		case int32:
+			buf = append(buf, "i32:"...)
+			buf = strconv.AppendInt(buf, int64(val), 10)
+		case float64:
+			buf = append(buf, "f64:"...)
+			buf = strconv.AppendFloat(buf, val, 'g', -1, 64)
+		case float32:
+			buf = append(buf, "f32:"...)
+			buf = strconv.AppendFloat(buf, float64(val), 'g', -1, 32)
+		default:
+			buf = fmt.Appendf(buf, "?:%v", val)
+		}
+	}
+	return buf
+}
+
+// groupByColumnIndex resolves the index of field f in cols.
+// Tries the alias-qualified name first (e.g. "t.age"), then falls back to the bare name.
+func groupByColumnIndex(cols []Column, f Field) int {
+	if f.AliasPrefix != "" {
+		qualified := f.AliasPrefix + "." + f.Name
+		for i, col := range cols {
+			if col.Name == qualified {
+				return i
+			}
+		}
+	}
+	for i, col := range cols {
+		if col.Name == f.Name {
+			return i
+		}
+	}
+	return -1
 }
 
 // rowDistinctKey builds a string key from a projected row's values for DISTINCT deduplication.

--- a/internal/minisql/select_helpers_test.go
+++ b/internal/minisql/select_helpers_test.go
@@ -162,6 +162,178 @@ func TestFindExpressionIndex(t *testing.T) {
 	})
 }
 
+func TestBuildGroupKey(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "age", Kind: Int8},
+		{Name: "name", Kind: Varchar},
+		{Name: "active", Kind: Boolean},
+		{Name: "score", Kind: Double},
+		{Name: "ratio", Kind: Real},
+	}
+
+	makeRow := func(vals ...OptionalValue) Row {
+		return NewRowWithValues(cols[:len(vals)], vals)
+	}
+
+	t.Run("int64 encoded with i64 prefix", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int64(42), Valid: true})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Equal(t, "i64:42", key)
+	})
+
+	t.Run("int32 encoded with i32 prefix", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int32(7), Valid: true})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Equal(t, "i32:7", key)
+	})
+
+	t.Run("bool true encoded as b:true", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[2:3], []OptionalValue{{Value: true, Valid: true}})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Equal(t, "b:true", key)
+	})
+
+	t.Run("bool false encoded as b:false", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[2:3], []OptionalValue{{Value: false, Valid: true}})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Equal(t, "b:false", key)
+	})
+
+	t.Run("float64 encoded with f64 prefix", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[3:4], []OptionalValue{{Value: float64(3.14), Valid: true}})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Contains(t, key, "f64:")
+	})
+
+	t.Run("float32 encoded with f32 prefix", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[4:5], []OptionalValue{{Value: float32(1.5), Valid: true}})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Contains(t, key, "f32:")
+	})
+
+	t.Run("TextPointer encoded with t prefix", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[1:2], []OptionalValue{{Value: NewTextPointer([]byte("hello")), Valid: true}})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Contains(t, key, "t5:hello")
+	})
+
+	t.Run("null value encoded as null", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Valid: false})
+		key := string(buildGroupKey(nil, row, []int{0}))
+		assert.Equal(t, "null", key)
+	})
+
+	t.Run("out-of-range index encoded as null", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int64(1), Valid: true})
+		key := string(buildGroupKey(nil, row, []int{99}))
+		assert.Equal(t, "null", key)
+	})
+
+	t.Run("negative index encoded as null", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int64(1), Valid: true})
+		key := string(buildGroupKey(nil, row, []int{-1}))
+		assert.Equal(t, "null", key)
+	})
+
+	t.Run("multiple columns separated by unit separator", func(t *testing.T) {
+		t.Parallel()
+		row := NewRowWithValues(cols[:2], []OptionalValue{
+			{Value: int64(1), Valid: true},
+			{Value: NewTextPointer([]byte("alice")), Valid: true},
+		})
+		key := string(buildGroupKey(nil, row, []int{0, 1}))
+		assert.Equal(t, "i64:1\x1ft5:alice", key)
+	})
+
+	t.Run("int64 and float64 with same value produce distinct keys", func(t *testing.T) {
+		t.Parallel()
+		r1 := makeRow(OptionalValue{Value: int64(1), Valid: true})
+		r2 := NewRowWithValues(cols[3:4], []OptionalValue{{Value: float64(1), Valid: true}})
+		k1 := string(buildGroupKey(nil, r1, []int{0}))
+		k2 := string(buildGroupKey(nil, r2, []int{0}))
+		assert.NotEqual(t, k1, k2)
+	})
+
+	t.Run("buf is reused across calls", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int64(5), Valid: true})
+		buf := make([]byte, 0, 64)
+		buf = buildGroupKey(buf[:0], row, []int{0})
+		assert.Equal(t, "i64:5", string(buf))
+		buf = buildGroupKey(buf[:0], row, []int{0})
+		assert.Equal(t, "i64:5", string(buf))
+	})
+
+	t.Run("empty column index list produces empty key", func(t *testing.T) {
+		t.Parallel()
+		row := makeRow(OptionalValue{Value: int64(1), Valid: true})
+		key := string(buildGroupKey(nil, row, []int{}))
+		assert.Equal(t, "", key)
+	})
+}
+
+func TestGroupByColumnIndex(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "id", Kind: Int8},
+		{Name: "name", Kind: Varchar},
+		{Name: "age", Kind: Int8},
+	}
+
+	t.Run("plain name found at correct index", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 1, groupByColumnIndex(cols, Field{Name: "name"}))
+	})
+
+	t.Run("first column found", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, groupByColumnIndex(cols, Field{Name: "id"}))
+	})
+
+	t.Run("last column found", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 2, groupByColumnIndex(cols, Field{Name: "age"}))
+	})
+
+	t.Run("missing name returns -1", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, -1, groupByColumnIndex(cols, Field{Name: "score"}))
+	})
+
+	t.Run("alias-qualified name falls back to bare name when column not qualified", func(t *testing.T) {
+		t.Parallel()
+		// Column is stored as plain "name", not "t.name" — expect fallback.
+		assert.Equal(t, 1, groupByColumnIndex(cols, Field{Name: "name", AliasPrefix: "t"}))
+	})
+
+	t.Run("alias-qualified name found when column is stored qualified", func(t *testing.T) {
+		t.Parallel()
+		qualifiedCols := []Column{
+			{Name: "t.id", Kind: Int8},
+			{Name: "t.name", Kind: Varchar},
+		}
+		assert.Equal(t, 1, groupByColumnIndex(qualifiedCols, Field{Name: "name", AliasPrefix: "t"}))
+	})
+
+	t.Run("empty cols returns -1", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, -1, groupByColumnIndex(nil, Field{Name: "id"}))
+	})
+}
+
 func TestWhereCondColumns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select_test.go
+++ b/internal/minisql/select_test.go
@@ -693,6 +693,278 @@ func TestTable_Select_Overflow(t *testing.T) {
 	})
 }
 
+// TestTable_SelectGroupBy covers selectGroupBy via Table.Select.
+// Uses testColumns: id(Int8), email(Varchar), age(Int4), verified(Boolean), score(Real), created(Timestamp).
+// We insert rows with two distinct verified values (true/false) and assert group counts and sums.
+func TestTable_SelectGroupBy(t *testing.T) {
+	table, txManager, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	// Insert 5 rows: 3 verified=true, 2 verified=false.  Age values: 10,20,30 / 40,50.
+	insertStmt := Statement{
+		Kind:   Insert,
+		Fields: []Field{{Name: "id"}, {Name: "email"}, {Name: "age"}, {Name: "verified"}, {Name: "score"}, {Name: "created"}},
+	}
+	for i, row := range [][]OptionalValue{
+		{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("a@e.com")), Valid: true}, {Value: int32(10), Valid: true}, {Value: true, Valid: true}, {Value: float32(1.0), Valid: true}, {Valid: false}},
+		{{Value: int64(2), Valid: true}, {Value: NewTextPointer([]byte("b@e.com")), Valid: true}, {Value: int32(20), Valid: true}, {Value: true, Valid: true}, {Value: float32(2.0), Valid: true}, {Valid: false}},
+		{{Value: int64(3), Valid: true}, {Value: NewTextPointer([]byte("c@e.com")), Valid: true}, {Value: int32(30), Valid: true}, {Value: true, Valid: true}, {Value: float32(3.0), Valid: true}, {Valid: false}},
+		{{Value: int64(4), Valid: true}, {Value: NewTextPointer([]byte("d@e.com")), Valid: true}, {Value: int32(40), Valid: true}, {Value: false, Valid: true}, {Value: float32(4.0), Valid: true}, {Valid: false}},
+		{{Value: int64(5), Valid: true}, {Value: NewTextPointer([]byte("e@e.com")), Valid: true}, {Value: int32(50), Valid: true}, {Value: false, Valid: true}, {Value: float32(5.0), Valid: true}, {Valid: false}},
+	} {
+		_ = i
+		ins := insertStmt
+		ins.Inserts = [][]OptionalValue{row}
+		err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := table.Insert(ctx, ins)
+			return err
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("group_by_count", func(t *testing.T) {
+		stmt := Statement{
+			Kind: Select,
+			Fields: []Field{
+				{Name: "verified"},
+				{Name: "count(*)"},
+			},
+			Aggregates: []AggregateExpr{
+				{Kind: 0},
+				{Kind: AggregateCount},
+			},
+			GroupBy: []Field{{Name: "verified"}},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 2)
+
+		counts := map[bool]int64{}
+		for _, r := range rows {
+			v, _ := r.GetValue("verified")
+			c, _ := r.GetValue("count(*)")
+			counts[v.Value.(bool)] = c.Value.(int64)
+		}
+		assert.Equal(t, int64(3), counts[true])
+		assert.Equal(t, int64(2), counts[false])
+	})
+
+	t.Run("group_by_sum_int", func(t *testing.T) {
+		stmt := Statement{
+			Kind: Select,
+			Fields: []Field{
+				{Name: "verified"},
+				{Name: "sum(age)"},
+			},
+			Aggregates: []AggregateExpr{
+				{Kind: 0},
+				{Kind: AggregateSum, Column: "age"},
+			},
+			GroupBy: []Field{{Name: "verified"}},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 2)
+
+		sums := map[bool]int64{}
+		for _, r := range rows {
+			v, _ := r.GetValue("verified")
+			s, _ := r.GetValue("sum(age)")
+			sums[v.Value.(bool)] = s.Value.(int64)
+		}
+		assert.Equal(t, int64(60), sums[true])  // 10+20+30
+		assert.Equal(t, int64(90), sums[false]) // 40+50
+	})
+
+	t.Run("group_by_min_max", func(t *testing.T) {
+		stmt := Statement{
+			Kind: Select,
+			Fields: []Field{
+				{Name: "verified"},
+				{Name: "min(age)"},
+				{Name: "max(age)"},
+			},
+			Aggregates: []AggregateExpr{
+				{Kind: 0},
+				{Kind: AggregateMin, Column: "age"},
+				{Kind: AggregateMax, Column: "age"},
+			},
+			GroupBy: []Field{{Name: "verified"}},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 2)
+
+		type minmax struct{ min, max int32 }
+		groups := map[bool]minmax{}
+		for _, r := range rows {
+			v, _ := r.GetValue("verified")
+			mn, _ := r.GetValue("min(age)")
+			mx, _ := r.GetValue("max(age)")
+			groups[v.Value.(bool)] = minmax{mn.Value.(int32), mx.Value.(int32)}
+		}
+		assert.Equal(t, minmax{10, 30}, groups[true])
+		assert.Equal(t, minmax{40, 50}, groups[false])
+	})
+
+	t.Run("group_by_avg", func(t *testing.T) {
+		stmt := Statement{
+			Kind: Select,
+			Fields: []Field{
+				{Name: "verified"},
+				{Name: "avg(age)"},
+			},
+			Aggregates: []AggregateExpr{
+				{Kind: 0},
+				{Kind: AggregateAvg, Column: "age"},
+			},
+			GroupBy: []Field{{Name: "verified"}},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 2)
+
+		avgs := map[bool]float64{}
+		for _, r := range rows {
+			v, _ := r.GetValue("verified")
+			a, _ := r.GetValue("avg(age)")
+			avgs[v.Value.(bool)] = a.Value.(float64)
+		}
+		assert.InDelta(t, 20.0, avgs[true], 0.001)  // (10+20+30)/3
+		assert.InDelta(t, 45.0, avgs[false], 0.001) // (40+50)/2
+	})
+
+	t.Run("group_by_with_having", func(t *testing.T) {
+		stmt := Statement{
+			Kind: Select,
+			Fields: []Field{
+				{Name: "verified"},
+				{Name: "count(*)"},
+			},
+			Aggregates: []AggregateExpr{
+				{Kind: 0},
+				{Kind: AggregateCount},
+			},
+			GroupBy: []Field{{Name: "verified"}},
+			Having: OneOrMore{{
+				{
+					Operand1: Operand{Type: OperandField, Value: Field{Name: "count(*)"}},
+					Operator: Gt,
+					Operand2: Operand{Type: OperandInteger, Value: int64(2)},
+				},
+			}},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+
+		rows := collectRows(ctx, result)
+		// Only verified=true group has count=3 > 2.
+		require.Len(t, rows, 1)
+		v, _ := rows[0].GetValue("verified")
+		assert.Equal(t, true, v.Value)
+	})
+}
+
+// TestTable_SelectAggregate covers selectAggregate via Table.Select (no GROUP BY).
+func TestTable_SelectAggregate(t *testing.T) {
+	table, txManager, _ := newTestTable(t, testColumns)
+	ctx := context.Background()
+
+	insertStmt := Statement{
+		Kind:   Insert,
+		Fields: []Field{{Name: "id"}, {Name: "email"}, {Name: "age"}, {Name: "verified"}, {Name: "score"}, {Name: "created"}},
+	}
+	for _, row := range [][]OptionalValue{
+		{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("a@e.com")), Valid: true}, {Value: int32(10), Valid: true}, {Value: true, Valid: true}, {Value: float32(1.0), Valid: true}, {Valid: false}},
+		{{Value: int64(2), Valid: true}, {Value: NewTextPointer([]byte("b@e.com")), Valid: true}, {Value: int32(20), Valid: true}, {Value: true, Valid: true}, {Value: float32(2.0), Valid: true}, {Valid: false}},
+		{{Value: int64(3), Valid: true}, {Value: NewTextPointer([]byte("c@e.com")), Valid: true}, {Value: int32(30), Valid: true}, {Value: false, Valid: true}, {Value: float32(3.0), Valid: true}, {Valid: false}},
+	} {
+		ins := insertStmt
+		ins.Inserts = [][]OptionalValue{row}
+		err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := table.Insert(ctx, ins)
+			return err
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("count_all", func(t *testing.T) {
+		stmt := Statement{
+			Kind:   Select,
+			Fields: []Field{{Name: "count(*)"}},
+			Aggregates: []AggregateExpr{
+				{Kind: AggregateCount},
+			},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 1)
+		// countResult hardcodes "COUNT(*)" (uppercase) as the result column name.
+		cnt, _ := rows[0].GetValue("COUNT(*)")
+		assert.Equal(t, int64(3), cnt.Value)
+	})
+
+	t.Run("sum_int_column", func(t *testing.T) {
+		stmt := Statement{
+			Kind:   Select,
+			Fields: []Field{{Name: "sum(age)"}},
+			Aggregates: []AggregateExpr{
+				{Kind: AggregateSum, Column: "age"},
+			},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 1)
+		s, _ := rows[0].GetValue("sum(age)")
+		assert.Equal(t, int64(60), s.Value) // 10+20+30
+	})
+
+	t.Run("avg_int_column", func(t *testing.T) {
+		stmt := Statement{
+			Kind:   Select,
+			Fields: []Field{{Name: "avg(age)"}},
+			Aggregates: []AggregateExpr{
+				{Kind: AggregateAvg, Column: "age"},
+			},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 1)
+		a, _ := rows[0].GetValue("avg(age)")
+		assert.InDelta(t, 20.0, a.Value.(float64), 0.001)
+	})
+
+	t.Run("min_max_int_column", func(t *testing.T) {
+		stmt := Statement{
+			Kind:   Select,
+			Fields: []Field{{Name: "min(age)"}, {Name: "max(age)"}},
+			Aggregates: []AggregateExpr{
+				{Kind: AggregateMin, Column: "age"},
+				{Kind: AggregateMax, Column: "age"},
+			},
+		}
+		result, err := table.Select(ctx, stmt)
+		require.NoError(t, err)
+		rows := collectRows(ctx, result)
+		require.Len(t, rows, 1)
+		mn, _ := rows[0].GetValue("min(age)")
+		mx, _ := rows[0].GetValue("max(age)")
+		assert.Equal(t, int32(10), mn.Value)
+		assert.Equal(t, int32(30), mx.Value)
+	})
+}
+
 func collectRows(ctx context.Context, r StatementResult) []Row {
 	results := []Row{}
 	for r.Rows.Next(ctx) {


### PR DESCRIPTION
Five sources of heap allocation removed from selectGroupBy:

1. Pre-computed column indices (groupByColIdx, aggColIdx) resolve field positions once before the row loop, replacing O(n) name scans (GetValue / OnlyFields) with O(1) index reads per row.

2. buildGroupKey writes the group key directly into a reusable []byte buffer using strconv.Append* instead of strings.Builder+fmt.Fprintf. The Go compiler optimises map[string][string([]byte)] lookups to avoid allocation when the key already exists in the map.

3. Flat aggStatePool amortises all per-group accumulator allocations into one []aggState slice; index-based access remains safe across pool grows.

4. Flat groupValPool applies the same pattern for GROUP BY column values, eliminating a make([]OptionalValue, numGroupBy) per new group.

5. Flat allResultValues block allocates one []OptionalValue covering every group's result row, replacing a make per group during result emission.

selectAggregate also gains pre-computed aggColIdx to remove per-row GetValue linear scans.

Benchmark (10K rows, 100 groups, GROUP BY age + COUNT(*) + SUM):
  Before: ~3.47 ms/op  5.16 MiB/op  52,654 allocs/op
  After:  ~2.19 ms/op  3.83 MiB/op  12,348 allocs/op
  SQLite: ~2.18 ms/op     3.6 KiB/op    309 allocs/op

-37% latency, -26% memory, -77% allocations.
GROUP BY latency now at parity with SQLite.