### PR TITLE
perf: eliminate redundant groupInvertedPostings copies and calls thro…

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -75,19 +75,21 @@ the same session before this baseline was taken.
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| BuildIndex (1k docs) | 10,568,210 | 48,928 | 2,533,610 | **4.17×** |
-| Insert_WithIndex | 362,813 | 2,410 | 111,469 | **3.25×** |
+| BuildIndex (1k docs) | 6,573,914 | 35,106 | 2,062,776 | **3.19×** |
+| Insert_WithIndex | 197,245 | 1,289 | 94,187 | **2.09×** |
 | Search_SingleTerm/rare (1 match) | 16,113 | — | 10,558 | **1.53×** |
 | Search_SingleTerm/medium (10 matches) | 15,909 | — | 11,676 | **1.36×** |
 | Search_SingleTerm/common (1k matches) | 15,762 | — | 66,954 | **0.24×** ✓ |
 | Search_MultiTermAND (10 matches) | 31,044 | — | 38,480 | **0.81×** ✓ |
 | Search_Phrase (100 matches) | 55,591 | — | 34,185 | **1.63×** |
-| Update_WithIndex | 120,824 | ~800 | 131,491 | **0.92×** ✓ |
-| Delete_WithIndex | 308,189 | ~2,200 | 196,694 | **1.57×** |
+| Update_WithIndex | 74,823 | 545 | 94,200 | **0.79×** ✓ |
+| Delete_WithIndex | 186,852 | 1,822 | 134,360 | **1.39×** |
 
 **Search improvements (2026-05-18/19):** Parser pre-computes `strings.ToUpper` once per query (was per-token×keyword). Single-term COUNT(\*) uses `DocFreq` from the index entry header — O(log N) vs O(N). Rare/medium dropped from ~11× to ~1.5×; common flipped to 4× faster than SQLite. Phrase search: replaced `map[RowID][]uint32` postings with sorted `[]invertedPosting` + binary search (eliminating per-row map allocations); phrase adjacency check replaced with zero-alloc binary search on sorted position arrays; COUNT(\*) with index-covered predicates skips B-tree row fetch entirely. Phrase dropped from 9.5× to 1.6×.
 
-**Maintenance improvements (2026-05-19):** `invertedEntryPage.Marshal` and `invertedPostingPage.Marshal` now write cells/blocks directly into the destination page buffer — eliminates one `make([]byte)` allocation per cell/block (77% alloc reduction in BuildIndex, ~24% in Insert). Fixed double-grouping in `makeInvertedEntryCell`: was calling `groupInvertedPostings` then passing to `encodeInvertedPostingList` which called `groupInvertedPostings` again; now calls `encodeGroupedInvertedPostingList` directly. Deferred the `allPostings` copy in `insertEntryLeaf` to only the code paths that need it. Update_WithIndex flipped to faster than SQLite (0.92×).
+**Maintenance improvements (2026-05-19, round 1):** `invertedEntryPage.Marshal` and `invertedPostingPage.Marshal` now write cells/blocks directly into the destination page buffer — eliminates one `make([]byte)` allocation per cell/block. Fixed double-grouping in `makeInvertedEntryCell` (was calling `encodeInvertedPostingList` which re-grouped already-grouped input; now calls `encodeGroupedInvertedPostingList` directly). Deferred the `allPostings` copy in `insertEntryLeaf` to only the paths that use it.
+
+**Maintenance improvements (2026-05-19, round 2):** Added `groupInvertedPostingsInPlace` — sorts and groups in-place with zero allocations for the common all-unique-RowID case. Switched `makeInvertedEntryCell`, `insertPostingIntoTreeCell`, and `replacePostingInTreeCell` to use it. Removed the redundant `groupInvertedPostings` calls inside `makeInvertedPostingBlocks` (callers always pass already-grouped input), `removeInvertedPosting` (callers always pass sorted decoded postings), and `readPostingTree` (postings from sequential sorted B-tree blocks are already in order). Net: Insert allocs 3,164→1,289 (−59%), Insert 3.76×→2.09×, Update 1.21×→0.79× (faster than SQLite), Delete 1.96×→1.39×, BuildIndex 3.64×→3.19× with 82% fewer allocs.
 
 ### JSON INVERTED INDEX
 
@@ -125,18 +127,18 @@ Ranked by ratio (excluding Vacuum):
 |---|---:|---:|
 | Explain | 4.33× | 68 |
 | CTE_Materialise | 4.25× | 14,134 |
-| FullText_BuildIndex | 4.17× | 48,928 |
-| FullText_Insert_WithIndex | 3.25× | 2,410 |
 | CountStar | 3.02× | 706 |
