### PR TITLE
fix: eliminate b.StopTimer overhead and per-iteration DB lifecycle in…

### DIFF
--- a/benchmarks/foreign_key_bench_test.go
+++ b/benchmarks/foreign_key_bench_test.go
@@ -144,21 +144,23 @@ func BenchmarkForeignKey_DeleteCascade(b *testing.B) {
 			}
 			defer delParent.Close()
 
-			b.ResetTimer()
+			// Pre-seed all b.N parent rows with 10 children each so the timed
+			// loop only measures the cascade delete, not the insert overhead.
 			for i := range b.N {
 				parentID := int64(i + 1)
-
-				b.StopTimer()
 				if _, err := insParent.Exec(parentID, fmt.Sprintf("parent-%d", i)); err != nil {
-					b.Fatalf("insert parent: %v", err)
+					b.Fatalf("pre-seed insert parent: %v", err)
 				}
 				for j := range 10 {
 					if _, err := insChild.Exec(parentID, fmt.Sprintf("child-%d-%d", i, j)); err != nil {
-						b.Fatalf("insert child: %v", err)
+						b.Fatalf("pre-seed insert child: %v", err)
 					}
 				}
-				b.StartTimer()
+			}
 
+			b.ResetTimer()
+			for i := range b.N {
+				parentID := int64(i + 1)
 				if _, err := delParent.Exec(parentID); err != nil {
 					b.Fatalf("delete parent: %v", err)
 				}

--- a/benchmarks/inverted_bench_test.go
+++ b/benchmarks/inverted_bench_test.go
@@ -40,16 +40,19 @@ var minisqlOnlyInvertedBenchDrivers = []invertedBenchDriver{invertedBenchDrivers
 func BenchmarkFullText_BuildIndex(b *testing.B) {
 	for _, d := range fullTextComparableDrivers(b) {
 		b.Run(d.name, func(b *testing.B) {
-			for i := range b.N {
-				db, cleanup := openInvertedBenchDB(b, d)
-				createFullTextTable(b, db, d)
-				seedFullTextRows(b, db, d, invertedSeedN, int64(i))
+			// Seed once; each iteration drops and recreates the index.
+			db, cleanup := openInvertedBenchDB(b, d)
+			defer cleanup()
+			createFullTextTable(b, db, d)
+			seedFullTextRows(b, db, d, invertedSeedN, 0)
+			createFullTextIndex(b, db, d)
 
+			b.ResetTimer()
+			for range b.N {
+				dropFullTextIndex(b, db, d)
 				b.StartTimer()
 				createFullTextIndex(b, db, d)
 				b.StopTimer()
-
-				cleanup()
 			}
 			b.ReportMetric(float64(invertedSeedN), "docs/op")
 		})
@@ -423,6 +426,19 @@ func createFullTextIndex(t testing.TB, db *sql.DB, d invertedBenchDriver) {
 		mustExec(t, db, `CREATE TRIGGER articles_fts_ai AFTER INSERT ON articles_fts BEGIN INSERT INTO articles_fts_index(rowid, body) VALUES (new.id, new.body); END`)
 		mustExec(t, db, `CREATE TRIGGER articles_fts_ad AFTER DELETE ON articles_fts BEGIN INSERT INTO articles_fts_index(articles_fts_index, rowid, body) VALUES('delete', old.id, old.body); END`)
 		mustExec(t, db, `CREATE TRIGGER articles_fts_au AFTER UPDATE ON articles_fts BEGIN INSERT INTO articles_fts_index(articles_fts_index, rowid, body) VALUES('delete', old.id, old.body); INSERT INTO articles_fts_index(rowid, body) VALUES (new.id, new.body); END`)
+	}
+}
+
+func dropFullTextIndex(t testing.TB, db *sql.DB, d invertedBenchDriver) {
+	t.Helper()
+	switch d.name {
+	case "minisql":
+		mustExec(t, db, `drop index "idx_articles_body"`)
+	case "sqlite":
+		mustExec(t, db, `DROP TRIGGER IF EXISTS articles_fts_au`)
+		mustExec(t, db, `DROP TRIGGER IF EXISTS articles_fts_ad`)
+		mustExec(t, db, `DROP TRIGGER IF EXISTS articles_fts_ai`)
+		mustExec(t, db, `DROP TABLE IF EXISTS articles_fts_index`)
 	}
 }
 


### PR DESCRIPTION
… slow benchmarks

BenchmarkForeignKey_DeleteCascade pre-seeds all b.N parent+child rows before b.ResetTimer() instead of toggling b.StopTimer/b.StartTimer on every iteration (250k mutex lock + time.Now calls at b.N≈125k dominated over the work).

BenchmarkFullText_BuildIndex seeds the table once and drops/recreates only the index per iteration rather than opening a new DB and seeding 1000 docs on every b.N iteration.  Adds dropFullTextIndex helper (minisql: DROP INDEX; SQLite: drop FTS5 virtual table + 3 triggers).  Reduces benchmark run from ~40 min to seconds.