### PR TITLE
perf: eliminate per-row allocations in IN-subquery semi-join hot path

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,3 +1,19 @@
+### 2026-05-17 — IN-subquery semi-join allocation pass
+
+Three allocation sources eliminated from the IN (subquery) → semi-join hot path:
+
+1. **Existence-only build table** — `hashJoinBucket.present map[string]struct{}` replaces `hashJoinBucket.rows map[string][]Row` for Semi/AntiSemi joins. The build phase no longer stores full inner rows or allocates a `[]Row` per distinct key — only the key set is stored.
+2. **Reused `[]byte` key buffer in build phase** — `appendHashKey` replaces `buildSideHashKey` (`make([]string, n)` + `strings.Join` = 2 allocs/row). The build callback resets a single `keyBuf` slice each inner row; one `string(keyBuf)` allocation happens only for new distinct keys.
+3. **Stack-local probe key buffer** — `executeHashJoinForRow` builds the probe key into a `[128]byte` stack array (via `appendHashKey`), avoiding the `make([]string, n)` + `strings.Join` pair that the old `probeSideHashKey` performed per outer row.
+
+`formatHashKeyPart` (returned allocated `string`) replaced by `appendHashKeyPart` (appends into caller buffer, zero allocs).
+
+| Benchmark | Before | After | Alloc Before | Alloc After | SQLite | Ratio (after vs SQLite) |
+|---|---:|---:|---:|---:|---:|---:|
+| Subquery_InList/minisql | ~10.7 ms/op | ~9.6 ms/op | ~8.31 MiB/op | ~6.70 MiB/op | ~3.7 ms/op | **2.6×** |
+
+~11% allocation reduction (−24,900 allocs/op, 219,580 → 194,680). ~10% latency reduction. Memory dropped from 8.31 MiB to ~6.70 MiB/op.
+
 ### 2026-05-17 — GROUP BY allocation pass
 
 Five allocation sources eliminated from the GROUP BY aggregation hot path:

--- a/internal/minisql/hash_join.go
+++ b/internal/minisql/hash_join.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/RichardKnop/minisql/pkg/bloom"
 )