+| FullText_BuildIndex | 3.19× | 35,106 |
 | Join_Left_UnmatchedRows | 2.84× | 203,249 |
 | WAL_Checkpoint | 2.62× | 305 |
 | Subquery_InList | 2.29× | 139,776 |
-| FullText_Delete_WithIndex | 1.57× | ~2,200 |
+| FullText_Insert_WithIndex | 2.09× | 1,289 |
 | Join_Inner_SmallLarge | 1.78× | 153,371 |
 | PointScan | 1.76× | 69 |
 | RangeScan | 1.74× | 19,922 |
 | FullText_Search_Phrase | 1.63× | — |
 | FullText_Search_SingleTerm/rare | 1.53× | — |
+| FullText_Delete_WithIndex | 1.39× | 1,822 |
 | FullText_Search_SingleTerm/medium | 1.36× | — |
 
 ### Summary: at parity or faster than SQLite
@@ -150,7 +152,7 @@ Ranked by ratio (excluding Vacuum):
 | Insert_SingleRow | **0.35×** (2.9× faster) |
 | ForeignKey_Insert | **0.40×** (2.5× faster) |
 | FullText_Search_MultiTermAND | **0.81×** (1.2× faster) |
-| FullText_Update_WithIndex | **0.92×** ✓ |
+| FullText_Update_WithIndex | **0.79×** (1.3× faster) |
 | ForeignKey_DeleteCascade | **0.98×** |
 | Select_FullScan | **0.93×** |
 | GroupBy_Aggregate | **0.97×** |

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -934,7 +934,7 @@ func (idx *dedicatedInvertedIndex) makeInvertedEntryCell(
 	postings []invertedPosting,
 	oldCells []invertedEntryCell,
 ) (invertedEntryCell, error) {
-	grouped := groupInvertedPostings(idx.mode, postings)
+	grouped := groupInvertedPostingsInPlace(idx.mode, postings)
 	payload, err := encodeGroupedInvertedPostingList(idx.mode, grouped)
 	if err != nil {
 		return invertedEntryCell{}, err
@@ -1033,7 +1033,7 @@ func (idx *dedicatedInvertedIndex) readPostingTree(ctx context.Context, cell inv
 		}
 		postings = append(postings, blockPostings...)
 	}
-	return groupInvertedPostings(idx.mode, postings), nil
+	return postings, nil
 }
 
 // insertPostingIntoTreeCell updates one existing posting-tree leaf block in place.
