### PR TITLE
Refactor/optimise group by having

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,23 +1,67 @@
 # Benchmark Results
 
+## 2026-05-19 — GROUP BY / HAVING zero-alloc streaming
+
+**GROUP BY zero-alloc sequential scan:** `selectGroupBy` materialised every
+matching row into a `[]Row` buffer before grouping — each row required
+`make([]OptionalValue, nCols)` from `UnmarshalWithMask` (91.75% of all
+allocs). Refactored into a `groupByAccumulator` struct (`process` / `buildResult`
+methods) + `selectGroupByZeroAlloc` which, for single sequential scans, iterates
+directly over B-tree cells with one reused `[]OptionalValue` buffer (same pattern
+as `countSequentialScanZeroAlloc`). GROUP BY column values are copied into the
+flat `groupValPool` inside `process`, so the buffer reuse is safe. Falls back to
+the materialising path for virtual tables and parallel scans.
+
+Net: **GroupBy_Aggregate** allocs 10,483 → 466 (96% drop), 2,082 µs → 803 µs
+(2.6× speedup, now **2.8× faster than SQLite**). **Having_Filter** allocs
+10,287 → 271 (97% drop), 1,944 µs → 767 µs (2.5× speedup, now **2.5× faster
+than SQLite**).
+
+---
+
+## 2026-05-19 — WAL aliasing fix + FK cascade benchmark redesign
+
+**`Cell.Unmarshal` aliasing fix (correctness):** `Cell.Unmarshal` previously
+sub-sliced `c.Value` directly into the WAL frame buffer. When the frame was
+returned to `pageDataPool` on the next commit and reused as `pageBuf`, writes
+corrupted the cell data still referenced by cached pages — producing a corrupt
+WAL frame that panicked on the next cache miss
+(`index out of range [65560] with length 3806`). Fix: copy value bytes into
+owned memory (`make+copy`, `isOwned=true`). Cost: +1 alloc per cell per
+cache-miss page load (~20 allocs/op added to Delete_ByPK, ~22 to Insert).
+Panic eliminated at 25 000-iteration cascade-delete benchmark run.
+
+**FK cascade benchmark redesign:** `BenchmarkForeignKey_DeleteCascade`
+pre-seeded all `b.N` rows before the timed loop. Calibration saw O(b.N²) cost
+(each delete scanned a growing table with no FK-column index), causing the
+framework to settle on tiny b.N values (≈ 136 at -benchtime=1s vs ≈ 125 k
+previously) where each delete traversed a much larger pre-seeded table. Result:
+spurious 7 ms/op vs the correct ≈ 50 µs/op. Fixed by moving insert inside the
+loop with `b.StopTimer`/`b.StartTimer`: each iteration inserts 1 parent + 10
+children (untimed) then deletes the parent (timed). Table size is always 0 net
+per iteration; timing is b.N-independent.
+
+---
+
 ## 2026-05-19 — CTE / CountStar zero-alloc optimisation
 
-**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26  
-**Settings:** `-benchtime=5s -count=3` · median of 3 runs shown
-
-**CTE_Materialise improvements (2026-05-19):** `UnmarshalWithMask` refactored to extract a shared `decodeColumnsWithMask` inner loop; added `unmarshalWithMaskInto` which accepts a caller-supplied values buffer so the dominant `make([]OptionalValue, n)` allocation can be eliminated for COUNT(\*) scans. `countSequentialScanZeroAlloc` pre-allocates one reuse buffer before the scan loop and re-uses it across every row — safe because COUNT(\*) never retains a row after the predicate check. Net: CTE_Materialise allocs 14,134→92 (99% reduction), 1,851µs→826µs (2.2× speedup), ratio 4.25×→1.62×. CountStar allocs 706→30 (96% reduction), 29.5µs→6.1µs (4.9× speedup), ratio 3.02×→0.56× (now faster than SQLite).
+**CTE_Materialise improvements (2026-05-19):** `UnmarshalWithMask` refactored
+to extract a shared `decodeColumnsWithMask` inner loop; added
+`unmarshalWithMaskInto` which accepts a caller-supplied values buffer so the
+dominant `make([]OptionalValue, n)` allocation can be eliminated for COUNT(\*)
+scans. `countSequentialScanZeroAlloc` pre-allocates one reuse buffer before the
+scan loop and re-uses it across every row — safe because COUNT(\*) never retains
+a row after the predicate check. Net: CTE_Materialise allocs 14,134 → 92
+(99% reduction), 1,851 µs → 787 µs (2.4× speedup). CountStar allocs 706 → 30
+(96% reduction), 29.5 µs → 6.4 µs (4.6× speedup, now faster than SQLite).
 
 ---
 
 ## 2026-05-18 — Baseline
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26  
-**Settings:** `-benchtime=5s -count=3` · median of 3 runs shown  
-**Commit:** `814f492` (zero-alloc qualified column name lookup) + `fix: appendRowID uint64 underflow`
-
-All benchmarks pass. `BenchmarkFullText_Delete_WithIndex` was previously
-panicking (uint64 underflow in `appendRowID` when `freeBytes < 8`); fixed in
-the same session before this baseline was taken.
+**Settings:** `-benchtime=1s -count=3` · median of 3 runs shown  
+**Commit:** `fix/delete-cascade-panic` branch (WAL aliasing fix applied)
 
 ---
 
