### PR TITLE
fix: prevent WAL frame buffer aliasing in Cell.Unmarshal causing pani…

### DIFF
--- a/internal/minisql/index.go
+++ b/internal/minisql/index.go
@@ -728,6 +728,22 @@ func (ui *Index[T]) removeFromInternal(ctx context.Context, page *Page, idx int,
 			return fmt.Errorf("remove successor key: %w", err)
 		}
 	default:
+		// Guard against overflow: if merging left + separator + right would exceed one page,
+		// steal the successor from the right child instead (mirrors the atLeastHalfFull path).
+		separatorSize := node.Cells[idx].Size()
+		rightUsed := rightChildNode.MaxSpace() - rightChildNode.freeBytes
+		if separatorSize+rightUsed > leftChildNode.freeBytes {
+			successor, err := ui.getSucc(ctx, node, idx)
+			if err != nil {
+				return fmt.Errorf("get successor key: %w", err)
+			}
+			node.Cells[idx].Key = successor.Key
+			node.Cells[idx].InlineRowIDs = successor.InlineRowIDs
+			node.Cells[idx].RowIDs = successor.RowIDs
+			node.Cells[idx].UniqueRowID = successor.UniqueRowID
+			node.Cells[idx].Overflow = successor.Overflow
+			return ui.remove(ctx, rightChildPage, successor.Key, rowID)
+		}
 		if err := ui.merge(ctx, page, leftChildPage, rightChildPage, uint32(idx)); err != nil {
 			return fmt.Errorf("merge children: %w", err)
 		}
@@ -819,7 +835,21 @@ func (ui *Index[T]) fill(ctx context.Context, parent, page *Page, idx int) error
 		return ui.borrowFromRight(ctx, parent, page, right, uint32(idx))
 	}
 
+	pageNode := page.IndexNode.(*IndexNode[T])
+
 	if idx != int(parentNode.Header.Keys) {
+		// Guard against merge overflow: merging two not-half-full nodes requires pulling one
+		// separator cell down from the parent. For int64 unique indexes, each cell is 20 bytes
+		// (8 key + 8 UniqueRowID + 4 Child). At the not-half-full threshold, a node can hold
+		// up to 102 cells (102×20 = 2040 ≤ MaxSpace/2 = 2040). Two such nodes plus one
+		// separator cell = (2×102+1)×20 = 4100 bytes, which exceeds MaxSpace (4081).
+		// When the merged content would overflow, the sibling must have ≥102 cells (that is
+		// why the merge would overflow), so force-borrowing 1 cell from it is always safe.
+		separatorSize := parentNode.Cells[idx].Size()
+		rightUsed := rightNode.MaxSpace() - rightNode.freeBytes
+		if separatorSize+rightUsed > pageNode.freeBytes {
+			return ui.borrowFromRight(ctx, parent, page, right, uint32(idx))
+		}
 		if err := ui.merge(ctx, parent, page, right, uint32(idx)); err != nil {
 			return fmt.Errorf("merge with left: %w", err)
 		}
@@ -827,6 +857,11 @@ func (ui *Index[T]) fill(ctx context.Context, parent, page *Page, idx int) error
 		return ui.pager.AddFreePage(ctx, right.Index)
 	}
 
+	separatorSize := parentNode.Cells[idx-1].Size()
+	pageUsed := pageNode.MaxSpace() - pageNode.freeBytes
+	if separatorSize+pageUsed > leftNode.freeBytes {
+		return ui.borrowFromLeft(ctx, parent, page, left, uint32(idx))
+	}
 	if err := ui.merge(ctx, parent, left, page, uint32(idx-1)); err != nil {
 		return fmt.Errorf("merge with right: %w", err)
 	}

--- a/internal/minisql/leaf_node.go
+++ b/internal/minisql/leaf_node.go
@@ -80,8 +80,8 @@ func (c *Cell) Marshal(buf []byte) {
 }
 
 // Unmarshal deserialises a cell from buf using the column schema to determine
-// each field's size. Value is sub-sliced directly into the page buffer (zero-copy);
-// isOwned is false until PrepareModifyCell is called.
+// each field's size. Value is copied into owned memory (isOwned=true) so that
+// the cell does not alias the source buffer, which may be returned to a pool.
 func (c *Cell) Unmarshal(columns []Column, buf []byte) (uint64, error) {
 	offset := uint64(0)
 
@@ -108,10 +108,13 @@ func (c *Cell) Unmarshal(columns []Column, buf []byte) (uint64, error) {
 		}
 	}
 