@@ -1057,7 +1057,7 @@ func (idx *dedicatedInvertedIndex) insertPostingIntoTreeCell(ctx context.Context
 
 	oldDocFreq := len(blockPostings)
 	oldPostingCount := countInvertedPostings(idx.mode, blockPostings)
-	updatedPostings := groupInvertedPostings(idx.mode, append(blockPostings, posting))
+	updatedPostings := groupInvertedPostingsInPlace(idx.mode, append(blockPostings, posting))
 	newDocFreq := len(updatedPostings)
 	newPostingCount := countInvertedPostings(idx.mode, updatedPostings)
 	if oldDocFreq == newDocFreq && oldPostingCount == newPostingCount {
@@ -1124,7 +1124,7 @@ func (idx *dedicatedInvertedIndex) replacePostingInTreeCell(
 	oldDocFreq := len(blockPostings)
 	oldPostingCount := countInvertedPostings(idx.mode, blockPostings)
 	updatedPostings := removeInvertedPosting(idx.mode, blockPostings, oldPosting)
-	updatedPostings = groupInvertedPostings(idx.mode, append(updatedPostings, newPosting))
+	updatedPostings = groupInvertedPostingsInPlace(idx.mode, append(updatedPostings, newPosting))
 	newDocFreq := len(updatedPostings)
 	newPostingCount := countInvertedPostings(idx.mode, updatedPostings)
 
@@ -2056,18 +2056,18 @@ func (idx *dedicatedInvertedIndex) freePostingTree(ctx context.Context, cell inv
 	return nil
 }
 
-// makeInvertedPostingBlocks groups postings into bounded compressed blocks.
+// makeInvertedPostingBlocks packs already-grouped postings into bounded
+// compressed blocks. Callers are responsible for grouping before this call.
 func makeInvertedPostingBlocks(mode invertedPostingMode, postings []invertedPosting) ([]invertedPostingBlock, error) {
-	grouped := groupInvertedPostings(mode, postings)
 	blocks := make([]invertedPostingBlock, 0)
-	for len(grouped) > 0 {
-		n, payload, err := encodeLargestInvertedPostingBlock(mode, grouped, invertedPostingBlockPayloadMax)
+	for len(postings) > 0 {
+		n, payload, err := encodeLargestInvertedPostingBlock(mode, postings, invertedPostingBlockPayloadMax)
 		if err != nil {
 			return nil, err
 		}
-		blockPostings := grouped[:n]
+		blockPostings := postings[:n]
 		blocks = append(blocks, postingBlockFromPostings(mode, blockPostings, payload))
-		grouped = grouped[n:]
+		postings = postings[n:]
 	}
 	return blocks, nil
 }
@@ -2182,8 +2182,9 @@ func countInvertedPostings(mode invertedPostingMode, postings []invertedPosting)
 }
 
 // removeInvertedPosting removes one row or selected positions from postings.
+// Postings must already be sorted by RowID (i.e. as returned by the codec).
 func removeInvertedPosting(mode invertedPostingMode, postings []invertedPosting, remove invertedPosting) []invertedPosting {
-	grouped := groupInvertedPostings(mode, postings)
+	grouped := postings
 	i, found := slices.BinarySearchFunc(grouped, remove.RowID, func(posting invertedPosting, rowID RowID) int {
 		if posting.RowID < rowID {
 			return -1

--- a/internal/minisql/inverted_posting.go
+++ b/internal/minisql/inverted_posting.go
@@ -223,6 +223,44 @@ func groupInvertedPostings(mode invertedPostingMode, postings []invertedPosting)
 	return grouped
 }
 
+// groupInvertedPostingsInPlace sorts and groups postings in-place, returning a
+// subslice of the input. The caller must not retain the input slice after this
+// call. Unlike groupInvertedPostings it avoids the up-front copy, so the common
+// case (all unique RowIDs) has zero allocations. Used on the hot insert/update
+// path where the caller always owns the slice.
+func groupInvertedPostingsInPlace(mode invertedPostingMode, postings []invertedPosting) []invertedPosting {
+	if len(postings) == 0 {
+		return postings
+	}
+	if len(postings) == 1 {
+		if mode == invertedPostingModePositions {
+			slices.Sort(postings[0].Positions)
+			postings[0].Positions = slices.Compact(postings[0].Positions)
+		}
+		return postings
+	}
+	slices.SortFunc(postings, compareInvertedPostings)
+	out := 0
+	for i := 1; i < len(postings); i++ {
+		if postings[out].RowID == postings[i].RowID {
+			if mode == invertedPostingModePositions {
+				postings[out].Positions = append(postings[out].Positions, postings[i].Positions...)
+			}
+		} else {
+			out++
+			postings[out] = postings[i]
+		}
+	}
+	postings = postings[:out+1]
+	if mode == invertedPostingModePositions {
+		for i := range postings {
+			slices.Sort(postings[i].Positions)
+			postings[i].Positions = slices.Compact(postings[i].Positions)
+		}
+	}
+	return postings
+}
+
 // compareInvertedPostings orders postings by row ID, then by first position for
 // positional postings. Canonical ordering keeps encoded payloads deterministic.
 func compareInvertedPostings(a, b invertedPosting) int {


### PR DESCRIPTION
…ughout posting codec

Memory profiling revealed groupInvertedPostings at 44% of all allocations in Insert_WithIndex. Three classes of waste fixed:

1. Added groupInvertedPostingsInPlace — sorts and compacts the slice in-place using a two-pointer approach. Zero allocations for the common case where all RowIDs are unique (no copy of the input, no new grouped slice). Switched makeInvertedEntryCell, insertPostingIntoTreeCell, and replacePostingInTreeCell to use it; all three pass freshly-allocated or freshly-decoded slices.

2. Removed redundant groupInvertedPostings from makeInvertedPostingBlocks — all three callers (writePostingTree, insertPostingIntoTreeCell, replacePostingInTreeCell) already pass grouped input, so this was always a wasted copy+sort.

3. Removed redundant groupInvertedPostings from removeInvertedPosting (all callers pass sorted decoded postings) and from readPostingTree (postings accumulated from sequential sorted B-tree leaf blocks are already in order).

Results vs original baseline:
- Insert_WithIndex: 382k→197k ns/op (−48%), allocs 3164→1289 (−59%), 3.76×→2.09×
- Update_WithIndex: 152k→75k ns/op (−51%), now faster than SQLite (0.79×)
- Delete_WithIndex: 350k→187k ns/op (−47%), 1.96×→1.39×
- BuildIndex:       10.6M→6.6M ns/op (−38%), allocs −82%, 3.64×→3.19×