@@ -25,80 +69,93 @@ the same session before this baseline was taken.
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| PointScan | 6,042 | 69 | 3,436 | **1.76×** |
-| Limit | 7,961 | 129 | 8,087 | **1.0×** |
-| FullScan (10k rows) | 4,810,296 | 112,321 | 5,186,549 | **0.93×** ✓ |
-| CountStar | 6,080 | 30 | 10,797 | **0.56×** ✓ |
-| IndexRangeScan | 739,527 | 11,077 | 730,900 | **1.01×** |
-| RangeScan | 1,510,027 | 19,922 | 869,343 | **1.74×** |
-| SecondaryIndex_LowSelectivity (5k rows) | 3,079,429 | 54,951 | 2,785,947 | **1.11×** |
-| SecondaryIndex_LowSelectivityLimit | 10,687 | 166 | 8,126 | **1.32×** |
+| PointScan | 8,701 | 69 | 4,054 | **2.15×** |
+| Limit | 9,980 | 129 | 9,492 | **1.05×** |
+| FullScan (10k rows) | 6,243,000 | 109,845 | 6,503,975 | **0.96×** ✓ |
+| CountStar | 6,388 | 30 | 10,617 | **0.60×** ✓ |
+| IndexRangeScan | 1,020,200 | 11,077 | 865,700 | **1.18×** |
+| RangeScan | 2,535,559 | 19,922 | 994,145 | **2.55×** |
+| SecondaryIndex_LowSelectivity (5k rows) | 3,883,000 | 54,952 | 3,119,121 | **1.25×** |
+| SecondaryIndex_LowSelectivityLimit | 14,840 | 166 | 9,422 | **1.57×** |
 
 ### INSERT
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| SingleRow | 17,865 | 56 | 44,282 | **0.35×** ✓ |
-| Batch (100 rows) | 385,420 | 3,401 | 234,899 | **1.64×** |
-| PreparedBatch (100 rows) | 384,286 | 3,400 | 229,264 | **1.68×** |
-| MultiValues (100 rows) | 242,745 | 2,530 | 171,803 | **1.41×** |
+| SingleRow | 23,516 | 56 | 63,692 | **0.37×** ✓ |
+| Batch (100 rows) | 471,600 | 3,372 | 283,300 | **1.66×** |
+| PreparedBatch (100 rows) | 465,576 | 3,378 | 316,700 | **1.47×** |
+| MultiValues (100 rows) | 275,068 | 2,497 | 191,739 | **1.43×** |
 
 ### UPDATE / DELETE / UPSERT
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| Update_ByPK | 12,196 | 75 | 38,080 | **0.32×** ✓ |
-| OnConflict_DoUpdate | 11,062 | 49 | 56,635 | **0.20×** ✓ |
-| Delete_ByPK | 23,031 | 109 | 113,479 | **0.20×** ✓ |
+| Update_ByPK | 17,085 | 75 | 41,610 | **0.41×** ✓ |
+| OnConflict_DoUpdate | 14,552 | 49 | 39,680 | **0.37×** ✓ |
+| Delete_ByPK | 31,370 | 131 | 98,560 | **0.32×** ✓ |
 
 ### JOIN
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| Join_Inner_SmallLarge (10k rows) | 8,185,594 | 153,371 | 4,592,612 | **1.78×** |
-| Join_Left_UnmatchedRows (10k rows) | 11,358,331 | 203,249 | 3,993,609 | **2.84×** |
+| Join_Inner_SmallLarge (10k rows) | 13,055,000 | 150,000 | 6,025,173 | **2.17×** |
+| Join_Left_UnmatchedRows (10k rows) | 22,140,000 | 199,893 | 4,894,000 | **4.52×** |
 
 ### GROUP BY / HAVING / DISTINCT
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| GroupBy_Aggregate (100 groups) | 2,120,776 | 12,347 | 2,197,493 | **0.97×** ✓ |
-| Having_Filter (100 groups) | 2,089,395 | 12,174 | 1,910,146 | **1.09×** |
-| Distinct_HighCardinality (10k rows) | 5,510,803 | 111,455 | 5,563,584 | **0.99×** ✓ |
+| GroupBy_Aggregate (100 groups) | 803,000 | 466 | 2,218,000 | **0.36×** ✓ |
+| Having_Filter (100 groups) | 767,000 | 271 | 1,910,000 | **0.40×** ✓ |
+| Distinct_HighCardinality (10k rows) | 5,380,000 | 110,160 | 5,395,000 | **1.00×** ✓ |
 
 ### SUBQUERY / CTE
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| Subquery_InList (5k rows) | 8,380,671 | 139,776 | 3,653,376 | **2.29×** |
-| CTE_Materialise | 826,014 | 92 | 510,964 | **1.62×** |
+| Subquery_InList (5k rows) | 12,837,000 | 134,879 | 4,019,000 | **3.19×** |
+| CTE_Materialise | 787,400 | 92 | 538,400 | **1.46×** |
 
 ### FOREIGN KEY
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| ForeignKey_Insert | 17,387 | 51 | 43,157 | **0.40×** ✓ |
-| ForeignKey_DeleteCascade | 49,555 | 170 | 50,359 | **0.98×** ✓ |
+| ForeignKey_Insert | 18,940 | 51 | 43,970 | **0.43×** ✓ |
+| ForeignKey_DeleteCascade | 51,071 | 170 | 49,351 | **1.03×** |
 
 ### FULL-TEXT SEARCH
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| BuildIndex (1k docs) | 6,573,914 | 35,106 | 2,062,776 | **3.19×** |
-| Insert_WithIndex | 197,245 | 1,289 | 94,187 | **2.09×** |
-| Search_SingleTerm/rare (1 match) | 16,113 | — | 10,558 | **1.53×** |
-| Search_SingleTerm/medium (10 matches) | 15,909 | — | 11,676 | **1.36×** |
-| Search_SingleTerm/common (1k matches) | 15,762 | — | 66,954 | **0.24×** ✓ |
-| Search_MultiTermAND (10 matches) | 31,044 | — | 38,480 | **0.81×** ✓ |
-| Search_Phrase (100 matches) | 55,591 | — | 34,185 | **1.63×** |
-| Update_WithIndex | 74,823 | 545 | 94,200 | **0.79×** ✓ |
-| Delete_WithIndex | 186,852 | 1,822 | 134,360 | **1.39×** |
+| BuildIndex (1k docs) | 10,730,000 | 35,097 | 2,383,000 | **4.50×** |
+| Insert_WithIndex | 294,100 | 1,234 | 94,280 | **3.12×** |
+| Search_SingleTerm/rare (1 match) | 19,600 | 72 | 10,870 | **1.80×** |
+| Search_SingleTerm/medium (10 matches) | 19,720 | 72 | 12,080 | **1.63×** |
+| Search_SingleTerm/common (1k matches) | 19,690 | 74 | 69,600 | **0.28×** ✓ |
+| Search_MultiTermAND (10 matches) | 34,970 | 104 | 42,930 | **0.81×** ✓ |
+| Search_Phrase (100 matches) | 56,170 | 526 | 30,630 | **1.84×** |
+| Update_WithIndex | 145,600 | 679 | 116,200 | **1.25×** |
+| Delete_WithIndex | 251,300 | 1,715 | 146,400 | **1.72×** |
 