-	// Pass 2: Sub-slice directly into page buffer — zero allocation, zero copy.
-	// isOwned stays false; PrepareModifyCell copies on first write (COW).
+	// Pass 2: Copy value bytes into owned memory. A zero-copy sub-slice would alias
+	// the source buffer (WAL frame buffers are returned to pageDataPool on the next
+	// commit and reused as pageBuf, corrupting any c.Value still pointing into them).
 	if totalSize > 0 {
-		c.Value = buf[offset : offset+totalSize]
+		c.Value = make([]byte, totalSize)
+		copy(c.Value, buf[offset:offset+totalSize])
+		c.isOwned = true
 		offset += totalSize
 	}
 

--- a/internal/minisql/leaf_node_test.go
+++ b/internal/minisql/leaf_node_test.go
@@ -32,8 +32,9 @@ func TestLeafNode_Marshal(t *testing.T) {
 		NextLeaf: 4,
 	}
 	node.Cells = append(node.Cells, Cell{
-		Key:   1,
-		Value: prefixWithLength(bytes.Repeat([]byte{'a'}, 230)),
+		Key:     1,
+		Value:   prefixWithLength(bytes.Repeat([]byte{'a'}, 230)),
+		isOwned: true, // Unmarshal produces owned copies to avoid aliasing page buffers
 	}, Cell{
 		Key:         2,
 		NullBitmask: bitwise.Set(uint64(0), 0),

--- a/internal/minisql/minisql_test.go
+++ b/internal/minisql/minisql_test.go
@@ -705,12 +705,14 @@ func newTestBtree() (*Page, []*Page, []*Page) {
 				},
 				Cells: []Cell{
 					{
-						Key:   1,
-						Value: prefixWithLength([]byte("ccc")),
+						Key:     1,
+						Value:   prefixWithLength([]byte("ccc")),
+						isOwned: true,
 					},
 					{
-						Key:   2,
-						Value: prefixWithLength([]byte("ddd")),
+						Key:     2,
+						Value:   prefixWithLength([]byte("ddd")),
+						isOwned: true,
 					},
 				},
 			},
@@ -729,8 +731,9 @@ func newTestBtree() (*Page, []*Page, []*Page) {
 				},
 				Cells: []Cell{
 					{
-						Key:   5,
-						Value: prefixWithLength([]byte("aaa")),
+						Key:     5,
+						Value:   prefixWithLength([]byte("aaa")),
+						isOwned: true,
 					},
 				},
 			},
@@ -749,12 +752,14 @@ func newTestBtree() (*Page, []*Page, []*Page) {
 				},
 				Cells: []Cell{
 					{
-						Key:   12,
-						Value: prefixWithLength([]byte("bbb")),
+						Key:     12,
+						Value:   prefixWithLength([]byte("bbb")),
+						isOwned: true,
 					},
 					{
-						Key:   18,
-						Value: prefixWithLength([]byte("fff")),
+						Key:     18,
+						Value:   prefixWithLength([]byte("fff")),
+						isOwned: true,
 					},
 				},
 			},
@@ -772,8 +777,9 @@ func newTestBtree() (*Page, []*Page, []*Page) {
 				},
 				Cells: []Cell{
 					{
-						Key:   21,
-						Value: prefixWithLength([]byte("ggg")),
+						Key:     21,
+						Value:   prefixWithLength([]byte("ggg")),
+						isOwned: true,
 					},
 				},
 			},


### PR DESCRIPTION
…c on LRU eviction

Cell.Unmarshal was sub-slicing c.Value directly into the WAL frame buffer (zero-copy). When that frame was later returned to pageDataPool on the next commit and reused as pageBuf for marshalPage, writes to the reused buffer corrupted the value bytes that cached cells still pointed into. On the next LRU eviction + WAL reload of page 0, unmarshal read a garbage text-column length (65536), advancing scanOffset to 65560 and panicking on a 3806-byte buffer in BenchmarkForeignKey_DeleteCascade.

Fix: copy value bytes into owned memory (make+copy, isOwned=true) so cells never alias the source buffer. The isOwned=true flag also eliminates the redundant PrepareModifyCell copy on first modification.

Also includes the previously committed fill() overflow guard (force-borrow instead of merge when merged content would exceed one page) and its corrected comment explaining the 102-cell threshold and 20-byte cell size.