### PR TITLE
Fix two read-own-writes bugs in explicit write transactions

### DIFF
--- a/e2e_tests/tx_test.go
+++ b/e2e_tests/tx_test.go
@@ -1,5 +1,105 @@
 package e2etests
 
+// TestTransaction_DML_ReadsOwnWrites verifies that an explicit transaction can
+// read its own uncommitted DML changes (INSERT, UPDATE, DELETE) and that those
+// changes are either persisted after COMMIT or fully reversed after ROLLBACK.
+func (s *TestSuite) TestTransaction_DML_ReadsOwnWrites() {
+	_, err := s.db.Exec(createUsersTableSQL)
+	s.Require().NoError(err)
+
+	s.Run("INSERT visible within tx, absent after ROLLBACK", func() {
+		tx, err := s.db.Begin()
+		s.Require().NoError(err)
+
+		_, err = tx.Exec(`insert into "users" ("email", "name") values (?, ?);`, "alice@example.com", "Alice")
+		s.Require().NoError(err)
+
+		// Row must be visible inside the same transaction.
+		var count int
+		err = tx.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(1, count)
+
+		s.Require().NoError(tx.Rollback())
+
+		// Row must be gone after rollback.
+		err = s.db.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(0, count)
+	})
+
+	s.Run("INSERT visible within tx, persisted after COMMIT", func() {
+		tx, err := s.db.Begin()
+		s.Require().NoError(err)
+
+		_, err = tx.Exec(`insert into "users" ("email", "name") values (?, ?);`, "bob@example.com", "Bob")
+		s.Require().NoError(err)
+
+		var count int
+		err = tx.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(1, count)
+
+		s.Require().NoError(tx.Commit())
+
+		err = s.db.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(1, count)
+	})
+
+	s.Run("UPDATE visible within tx, reversed after ROLLBACK", func() {
+		// Ensure at least one row exists (from previous committed subtest).
+		var count int
+		err := s.db.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Require().Equal(1, count)
+
+		tx, err := s.db.Begin()
+		s.Require().NoError(err)
+
+		_, err = tx.Exec(`update "users" set "name" = ? where "name" = ?;`, "Bobby", "Bob")
+		s.Require().NoError(err)
+
+		// Updated name must be visible within the same transaction.
+		var name string
+		err = tx.QueryRow(`select "name" from "users" where "email" = ?;`, "bob@example.com").Scan(&name)
+		s.Require().NoError(err)
+		s.Equal("Bobby", name)
+
+		s.Require().NoError(tx.Rollback())
+
+		// Original name must be restored after rollback.
+		err = s.db.QueryRow(`select "name" from "users" where "email" = ?;`, "bob@example.com").Scan(&name)
+		s.Require().NoError(err)
+		s.Equal("Bob", name)
+	})
+
+	s.Run("DELETE visible within tx, reversed after ROLLBACK", func() {
+		var count int
+		err := s.db.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Require().Equal(1, count)
+
+		tx, err := s.db.Begin()
+		s.Require().NoError(err)
+
+		_, err = tx.Exec(`delete from "users" where "email" = ?;`, "bob@example.com")
+		s.Require().NoError(err)
+
+		// Row must be gone inside the transaction.
+		err = tx.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(0, count)
+
+		s.Require().NoError(tx.Rollback())
+
+		// Row must be restored after rollback.
+		err = s.db.QueryRow(`select count(*) from "users";`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(1, count)
+	})
+}
+
 func (s *TestSuite) TestTransaction() {
 	s.Run("Create a table in a transaction but rollback before commit", func() {
 		tx, err := s.db.Begin()

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -315,6 +315,9 @@ func countResult(count int64) StatementResult {
 //
 // Fast path: if a row-count getter has been registered (set by the Database
 // after loading the table), returns the cached count in O(1) without any I/O.
+// The fast path is skipped when an active write transaction is in context
+// because its uncommitted changes (in the WriteSet) are not yet reflected in
+// the row-count cache — the page walk uses ReadPage which checks the WriteSet.
 //
 // Fallback: walks the B+ tree leaf page chain and sums Header.Cells on each
 // page — O(leaf pages), no row data read or deserialised.
@@ -322,7 +325,9 @@ func countResult(count int64) StatementResult {
 // This is only valid for COUNT(*) with no WHERE clause and no JOIN.
 func (t *Table) countAllLeafWalk(ctx context.Context) (StatementResult, error) {
 	var count int64
-	if t.getRowCount != nil {
+	tx := TxFromContext(ctx)
+	useCache := t.getRowCount != nil && (tx == nil || tx.ReadOnly)
+	if useCache {
 		count = t.getRowCount()
 	} else {
 		cursor, err := t.SeekFirst(ctx)

--- a/minisql.go
+++ b/minisql.go
@@ -334,7 +334,11 @@ func (c *Conn) TransactionContext(ctx context.Context) context.Context {
 func (c *Conn) executeQueryStatement(ctx context.Context, stmt minisql.Statement) (minisql.StatementResult, context.Context, *minisql.Transaction, error) {
 	if c.HasActiveTransaction() || (stmt.Kind != minisql.Select && stmt.Kind != minisql.Explain) {
 		result, err := c.executeStatement(ctx, stmt)
-		return result, ctx, nil, err
+		// When there is an active write transaction, the row view iterator
+		// fetches rows lazily using the returned context. Passing the
+		// transaction context ensures ReadPage checks the WriteSet so that
+		// uncommitted writes are visible within the same transaction.
+		return result, c.TransactionContext(ctx), nil, err
 	}
 
 	txManager := c.db.GetTransactionManager()


### PR DESCRIPTION
Uncommitted DML changes were invisible to subsequent queries within the same explicit BEGIN transaction:

1. countAllLeafWalk fast path bypassed the WriteSet: the cached row count (d.rowCounts) is only updated at commit time, so COUNT(*) returned stale results during an in-progress write transaction.  Fix: skip the cache when a write transaction is active in context; fall through to the leaf-page walk which uses ReadPage and checks the WriteSet.

2. Row view iterator received a context without the write transaction: executeQueryStatement returned the original ctx (no transaction) as rowsCtx, so lazy row fetches in the RowViewIterator called ReadPage without a transaction and got the pre-write LRU cache page instead of the WriteSet clone.  Fix: return TransactionContext(ctx) so the iterator always operates under the active transaction's WriteSet view.

Add TestTransaction_DML_ReadsOwnWrites e2e test covering INSERT/UPDATE/ DELETE read-own-writes and ROLLBACK correctness for DML statements.