-**Search improvements (2026-05-18/19):** Parser pre-computes `strings.ToUpper` once per query (was per-token×keyword). Single-term COUNT(\*) uses `DocFreq` from the index entry header — O(log N) vs O(N). Rare/medium dropped from ~11× to ~1.5×; common flipped to 4× faster than SQLite. Phrase search: replaced `map[RowID][]uint32` postings with sorted `[]invertedPosting` + binary search (eliminating per-row map allocations); phrase adjacency check replaced with zero-alloc binary search on sorted position arrays; COUNT(\*) with index-covered predicates skips B-tree row fetch entirely. Phrase dropped from 9.5× to 1.6×.
+**Search improvements (2026-05-18/19):** Parser pre-computes `strings.ToUpper`
+once per query (was per-token×keyword). Single-term COUNT(\*) uses `DocFreq`
+from the index entry header — O(log N) vs O(N). Rare/medium dropped from
+~11× to ~1.6×; common flipped to 3.6× faster than SQLite. Phrase search:
+replaced `map[RowID][]uint32` postings with sorted `[]invertedPosting` +
+binary search (eliminating per-row map allocations); phrase adjacency check
+replaced with zero-alloc binary search on sorted position arrays; COUNT(\*)
+with index-covered predicates skips B-tree row fetch entirely. Phrase dropped
+from 9.5× to 1.8×. MultiTermAND now faster than SQLite.
 
-**Maintenance improvements (2026-05-19, round 1):** `invertedEntryPage.Marshal` and `invertedPostingPage.Marshal` now write cells/blocks directly into the destination page buffer — eliminates one `make([]byte)` allocation per cell/block. Fixed double-grouping in `makeInvertedEntryCell` (was calling `encodeInvertedPostingList` which re-grouped already-grouped input; now calls `encodeGroupedInvertedPostingList` directly). Deferred the `allPostings` copy in `insertEntryLeaf` to only the paths that use it.
-
-**Maintenance improvements (2026-05-19, round 2):** Added `groupInvertedPostingsInPlace` — sorts and groups in-place with zero allocations for the common all-unique-RowID case. Switched `makeInvertedEntryCell`, `insertPostingIntoTreeCell`, and `replacePostingInTreeCell` to use it. Removed the redundant `groupInvertedPostings` calls inside `makeInvertedPostingBlocks` (callers always pass already-grouped input), `removeInvertedPosting` (callers always pass sorted decoded postings), and `readPostingTree` (postings from sequential sorted B-tree blocks are already in order). Net: Insert allocs 3,164→1,289 (−59%), Insert 3.76×→2.09×, Update 1.21×→0.79× (faster than SQLite), Delete 1.96×→1.39×, BuildIndex 3.64×→3.19× with 82% fewer allocs.
+**Maintenance improvements (2026-05-19):** `invertedEntryPage.Marshal` and
+`invertedPostingPage.Marshal` now write cells/blocks directly into the
+destination page buffer — eliminates one `make([]byte)` allocation per
+cell/block. Added `groupInvertedPostingsInPlace` — sorts and groups in-place
+with zero allocations for the common all-unique-RowID case. Removed redundant
+`groupInvertedPostings` calls throughout the codec. Net: Insert allocs
+3,164 → 1,234 (−61%), Update_WithIndex now 1.25× (was 1.39×), Delete_WithIndex
+1.72× (was 1.96×).
 
 ### JSON INVERTED INDEX
 
@@ -106,22 +163,23 @@ No SQLite equivalent (minisql-only feature).
 
 | Benchmark | minisql ns/op | minisql allocs/op |
 |---|---:|---:|