@@ -21,12 +20,21 @@ const (
 
 // hashJoinBucket is the in-memory hash table built from the inner (build) side
 // of a single hash join.  The map key is a null-byte-delimited encoding of the
-// join column values; the value is the list of inner rows sharing that key.
+// join column values.
+//
+// For regular joins (INNER/LEFT/RIGHT/FULL OUTER) rows holds all inner rows per
+// key so they can be combined with the outer row on a hit.
+//
+// For semi/anti-semi joins only key existence is needed; present stores just the
+// set of keys and rows is nil, eliminating the per-key []Row allocation and the
+// cost of keeping full inner rows in memory.
+//
 // innerColumns is kept to construct NULL rows for LEFT JOIN misses.
 // filter is a Bloom filter over the same key set used to reject probe keys
 // that are definitely not present, avoiding an unnecessary map lookup.
 type hashJoinBucket struct {
-	rows         map[string][]Row
+	rows         map[string][]Row   // non-nil for INNER/LEFT/RIGHT/FULL OUTER joins
+	present      map[string]struct{} // non-nil for Semi/AntiSemi joins
 	innerColumns []Column
 	filter       *bloom.Filter
 }
@@ -51,19 +59,40 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 		if n <= 0 {
 			n = bloomMinN
 		}
+
+		isSemiJoin := join.Type == Semi || join.Type == AntiSemi
 		bucket := &hashJoinBucket{
-			rows:         make(map[string][]Row),
 			innerColumns: innerTable.Columns,
 			filter:       bloom.New(uint(n), bloomFPRate),
 		}
+		if isSemiJoin {
+			bucket.present = make(map[string]struct{})
+		} else {
+			bucket.rows = make(map[string][]Row)
+		}
+
 		innerFields := fieldsFromColumns(innerTable.Columns...)
+		// keyBuf is reused across rows in the build phase to avoid one alloc per row.
+		var keyBuf []byte
 		if err := runTableScan(ctx, plan, innerTable, innerScan, innerFields, func(row Row) error {
-			key := buildSideHashKey(join, row)
-			if key == "" {
+			keyBuf = appendHashKey(keyBuf[:0], join, row, "", 0, true)
+			if keyBuf == nil {
 				return nil // NULL join key — never matches
 			}
-			bucket.rows[key] = append(bucket.rows[key], row)
-			bucket.filter.Add([]byte(key))
+			if isSemiJoin {
+				// Existence check only: avoid storing full inner rows.
+				// The Go compiler optimises map[string]struct{}[string([]byte)] to
+				// skip allocation when the key already exists.
+				if _, exists := bucket.present[string(keyBuf)]; !exists {
+					key := string(keyBuf)
+					bucket.present[key] = struct{}{}
+					bucket.filter.Add(keyBuf)
+				}
+			} else {
+				key := string(keyBuf)
+				bucket.rows[key] = append(bucket.rows[key], row)
+				bucket.filter.Add(keyBuf)
+			}
 			return nil
 		}); err != nil {
 			return nil, fmt.Errorf("hash join build phase (join %d): %w", i, err)
@@ -73,69 +102,65 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 	return buckets, nil
 }
 
-// buildSideHashKey encodes the inner (build-side) row's join column values
-// into a string key.  Returns "" when any join column is NULL (NULL never
-// matches anything in SQL).
-func buildSideHashKey(join JoinPlan, innerRow Row) string {
-	parts := make([]string, len(join.JoinColumnPairs))
-	for i, pair := range join.JoinColumnPairs {
-		val, ok := innerRow.GetValue(pair.JoinTableColumn.Name)
-		if !ok || !val.Valid {
-			return ""
-		}
-		parts[i] = formatHashKeyPart(val.Value)
-	}
-	return strings.Join(parts, "\x00")
-}
-
-// probeSideHashKey encodes the outer (probe-side) row's join column values
-// into a string key compatible with buildSideHashKey.  Returns "" when any
-// join column is NULL.
+// appendHashKey encodes the join column values from row into buf and returns
+// the extended slice.  Returns nil when any join column is NULL (NULL never
+// matches in SQL).
 //
-// joinIndex==0: currentRow has plain column names (not yet alias-prefixed).
-// joinIndex >0: currentRow already carries "alias.column" prefixes.
-func probeSideHashKey(join JoinPlan, currentRow Row, fromAlias string, joinIndex int) string {
-	parts := make([]string, len(join.JoinColumnPairs))
+// buildSide=true  → uses JoinTableColumn (inner/build side).
+// buildSide=false → uses BaseTableColumn (outer/probe side); when joinIndex>0
+// the column name is qualified with fromAlias.
+//
+// The caller resets buf to buf[:0] between calls to reuse the backing array.
+func appendHashKey(buf []byte, join JoinPlan, row Row, fromAlias string, joinIndex int, buildSide bool) []byte {
 	for i, pair := range join.JoinColumnPairs {
-		colName := pair.BaseTableColumn.Name
-		if joinIndex > 0 {
-			colName = fromAlias + "." + colName
+		var colName string
+		if buildSide {
+			colName = pair.JoinTableColumn.Name
+		} else {
+			colName = pair.BaseTableColumn.Name
+			if joinIndex > 0 {
+				colName = fromAlias + "." + colName
+			}
 		}
-		val, ok := currentRow.GetValue(colName)
+		val, ok := row.GetValue(colName)
 		if !ok || !val.Valid {
-			return ""
+			return nil // NULL key — never matches
 		}
-		parts[i] = formatHashKeyPart(val.Value)
+		if i > 0 {
+			buf = append(buf, '\x00')
+		}
+		buf = appendHashKeyPart(buf, val.Value)
 	}
-	return strings.Join(parts, "\x00")
+	return buf
 }
 
-// formatHashKeyPart encodes a single column value as a string suitable for
-// use inside a hash key.  Each type has a distinct, reversible representation.
-func formatHashKeyPart(v any) string {
+// appendHashKeyPart encodes a single column value into buf using a distinct,
+// reversible representation for each type.
+func appendHashKeyPart(buf []byte, v any) []byte {
 	switch x := v.(type) {
 	case int64:
-		return strconv.FormatInt(x, 10)
+		return strconv.AppendInt(buf, x, 10)
 	case int32:
-		return strconv.FormatInt(int64(x), 10)
+		return strconv.AppendInt(buf, int64(x), 10)
 	case int8:
-		return strconv.FormatInt(int64(x), 10)
+		return strconv.AppendInt(buf, int64(x), 10)
 	case float32:
-		return strconv.FormatFloat(float64(x), 'f', -1, 32)
+		return strconv.AppendFloat(buf, float64(x), 'f', -1, 32)
 	case float64:
-		return strconv.FormatFloat(x, 'f', -1, 64)
+		return strconv.AppendFloat(buf, x, 'f', -1, 64)
 	case string:
-		return x
+		return append(buf, x...)
 	case TextPointer:
-		return x.String()
+		return append(buf, x.String()...)
 	case bool:
 		if x {
-			return "1"
+			return append(buf, '1')
 		}
-		return "0"
+		return append(buf, '0')
 	case TimestampMicros:
-		return strconv.FormatInt(int64(x), 10)
+		return strconv.AppendInt(buf, int64(x), 10)
 	default:
-		return fmt.Sprintf("%v", v)
+		return fmt.Appendf(buf, "%v", v)
 	}
 }
+

--- a/internal/minisql/hash_join_test.go
+++ b/internal/minisql/hash_join_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormatHashKeyPart(t *testing.T) {
+func TestAppendHashKeyPart(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -30,12 +30,12 @@ func TestFormatHashKeyPart(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, formatHashKeyPart(tc.input))
+			assert.Equal(t, tc.want, string(appendHashKeyPart(nil, tc.input)))
 		})
 	}
 }
 
-func TestBuildSideHashKey(t *testing.T) {
+func TestAppendHashKey_BuildSide(t *testing.T) {
 	t.Parallel()
 
 	cols := []Column{
@@ -55,16 +55,16 @@ func TestBuildSideHashKey(t *testing.T) {
 			{Valid: true, Value: int64(1)},
 			{Valid: true, Value: "sports"},
 		})
-		assert.Equal(t, "sports", buildSideHashKey(join, row))
+		assert.Equal(t, "sports", string(appendHashKey(nil, join, row, "", 0, true)))
 	})
 
-	t.Run("NULL value returns empty string", func(t *testing.T) {
+	t.Run("NULL value returns nil", func(t *testing.T) {
 		t.Parallel()
 		row := NewRowWithValues(cols, []OptionalValue{
 			{Valid: true, Value: int64(1)},
 			{Valid: false},
 		})
-		assert.Equal(t, "", buildSideHashKey(join, row))
+		assert.Nil(t, appendHashKey(nil, join, row, "", 0, true))
 	})
 
 	t.Run("composite key joins parts with null byte", func(t *testing.T) {
@@ -79,11 +79,11 @@ func TestBuildSideHashKey(t *testing.T) {
 			{Valid: true, Value: int64(7)},
 			{Valid: true, Value: "music"},
 		})
-		assert.Equal(t, "7\x00music", buildSideHashKey(join2, row))
+		assert.Equal(t, "7\x00music", string(appendHashKey(nil, join2, row, "", 0, true)))
 	})
 }
 
-func TestProbeSideHashKey(t *testing.T) {
+func TestAppendHashKey_ProbeSide(t *testing.T) {
 	t.Parallel()
 
 	cols := []Column{
@@ -102,7 +102,7 @@ func TestProbeSideHashKey(t *testing.T) {
 			{Valid: true, Value: int64(5)},
 			{Valid: true, Value: "alice"},
 		})
-		assert.Equal(t, "5", probeSideHashKey(join, row, "u", 0))
+		assert.Equal(t, "5", string(appendHashKey(nil, join, row, "u", 0, false)))
 	})
 
 	t.Run("joinIndex 1 uses alias-prefixed column name", func(t *testing.T) {
@@ -112,16 +112,16 @@ func TestProbeSideHashKey(t *testing.T) {
 		row := NewRowWithValues(prefixedCols, []OptionalValue{
 			{Valid: true, Value: int64(5)},
 		})
-		assert.Equal(t, "5", probeSideHashKey(join, row, "u", 1))
+		assert.Equal(t, "5", string(appendHashKey(nil, join, row, "u", 1, false)))
 	})
 
-	t.Run("NULL probe key returns empty string", func(t *testing.T) {
+	t.Run("NULL probe key returns nil", func(t *testing.T) {
 		t.Parallel()
 		row := NewRowWithValues(cols, []OptionalValue{
 			{Valid: false},
 			{Valid: true, Value: "alice"},
 		})
-		assert.Equal(t, "", probeSideHashKey(join, row, "u", 0))
+		assert.Nil(t, appendHashKey(nil, join, row, "u", 0, false))
 	})
 }
 

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -1116,23 +1116,20 @@ func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, jo
 
 	bucket := hashTables[joinIndex]
 
-	probeKey := probeSideHashKey(join, currentRow, fromAlias, joinIndex)
-	var matchingRows []Row
-	if probeKey != "" && bucket != nil {
-		// Check the Bloom filter before touching the hash map: if the filter
-		// says the key is definitely absent, skip the map probe entirely.
-		if bucket.filter.MayContain([]byte(probeKey)) {
-			matchingRows = bucket.rows[probeKey]
-		}
-	}
+	// Build the probe key into a stack-local buffer; nil means a NULL join column.
+	var probeKeyBuf [128]byte
+	probeKey := appendHashKey(probeKeyBuf[:0], join, currentRow, fromAlias, joinIndex, false)
 
-	// Semi-join / anti-semi-join: check existence only, emit the outer row
-	// (not the combined row).  At joinIndex==0 the outer row has plain column
-	// names; prefix them with fromAlias so downstream projection resolves
-	// alias-qualified SELECT fields (e.g. "u.name") correctly.
+	// Semi-join / anti-semi-join: check existence only — no need to load inner
+	// rows.  The build phase populated bucket.present (not bucket.rows).
 	if join.Type == Semi || join.Type == AntiSemi {
-		emit := join.Type == Semi && len(matchingRows) > 0
-		emit = emit || (join.Type == AntiSemi && len(matchingRows) == 0)
+		var found bool
+		if probeKey != nil && bucket != nil && bucket.filter.MayContain(probeKey) {
+			// Go compiler optimises map[string]struct{}[string([]byte)] to avoid
+			// allocation when the key is already present.
+			_, found = bucket.present[string(probeKey)]
+		}
+		emit := (join.Type == Semi && found) || (join.Type == AntiSemi && !found)
 		if emit {
 			outerRow := currentRow
 			if joinIndex == 0 {
@@ -1141,6 +1138,16 @@ func (p QueryPlan) executeHashJoinForRow(ctx context.Context, currentRow Row, jo
 			return p.executeJoinsForRow(ctx, nil, outerRow, joinIndex+1, filteredPipe, hashTables, memos)
 		}
 		return nil
+	}
+
+	// Regular join: retrieve matching inner rows from bucket.rows.
+	var matchingRows []Row
+	if probeKey != nil && bucket != nil {
+		// Check the Bloom filter before touching the hash map: if the filter
+		// says the key is definitely absent, skip the map probe entirely.
+		if bucket.filter.MayContain(probeKey) {
+			matchingRows = bucket.rows[string(probeKey)]
+		}
 	}
 
 	matched := false


### PR DESCRIPTION
Replace buildSideHashKey/probeSideHashKey (make([]string)+strings.Join = 2 allocs/row each) with appendHashKey, which appends directly into a caller-supplied []byte buffer reused across rows.

For Semi/AntiSemi joins (IN subquery path), add hashJoinBucket.present (map[string]struct{}) so the build phase stores only key existence instead of full inner rows (map[string][]Row + per-key []Row alloc).

Probe side uses a [128]byte stack-local buffer, avoiding heap allocation for typical int64 join keys.

Result: 219,580 → 194,680 allocs/op (~11% reduction), 10.7ms → ~9.6ms, 8.31 MiB → ~6.7 MiB/op on BenchmarkSubquery_InList.