-| BuildIndex (1k docs) | 35,274,625 | 215,818 |
-| Insert_WithIndex | 720,165 | 1,015 |
-| Update_WithIndex | 9,436 | 87 |
-| Delete_WithIndex | 508,629 | 892 |
-| Contains_KeyValue (indexed, 334 matches) | 122,021 | 2,076 |
-| Contains_ObjectSubset (indexed, 334 matches) | 154,298 | 2,147 |
+| BuildIndex (1k docs) | 34,750,000 | 144,390 |
+| Insert_WithIndex | 989,600 | 724 |
+| Update_WithIndex | 18,537 | 93 |
+| Delete_WithIndex | 740,400 | 668 |
+| Contains_KeyValue (indexed, 334 matches) | 93,670 | 147 |
+| Contains_ObjectSubset (indexed, 334 matches) | 143,300 | 218 |
 
-SQLite with expression index: `Contains_KeyValue` ~30µs (4.1× faster), `Contains_ObjectSubset` ~129µs (1.2× faster).
+SQLite with expression index: `Contains_KeyValue` ~32 µs (2.9× faster),
+`Contains_ObjectSubset` ~140 µs (1.0×, at parity).
 
 ### MAINTENANCE
 
 | Benchmark | minisql ns/op | minisql allocs/op | SQLite ns/op | Ratio |
 |---|---:|---:|---:|---:|
-| Vacuum_Small | 20,101,857 | 25,791 | 239,274 | **84×** |
-| WAL_Checkpoint | 167,806 | 305 | 64,177 | **2.62×** |
-| Explain | 5,038 | 68 | 1,163 | **4.33×** |
+| Vacuum_Small | 26,540,000 | 21,509 | 637,700 | **41.6×** |
+| WAL_Checkpoint | 300,262 | 46 | 122,220 | **2.46×** |
+| Explain | 6,804 | 68 | 1,683 | **4.04×** |
 
 Vacuum gap is expected — minisql does a full copy-compact-swap; SQLite reclaims
 free pages in-place. Not a meaningful comparison.
@@ -134,50 +192,37 @@ Ranked by ratio (excluding Vacuum):
 
 | Benchmark | Ratio | allocs/op |
 |---|---:|---:|
-| Explain | 4.33× | 68 |
-| FullText_BuildIndex | 3.19× | 35,106 |
-| Join_Left_UnmatchedRows | 2.84× | 203,249 |
-| WAL_Checkpoint | 2.62× | 305 |
-| Subquery_InList | 2.29× | 139,776 |
-| FullText_Insert_WithIndex | 2.09× | 1,289 |
-| Join_Inner_SmallLarge | 1.78× | 153,371 |
-| PointScan | 1.76× | 69 |
-| RangeScan | 1.74× | 19,922 |
-| FullText_Search_Phrase | 1.63× | — |
-| CTE_Materialise | 1.62× | 92 |
-| FullText_Search_SingleTerm/rare | 1.53× | — |
-| FullText_Delete_WithIndex | 1.39× | 1,822 |
-| FullText_Search_SingleTerm/medium | 1.36× | — |
+| Join_Left_UnmatchedRows | **4.52×** | 199,893 |
+| FullText_BuildIndex | **4.50×** | 35,097 |
+| Explain | **4.04×** | 68 |
+| Subquery_InList | **3.19×** | 134,879 |
+| FullText_Insert_WithIndex | **3.12×** | 1,234 |
+| RangeScan | **2.55×** | 19,922 |
+| WAL_Checkpoint | **2.46×** | 46 |
+| Join_Inner_SmallLarge | **2.17×** | 150,000 |
+| PointScan | **2.15×** | 69 |
+| FullText_Search_Phrase | **1.84×** | 526 |
+| FullText_Search_SingleTerm/rare | **1.80×** | 72 |
+| FullText_Search_SingleTerm/medium | **1.63×** | 72 |
+| SecondaryIndex_LowSelectivityLimit | **1.57×** | 166 |
+| CTE_Materialise | **1.46×** | 92 |
+| FullText_Delete_WithIndex | **1.72×** | 1,715 |
 
 ### Summary: at parity or faster than SQLite
 
 | Benchmark | Ratio |
 |---|---:|
-| FullText_Search_SingleTerm/common | **0.24×** (4.2× faster) |
-| Delete_ByPK | **0.20×** (5× faster) |
-| OnConflict_DoUpdate | **0.20×** (5× faster) |
-| Update_ByPK | **0.32×** (3× faster) |
-| Insert_SingleRow | **0.35×** (2.9× faster) |
-| ForeignKey_Insert | **0.40×** (2.5× faster) |
-| CountStar | **0.56×** (1.8× faster) |
+| Delete_ByPK | **0.32×** (3.1× faster) |
+| OnConflict_DoUpdate | **0.37×** (2.7× faster) |
+| Insert_SingleRow | **0.37×** (2.7× faster) |
+| GroupBy_Aggregate | **0.36×** (2.8× faster) |
+| Having_Filter | **0.40×** (2.5× faster) |
+| Update_ByPK | **0.41×** (2.4× faster) |
+| ForeignKey_Insert | **0.43×** (2.3× faster) |
+| CountStar | **0.60×** (1.7× faster) |
+| FullText_Search_SingleTerm/common | **0.28×** (3.6× faster) |
 | FullText_Search_MultiTermAND | **0.81×** (1.2× faster) |
-| FullText_Update_WithIndex | **0.79×** (1.3× faster) |
-| ForeignKey_DeleteCascade | **0.98×** |
-| Select_FullScan | **0.93×** |
-| GroupBy_Aggregate | **0.97×** |
-| Distinct_HighCardinality | **0.99×** |
-| Select_Limit | **1.0×** |
-| Select_IndexRangeScan | **1.01×** |
-
----
-
-### Benchmark run-time anomalies
-
-Two benchmarks took far longer than expected to complete the 3-run suite:
-
-- `BenchmarkForeignKey_DeleteCascade`: **333s** — benchmark setup is likely
-  not isolated behind `b.ResetTimer()` correctly, or teardown is running inside
-  the timed window.
-- `BenchmarkFullText_BuildIndex`: Restructured to seed rows once then drop+recreate the index per iteration, so `b.N` no longer re-inserts rows. SQLite FTS5 path is now much faster to run.
-- `BenchmarkVacuum_Small`: **242s** — 20ms/op × large `b.N` × 3 runs; expected
-  given the algorithm cost.
+| ForeignKey_DeleteCascade | **1.03×** |
+| Select_FullScan | **0.96×** |
+| Distinct_HighCardinality | **1.00×** |
+| Select_Limit | **1.05×** |

--- a/benchmarks/foreign_key_bench_test.go
+++ b/benchmarks/foreign_key_bench_test.go
@@ -76,9 +76,10 @@ func BenchmarkForeignKey_Insert(b *testing.B) {
 }
 
 // BenchmarkForeignKey_DeleteCascade measures the cost of deleting a parent row
-// that has cascade-delete children.  Each iteration inserts a parent with 10
-// children, then deletes the parent (triggering cascade deletion of all 10 children).
-// The insert phase is excluded from timing via b.StopTimer / b.StartTimer.
+// that has cascade-delete children. Each iteration inserts a parent with 10
+// children (untimed), then deletes the parent (timed), triggering cascade
+// deletion of all 10 children. The table always contains exactly 1 parent and
+// 10 children during the timed delete, giving stable, b.N-independent timing.
 func BenchmarkForeignKey_DeleteCascade(b *testing.B) {
 	for _, d := range drivers {
 		b.Run(d.name, func(b *testing.B) {
@@ -144,23 +145,23 @@ func BenchmarkForeignKey_DeleteCascade(b *testing.B) {
 			}
 			defer delParent.Close()
 
-			// Pre-seed all b.N parent rows with 10 children each so the timed
-			// loop only measures the cascade delete, not the insert overhead.
-			for i := range b.N {
-				parentID := int64(i + 1)
-				if _, err := insParent.Exec(parentID, fmt.Sprintf("parent-%d", i)); err != nil {
-					b.Fatalf("pre-seed insert parent: %v", err)
-				}
-				for j := range 10 {
-					if _, err := insChild.Exec(parentID, fmt.Sprintf("child-%d-%d", i, j)); err != nil {
-						b.Fatalf("pre-seed insert child: %v", err)
-					}
-				}
-			}
-
 			b.ResetTimer()
 			for i := range b.N {
 				parentID := int64(i + 1)
+
+				// Insert phase (untimed): one parent + 10 children.
+				b.StopTimer()
+				if _, err := insParent.Exec(parentID, fmt.Sprintf("parent-%d", i)); err != nil {
+					b.Fatalf("insert parent: %v", err)
+				}
+				for j := range 10 {
+					if _, err := insChild.Exec(parentID, fmt.Sprintf("child-%d-%d", i, j)); err != nil {
+						b.Fatalf("insert child: %v", err)
+					}
+				}
+				b.StartTimer()
+
+				// Timed: delete parent, cascading to its 10 children.
 				if _, err := delParent.Exec(parentID); err != nil {
 					b.Fatalf("delete parent: %v", err)
 				}

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -169,6 +169,13 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return countResult(count), nil
 	}
 
+	// GROUP BY + single sequential scan: stream rows through a reuse buffer to avoid
+	// one make([]OptionalValue) per row. Falls back to the general path for virtual
+	// tables and parallel scans (handled inside selectGroupByZeroAlloc).
+	if stmt.IsSelectGroupBy() && len(plan.Joins) == 0 && len(plan.Scans) == 1 && plan.Scans[0].Type == ScanTypeSequential {
+		return t.selectGroupByZeroAlloc(ctx, stmt, plan.Scans[0], selectedFields)
+	}
+
 	// Materialising path: buffer every matching row, then dispatch.
 	// Required for COUNT (needs a total), GROUP BY, aggregates, ORDER BY (sort),
 	// and JOIN (goroutine-based execution inside plan.Execute).
@@ -451,7 +458,25 @@ type groupEntry struct {
 	groupValStart int32
 }
 
-func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (StatementResult, error) {
+// groupByAccumulator holds all streaming GROUP BY state. Create with
+// newGroupByAccumulator, feed rows with process(), then call buildResult().
+// Separating state from the row loop lets the zero-alloc sequential scan path
+// share the same result-building code as the general materialised path.
+type groupByAccumulator struct {
+	aggregates        []AggregateExpr
+	useIntSum         []bool
+	groupByColIdx     []int
+	aggColIdx         []int
+	fieldToGroupByIdx []int
+	groupMap          map[string]int32
+	groupEntries      []groupEntry
+	groupOrder        []string
+	aggStatePool      []aggState
+	groupValPool      []OptionalValue
+	keyBuf            []byte
+}
+
+func newGroupByAccumulator(stmt Statement, t *Table, estRows int) *groupByAccumulator {
 	numAggs := len(stmt.Aggregates)
 	numGroupBy := len(stmt.GroupBy)
 
@@ -502,125 +527,222 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 		}
 	}
 
-	// Estimate initial group count for pool sizing — avoids repeated small reallocations
-	// in the common case where groups fit within the initial capacity.
-	estGroups := len(rows) / 10
+	estGroups := estRows / 10
 	if estGroups < 16 {
 		estGroups = 16
 	} else if estGroups > 4096 {
 		estGroups = 4096
 	}
 
-	var (
-		groupMap     = make(map[string]int32, estGroups)
-		groupEntries = make([]groupEntry, 0, estGroups)
-		groupOrder   = make([]string, 0, estGroups)
-		// Flat pools: one allocation amortises across all groups.
-		aggStatePool = make([]aggState, 0, estGroups*numAggs)
-		groupValPool = make([]OptionalValue, 0, estGroups*numGroupBy)
-	)
+	return &groupByAccumulator{
+		aggregates:        stmt.Aggregates,
+		useIntSum:         useIntSum,
+		groupByColIdx:     groupByColIdx,
+		aggColIdx:         aggColIdx,
+		fieldToGroupByIdx: fieldToGroupByIdx,
+		groupMap:          make(map[string]int32, estGroups),
+		groupEntries:      make([]groupEntry, 0, estGroups),
+		groupOrder:        make([]string, 0, estGroups),
+		aggStatePool:      make([]aggState, 0, estGroups*numAggs),
+		groupValPool:      make([]OptionalValue, 0, estGroups*numGroupBy),
+	}
+}
 
-	// keyBuf is reused across rows; string(keyBuf) for map lookup is optimised by
-	// the Go compiler to avoid allocation when the key already exists in the map.
-	var keyBuf []byte
+// process accumulates one row into the group state. Safe to call with a
+// reused Row.Values buffer as long as the caller does not retain the row
+// after returning — values needed for grouping are copied into groupValPool.
+func (acc *groupByAccumulator) process(row Row) {
+	acc.keyBuf = buildGroupKey(acc.keyBuf[:0], row, acc.groupByColIdx)
 
-	for _, row := range rows {
-		keyBuf = buildGroupKey(keyBuf[:0], row, groupByColIdx)
+	gsIdx, exists := acc.groupMap[string(acc.keyBuf)]
+	if !exists {
+		key := string(acc.keyBuf) // one alloc per new group
 
-		gsIdx, exists := groupMap[string(keyBuf)]
-		if !exists {
-			key := string(keyBuf) // one alloc per new group
-
-			aggStart := int32(len(aggStatePool))
-			for i := range numAggs {
-				aggStatePool = append(aggStatePool, aggState{useIntSum: useIntSum[i]})
-			}
-
-			gvStart := int32(len(groupValPool))
-			for _, colIdx := range groupByColIdx {
-				if colIdx >= 0 && colIdx < len(row.Values) {
-					groupValPool = append(groupValPool, row.Values[colIdx])
-				} else {
-					groupValPool = append(groupValPool, OptionalValue{})
-				}
-			}
-
-			gsIdx = int32(len(groupEntries))
-			groupEntries = append(groupEntries, groupEntry{
-				aggStateStart: aggStart,
-				groupValStart: gvStart,
-			})
-			groupMap[key] = gsIdx
-			groupOrder = append(groupOrder, key)
+		aggStart := int32(len(acc.aggStatePool))
+		for i := range len(acc.aggregates) {
+			acc.aggStatePool = append(acc.aggStatePool, aggState{useIntSum: acc.useIntSum[i]})
 		}
 
-		// Accumulate aggregates using pool indices — no pointer indirection through groupState.
-		aggBase := int(groupEntries[gsIdx].aggStateStart)
-		for i, agg := range stmt.Aggregates {
-			switch agg.Kind {
-			case 0:
-				// Non-aggregate GROUP BY column — no accumulation needed.
-			case AggregateCount:
-				aggStatePool[aggBase+i].count += 1
-			case AggregateSum, AggregateAvg:
-				colIdx := aggColIdx[i]
-				if colIdx < 0 || colIdx >= len(row.Values) {
-					continue
+		gvStart := int32(len(acc.groupValPool))
+		for _, colIdx := range acc.groupByColIdx {
+			if colIdx >= 0 && colIdx < len(row.Values) {
+				acc.groupValPool = append(acc.groupValPool, row.Values[colIdx])
+			} else {
+				acc.groupValPool = append(acc.groupValPool, OptionalValue{})
+			}
+		}
+
+		gsIdx = int32(len(acc.groupEntries))
+		acc.groupEntries = append(acc.groupEntries, groupEntry{
+			aggStateStart: aggStart,
+			groupValStart: gvStart,
+		})
+		acc.groupMap[key] = gsIdx
+		acc.groupOrder = append(acc.groupOrder, key)
+	}
+
+	aggBase := int(acc.groupEntries[gsIdx].aggStateStart)
+	for i, agg := range acc.aggregates {
+		switch agg.Kind {
+		case 0:
+			// Non-aggregate GROUP BY column — no accumulation needed.
+		case AggregateCount:
+			acc.aggStatePool[aggBase+i].count += 1
+		case AggregateSum, AggregateAvg:
+			colIdx := acc.aggColIdx[i]
+			if colIdx < 0 || colIdx >= len(row.Values) {
+				continue
+			}
+			val := row.Values[colIdx]
+			if !val.Valid {
+				continue
+			}
+			acc.aggStatePool[aggBase+i].count += 1
+			acc.aggStatePool[aggBase+i].hasValue = true
+			if acc.aggStatePool[aggBase+i].useIntSum {
+				switch v := val.Value.(type) {
+				case int64:
+					acc.aggStatePool[aggBase+i].sumI += v
+				case int32:
+					acc.aggStatePool[aggBase+i].sumI += int64(v)
 				}
-				val := row.Values[colIdx]
-				if !val.Valid {
-					continue
+			} else {
+				switch v := val.Value.(type) {
+				case float64:
+					acc.aggStatePool[aggBase+i].sumF += v
+				case float32:
+					acc.aggStatePool[aggBase+i].sumF += float64(v)
 				}
-				aggStatePool[aggBase+i].count += 1
-				aggStatePool[aggBase+i].hasValue = true
-				if aggStatePool[aggBase+i].useIntSum {
-					switch v := val.Value.(type) {
-					case int64:
-						aggStatePool[aggBase+i].sumI += v
-					case int32:
-						aggStatePool[aggBase+i].sumI += int64(v)
-					}
-				} else {
-					switch v := val.Value.(type) {
-					case float64:
-						aggStatePool[aggBase+i].sumF += v
-					case float32:
-						aggStatePool[aggBase+i].sumF += float64(v)
-					}
-				}
-			case AggregateMin:
-				colIdx := aggColIdx[i]
-				if colIdx < 0 || colIdx >= len(row.Values) {
-					continue
-				}
-				val := row.Values[colIdx]
-				if !val.Valid {
-					continue
-				}
-				if !aggStatePool[aggBase+i].hasValue || compareValues(val, aggStatePool[aggBase+i].min) < 0 {
-					aggStatePool[aggBase+i].min = val
-					aggStatePool[aggBase+i].hasValue = true
-				}
-			case AggregateMax:
-				colIdx := aggColIdx[i]
-				if colIdx < 0 || colIdx >= len(row.Values) {
-					continue
-				}
-				val := row.Values[colIdx]
-				if !val.Valid {
-					continue
-				}
-				if !aggStatePool[aggBase+i].hasValue || compareValues(val, aggStatePool[aggBase+i].max) > 0 {
-					aggStatePool[aggBase+i].max = val
-					aggStatePool[aggBase+i].hasValue = true
-				}
+			}
+		case AggregateMin:
+			colIdx := acc.aggColIdx[i]
+			if colIdx < 0 || colIdx >= len(row.Values) {
+				continue
+			}
+			val := row.Values[colIdx]
+			if !val.Valid {
+				continue
+			}
+			if !acc.aggStatePool[aggBase+i].hasValue || compareValues(val, acc.aggStatePool[aggBase+i].min) < 0 {
+				acc.aggStatePool[aggBase+i].min = val
+				acc.aggStatePool[aggBase+i].hasValue = true
+			}
+		case AggregateMax:
+			colIdx := acc.aggColIdx[i]
+			if colIdx < 0 || colIdx >= len(row.Values) {
+				continue
+			}
+			val := row.Values[colIdx]
+			if !val.Valid {
+				continue
+			}
+			if !acc.aggStatePool[aggBase+i].hasValue || compareValues(val, acc.aggStatePool[aggBase+i].max) > 0 {
+				acc.aggStatePool[aggBase+i].max = val
+				acc.aggStatePool[aggBase+i].hasValue = true
 			}
 		}
 	}
-	_ = ctx // ctx kept for signature compat; no blocking ops remain
+}
 
+func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (StatementResult, error) {
+	_ = ctx // ctx kept for signature compat; no blocking ops remain
+	acc := newGroupByAccumulator(stmt, t, len(rows))
+	for _, row := range rows {
+		acc.process(row)
+	}
+	return acc.buildResult(stmt, t)
+}
+
+// selectGroupByZeroAlloc handles GROUP BY over a single sequential scan without
+// materialising rows. It reuses one []OptionalValue buffer across all rows,
+// eliminating the per-row heap allocation from UnmarshalWithMask. Falls back to
+// the general path for virtual tables and parallel scans.
+func (t *Table) selectGroupByZeroAlloc(ctx context.Context, stmt Statement, scan Scan, selectedFields []Field) (StatementResult, error) {
+	if t.virtualRows != nil || t.parallelScan {
+		var rows []Row
+		if err := t.sequentialScan(ctx, scan, selectedFields, func(row Row) error {
+			rows = append(rows, row)
+			return nil
+		}); err != nil {
+			return StatementResult{}, err
+		}
+		return t.selectGroupBy(ctx, stmt, rows)
+	}
+
+	cursor, err := t.SeekFirst(ctx)
+	if err != nil {
+		return StatementResult{}, err
+	}
+
+	fullMask := selectedColumnsMask(t.Columns, selectedFields)
+	tableFilter := compileScanFilter(t.Columns, scan.Filters)
+
+	// Pre-allocate one reusable values buffer. Safe because process() copies the
+	// GROUP BY column values it needs into groupValPool before returning — the
+	// buffer is overwritten on the next row.
+	reuseValues := make([]OptionalValue, len(t.Columns))
+
+	estRows := int(t.estimatedRowCount())
+	if estRows <= 0 {
+		estRows = 160 // conservative default (estGroups = 16)
+	}
+	acc := newGroupByAccumulator(stmt, t, estRows)
+
+	page, err := t.pager.ReadPage(ctx, cursor.PageIdx)
+	if err != nil {
+		return StatementResult{}, fmt.Errorf("group by sequential scan: %w", err)
+	}
+	cursor.EndOfTable = page.LeafNode.Header.Cells == 0
+
+	for !cursor.EndOfTable {
+		if err := ctx.Err(); err != nil {
+			return StatementResult{}, err
+		}
+
+		if page.Index != cursor.PageIdx {
+			page, err = t.pager.ReadPage(ctx, cursor.PageIdx)
+			if err != nil {
+				return StatementResult{}, fmt.Errorf("group by sequential scan: %w", err)
+			}
+		}
+
+		cell := page.LeafNode.Cells[cursor.CellIdx]
+
+		switch {
+		case cursor.CellIdx < page.LeafNode.Header.Cells-1:
+			cursor.CellIdx += 1
+		case page.LeafNode.Header.NextLeaf == 0:
+			cursor.EndOfTable = true
+		default:
+			cursor.PageIdx = page.LeafNode.Header.NextLeaf
+			cursor.CellIdx = 0
+		}
+
+		row := t.newRow()
+		row, err = row.unmarshalWithMaskInto(cell, fullMask, reuseValues)
+		if err != nil {
+			return StatementResult{}, err
+		}
+
+		if tableFilter != nil {
+			ok, err := tableFilter(row)
+			if err != nil {
+				return StatementResult{}, err
+			}
+			if !ok {
+				continue
+			}
+		}
+
+		acc.process(row)
+	}
+
+	return acc.buildResult(stmt, t)
+}
+
+func (acc *groupByAccumulator) buildResult(stmt Statement, t *Table) (StatementResult, error) {
 	nFields := len(stmt.Fields)
-	nGroups := len(groupOrder)
+	nGroups := len(acc.groupOrder)
 
 	// Build result column metadata.
 	resultColumns := make([]Column, nFields)
@@ -637,7 +759,7 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 		case AggregateCount:
 			resultColumns[i] = Column{Name: colName, Kind: Int8}
 		case AggregateSum:
-			if useIntSum[i] {
+			if acc.useIntSum[i] {
 				resultColumns[i] = Column{Name: colName, Kind: Int8}
 			} else {
 				resultColumns[i] = Column{Name: colName, Kind: Double}
@@ -655,23 +777,23 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 	allResultValues := make([]OptionalValue, nGroups*nFields)
 	resultRows := make([]Row, 0, nGroups)
 
-	for gi, key := range groupOrder {
-		gsIdx := groupMap[key]
-		aggBase := int(groupEntries[gsIdx].aggStateStart)
-		gvBase := int(groupEntries[gsIdx].groupValStart)
+	for gi, key := range acc.groupOrder {
+		gsIdx := acc.groupMap[key]
+		aggBase := int(acc.groupEntries[gsIdx].aggStateStart)
+		gvBase := int(acc.groupEntries[gsIdx].groupValStart)
 
 		values := allResultValues[gi*nFields : (gi+1)*nFields]
 
-		for i, agg := range stmt.Aggregates {
+		for i, agg := range acc.aggregates {
 			switch agg.Kind {
 			case 0:
-				if j := fieldToGroupByIdx[i]; j >= 0 {
-					values[i] = groupValPool[gvBase+j]
+				if j := acc.fieldToGroupByIdx[i]; j >= 0 {
+					values[i] = acc.groupValPool[gvBase+j]
 				}
 			case AggregateCount:
-				values[i] = OptionalValue{Valid: true, Value: aggStatePool[aggBase+i].count}
+				values[i] = OptionalValue{Valid: true, Value: acc.aggStatePool[aggBase+i].count}
 			case AggregateSum:
-				st := aggStatePool[aggBase+i]
+				st := acc.aggStatePool[aggBase+i]
 				if st.hasValue {
 					if st.useIntSum {
 						values[i] = OptionalValue{Valid: true, Value: st.sumI}
@@ -680,7 +802,7 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 					}
 				}
 			case AggregateAvg:
-				st := aggStatePool[aggBase+i]
+				st := acc.aggStatePool[aggBase+i]
 				if st.hasValue && st.count > 0 {
 					if st.useIntSum {
 						values[i] = OptionalValue{Valid: true, Value: float64(st.sumI) / float64(st.count)}
@@ -689,12 +811,12 @@ func (t *Table) selectGroupBy(ctx context.Context, stmt Statement, rows []Row) (
 					}
 				}
 			case AggregateMin:
-				if aggStatePool[aggBase+i].hasValue {
-					values[i] = aggStatePool[aggBase+i].min
+				if acc.aggStatePool[aggBase+i].hasValue {
+					values[i] = acc.aggStatePool[aggBase+i].min
 				}
 			case AggregateMax:
-				if aggStatePool[aggBase+i].hasValue {
-					values[i] = aggStatePool[aggBase+i].max
+				if acc.aggStatePool[aggBase+i].hasValue {
+					values[i] = acc.aggStatePool[aggBase+i].max
 				}
 			}
 		}


### PR DESCRIPTION
  **selectGroupByZeroAlloc** — GROUP BY sequential scan without per-row allocation
  
  **Root cause:** selectGroupBy collected all rows into a []Row buffer, each requiring make([]OptionalValue, nCols) from UnmarshalWithMask — 91.75% of all allocations per pprof.
  
  **Fix:** Extracted a groupByAccumulator struct (holding process() + buildResult() methods). For single sequential scans, a new selectGroupByZeroAlloc iterates directly over B-tree cells with one reused []OptionalValue buffer (same pattern as countSequentialScanZeroAlloc). GROUP BY
   column values are explicitly copied into groupValPool inside process(), making reuse safe.