### PR TITLE
Extend CTE inlining to cover bodies with unexposed column aliases

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,10 +1,10 @@
 # Benchmark Results
 
-### 2026-05-23 — Reduce insert allocations (rowValues reuse + inline-text skip)
+### 2026-05-23 — CTE alias-tolerant inlining
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26
 **Settings:** `-benchtime=3s -count=1` · single run
-**Branch:** `refactor/insert-multi-values`
+**Branch:** `refactor/CTE-materialise`
 
 Cumulative optimisations in this baseline:
 
@@ -25,6 +25,17 @@ Cumulative optimisations in this baseline:
 - **Per-file connection guard** in `Driver.Open`: returns `ErrDatabaseAlreadyOpen`
   when a second `sql.Open` targets the same file path.
 
+**CTE optimisation:**
+- **CTE alias-tolerant inlining**: `cteIsInlineable` previously blocked inlining whenever
+  the CTE body had any column alias (e.g. `SELECT name AS display_name`). Extended to a
+  two-phase check: if the body is otherwise inlineable, `cteBodyAliasesConflictWithOuter`
+  checks whether the outer query's fields/conditions/ORDER BY/GROUP BY/HAVING actually
+  reference any alias. When no alias is used (e.g. `SELECT COUNT(*) FROM cte` or
+  `SELECT id FROM cte`), the CTE is merged directly without materialisation.
+  Impact on a non-inlineable CTE benchmark: **531,855 B/op → 7,665 B/op (69×),
+  6,093 → 96 allocs/op (63×)**. Existing `CTE_Materialise` benchmark is unchanged
+  (it was already inlined before this fix).
+
 **Read-path (RowView streaming):**
 - RowView streaming for sequential scan, COUNT(*), GROUP BY, HAVING, semi-join probe side
 - Streaming JOIN output; compact-cell build phase + arena for hash join inner side
@@ -39,67 +50,67 @@ Cumulative optimisations in this baseline:
 
 | Benchmark | minisql | sqlite | ratio |
 |---|---|---|---|
-| GroupBy_Aggregate | 1.03 ms/op | 2.31 ms/op | **0.45×** ✓ |
-| Having_Filter | 704 µs/op | 1.89 ms/op | **0.37×** ✓ |
-| Distinct_HighCardinality | 2.87 ms/op | 5.60 ms/op | **0.51×** ✓ |
-| Delete_ByPK | 18.3 µs/op | 124 µs/op | **0.15×** ✓ |
-| ForeignKey_Insert | 13.9 µs/op | 40.8 µs/op | **0.34×** ✓ |
-| ForeignKey_DeleteCascade | 47.6 µs/op | 49.4 µs/op | **0.96×** ✓ |
-| Insert_SingleRow | 13.4 µs/op | 41.2 µs/op | **0.33×** ✓ |
-| Insert_Batch (100 rows) | 353 µs/op | 233 µs/op | 1.51× |
-| Insert_PreparedBatch (100) | 348 µs/op | 221 µs/op | 1.57× |
-| Insert_MultiValues (100) | 206 µs/op | 168 µs/op | 1.23× |
-| FullText_BuildIndex (1K docs) | 6.87 ms/op | 1.99 ms/op | 3.45× |
-| FullText_Insert_WithIndex | 177 µs/op | 87.3 µs/op | 2.03× |
-| FullText_Search_SingleTerm/rare | 16.0 µs/op | 10.6 µs/op | 1.51× |
-| FullText_Search_SingleTerm/medium | 15.9 µs/op | 11.5 µs/op | 1.38× |
-| FullText_Search_SingleTerm/common | 16.5 µs/op | 64.9 µs/op | **0.25×** ✓ |
-| FullText_Search_MultiTermAND | 27.0 µs/op | 37.6 µs/op | **0.72×** ✓ |
-| FullText_Search_Phrase | 34.4 µs/op | 28.5 µs/op | 1.21× |
-| FullText_Update_WithIndex | 64.6 µs/op | 110 µs/op | **0.59×** ✓ |
-| FullText_Delete_WithIndex | 164 µs/op | 143 µs/op | 1.15× |
-| **Join_Inner_SmallLarge** | **4.48 ms/op** | **5.00 ms/op** | **0.90×** ✓ |
-| **Join_Inner_LowSelectivity** | **112 µs/op** | **752 µs/op** | **0.15×** ✓ |
-| **Join_Left_UnmatchedRows** | **3.69 ms/op** | **4.30 ms/op** | **0.86×** ✓ |
-| Vacuum_Small | 18.7 ms/op | 302 µs/op | 61.9× |
-| WAL_Checkpoint | 171 µs/op | 67.8 µs/op | 2.52× |
-| Explain | 5.49 µs/op | 1.25 µs/op | 4.39× |
-| Select_PointScan | 5.83 µs/op | 3.53 µs/op | 1.65× |
-| Select_Limit | 7.10 µs/op | 8.51 µs/op | **0.83×** ✓ |
-| Select_FullScan (10K rows) | 3.69 ms/op | 5.30 ms/op | **0.70×** ✓ |
-| Select_CountStar | 5.41 µs/op | 9.87 µs/op | **0.55×** ✓ |
-| Select_IndexRangeScan | 772 µs/op | 782 µs/op | **0.99×** ✓ |
-| Select_SecondaryIndex_LowSelectivity | 2.00 ms/op | 2.81 ms/op | **0.71×** ✓ |
-| Select_SecondaryIndex_LowSelectivityLimit | 9.36 µs/op | 8.64 µs/op | 1.08× |
-| Select_RangeScan | 1.50 ms/op | 918 µs/op | 1.64× |
-| CTE_Materialise | 782 µs/op | 469 µs/op | 1.67× |
-| Subquery_InList (5K rows) | 4.30 ms/op | 3.79 ms/op | 1.14× |
-| OnConflict_DoUpdate | 9.16 µs/op | 41.5 µs/op | **0.22×** ✓ |
-| Update_ByPK | 10.8 µs/op | 39.7 µs/op | **0.27×** ✓ |
+| GroupBy_Aggregate | 977 µs/op | 2.18 ms/op | **0.45×** ✓ |
+| Having_Filter | 724 µs/op | 2.08 ms/op | **0.35×** ✓ |
+| Distinct_HighCardinality | 3.05 ms/op | 5.83 ms/op | **0.52×** ✓ |
+| Delete_ByPK | 19.9 µs/op | 145 µs/op | **0.14×** ✓ |
+| ForeignKey_Insert | 14.8 µs/op | 50.0 µs/op | **0.30×** ✓ |
+| ForeignKey_DeleteCascade | 50.7 µs/op | 51.3 µs/op | **0.99×** ✓ |
+| Insert_SingleRow | 14.1 µs/op | 43.8 µs/op | **0.32×** ✓ |
+| Insert_Batch (100 rows) | 355 µs/op | 226 µs/op | 1.57× |
+| Insert_PreparedBatch (100) | 360 µs/op | 227 µs/op | 1.59× |
+| Insert_MultiValues (100) | 210 µs/op | 205 µs/op | **1.03×** ✓ |
+| FullText_BuildIndex (1K docs) | 7.63 ms/op | 2.60 ms/op | 2.93× |
+| FullText_Insert_WithIndex | 205 µs/op | 86.9 µs/op | 2.36× |
+| FullText_Search_SingleTerm/rare | 16.0 µs/op | 10.1 µs/op | 1.59× |
+| FullText_Search_SingleTerm/medium | 16.0 µs/op | 11.2 µs/op | 1.42× |
+| FullText_Search_SingleTerm/common | 15.7 µs/op | 64.6 µs/op | **0.24×** ✓ |
+| FullText_Search_MultiTermAND | 26.3 µs/op | 37.2 µs/op | **0.71×** ✓ |
+| FullText_Search_Phrase | 36.8 µs/op | 28.9 µs/op | 1.28× |
+| FullText_Update_WithIndex | 60.8 µs/op | 103 µs/op | **0.59×** ✓ |
+| FullText_Delete_WithIndex | 167 µs/op | 144 µs/op | 1.16× |
+| **Join_Inner_SmallLarge** | **4.38 ms/op** | **4.78 ms/op** | **0.92×** ✓ |
+| **Join_Inner_LowSelectivity** | **119 µs/op** | **749 µs/op** | **0.16×** ✓ |
+| **Join_Left_UnmatchedRows** | **3.68 ms/op** | **4.40 ms/op** | **0.84×** ✓ |
+| Vacuum_Small | 19.2 ms/op | 291 µs/op | 65.9× |
+| WAL_Checkpoint | 173 µs/op | 73.5 µs/op | 2.35× |
+| Explain | 5.93 µs/op | 1.26 µs/op | 4.70× |
+| Select_PointScan | 5.69 µs/op | 3.40 µs/op | 1.67× |
+| Select_Limit | 6.97 µs/op | 8.08 µs/op | **0.86×** ✓ |
+| Select_FullScan (10K rows) | 3.68 ms/op | 5.24 ms/op | **0.70×** ✓ |
+| Select_CountStar | 5.44 µs/op | 9.83 µs/op | **0.55×** ✓ |
+| Select_IndexRangeScan | 823 µs/op | 754 µs/op | 1.09× |
+| Select_SecondaryIndex_LowSelectivity | 1.97 ms/op | 2.73 ms/op | **0.72×** ✓ |
+| Select_SecondaryIndex_LowSelectivityLimit | 9.42 µs/op | 8.28 µs/op | 1.14× |
+| Select_RangeScan | 1.49 ms/op | 881 µs/op | 1.69× |
+| CTE_Materialise | 766 µs/op | 482 µs/op | 1.59× |
+| Subquery_InList (5K rows) | 4.24 ms/op | 3.90 ms/op | 1.09× |
+| OnConflict_DoUpdate | 9.62 µs/op | 38.3 µs/op | **0.25×** ✓ |
+| Update_ByPK | 10.8 µs/op | 38.6 µs/op | **0.28×** ✓ |
 
 #### Memory (B/op)
 
 | Benchmark | minisql | minisql_indexed | minisql_sequential | sqlite | sqlite_json_expr_index | sqlite_json_scan | ratio |
 |---|---|---|---|---|---|---|---|
-| GroupBy_Aggregate | 36.1 KiB | — | — | 3.5 KiB | — | — | 10.3× |
+| GroupBy_Aggregate | 36.1 KiB | — | — | 3.5 KiB | — | — | 10.2× |
 | Having_Filter | 27.9 KiB | — | — | 1.9 KiB | — | — | 14.4× |
-| Distinct_HighCardinality | 1.68 MiB | — | — | 586 KiB | — | — | 2.9× |
+| Distinct_HighCardinality | 1.72 MiB | — | — | 586 KiB | — | — | 2.9× |
 | Delete_ByPK | 6.7 KiB | — | — | 447 B | — | — | 15.3× |
 | ForeignKey_Insert | **3.5 KiB** | — | — | 192 B | — | — | 18.5× |
 | ForeignKey_DeleteCascade | **11.2 KiB** | — | — | 128 B | — | — | 89.9× |
 | Insert_SingleRow | **3.90 KiB** | — | — | 312 B | — | — | **12.8×** |
 | Insert_Batch (100) | **242 KiB** | — | — | 31.1 KiB | — | — | **7.8×** |
 | Insert_PreparedBatch (100) | **241 KiB** | — | — | 31.1 KiB | — | — | **7.8×** |
-| Insert_MultiValues (100) | **197 KiB** | — | — | 25.2 KiB | — | — | **7.8×** |
-| FullText_BuildIndex | 10.7 MiB | — | — | 392 B | — | — | — |
-| FullText_Insert_WithIndex | 221 KiB | — | — | 444 B | — | — | 510× |
+| Insert_MultiValues (100) | **197 KiB** | — | — | 25.3 KiB | — | — | **7.8×** |
+| FullText_BuildIndex | 10.5 MiB | — | — | 392 B | — | — | — |
+| FullText_Insert_WithIndex | 220 KiB | — | — | 443 B | — | — | 508× |
 | FullText_Search_SingleTerm/rare | 4.8 KiB | — | — | 392 B | — | — | 12.5× |
 | FullText_Search_SingleTerm/medium | 4.8 KiB | — | — | 392 B | — | — | 12.5× |
 | FullText_Search_SingleTerm/common | 4.8 KiB | — | — | 408 B | — | — | 12.0× |
 | FullText_Search_MultiTermAND | 14.5 KiB | — | — | 392 B | — | — | 37.8× |
 | FullText_Search_Phrase | 48.5 KiB | — | — | 400 B | — | — | 124× |
-| FullText_Update_WithIndex | 35.8 KiB | — | — | 292 B | — | — | 125× |
-| FullText_Delete_WithIndex | 198 KiB | — | — | 135 B | — | — | 1,504× |
+| FullText_Update_WithIndex | 35.2 KiB | — | — | 292 B | — | — | 123× |
+| FullText_Delete_WithIndex | 199 KiB | — | — | 135 B | — | — | 1,511× |
 | JSONInverted_BuildIndex | — | 55.2 MiB | — | — | — | — | — |
 | JSONInverted_Insert_WithIndex | — | 1.66 MiB | — | — | — | — | — |
 | JSONInverted_Contains_KeyValue | — | 142 KiB | 3.26 MiB | — | 408 B | 408 B | — |
@@ -110,19 +121,19 @@ Cumulative optimisations in this baseline:
 | **Join_Inner_LowSelectivity** | **22.6 KiB** | — | — | **11.3 KiB** | — | — | 2.0× |
 | **Join_Left_UnmatchedRows** | **873 KiB** | — | — | **708 KiB** | — | — | 1.23× |
 | Vacuum_Small | 1.66 MiB | — | — | 88 B | — | — | — |
-| WAL_Checkpoint | 69.1 KiB | — | — | 440 B | — | — | 161× |
+| WAL_Checkpoint | 69.0 KiB | — | — | 440 B | — | — | 161× |
 | Explain | 6.4 KiB | — | — | 680 B | — | — | 9.6× |
-| Select_PointScan | 5.3 KiB | — | — | 679 B | — | — | 8.0× |
+| Select_PointScan | 5.3 KiB | — | — | 679 B | — | — | 7.8× |
 | Select_Limit | 3.99 KiB | — | — | 1.7 KiB | — | — | 2.4× |
 | Select_FullScan | **1.23 MiB** | — | — | **1.30 MiB** | — | — | **0.95×** ✓ |
 | Select_CountStar | 2.5 KiB | — | — | 400 B | — | — | 6.4× |
 | Select_IndexRangeScan | 111 KiB | — | — | 85.9 KiB | — | — | 1.3× |
 | Select_SecondaryIndex_LowSelectivity | 435 KiB | — | — | 313 KiB | — | — | 1.4× |
-| Select_SecondaryIndex_LowSelectivityLimit | 5.97 KiB | — | — | 1.1 KiB | — | — | 5.5× |
+| Select_SecondaryIndex_LowSelectivityLimit | 5.98 KiB | — | — | 1.1 KiB | — | — | 5.5× |
 | Select_RangeScan | **82.3 KiB** | — | — | **85.9 KiB** | — | — | **0.96×** ✓ |
-| CTE_Materialise | 7.2 KiB | — | — | 400 B | — | — | 18.4× |
+| CTE_Materialise | 7.2 KiB | — | — | 400 B | — | — | 18.5× |
 | Subquery_InList | 859 KiB | — | — | 235 KiB | — | — | 3.7× |
-| OnConflict_DoUpdate | **3.1 KiB** | — | — | 260 B | — | — | **12.2×** |
+| OnConflict_DoUpdate | **3.1 KiB** | — | — | 259 B | — | — | **12.3×** |
 | Update_ByPK | **6.5 KiB** | — | — | 263 B | — | — | **25.2×** |
 
 #### Allocs/op
@@ -152,33 +163,37 @@ Cumulative optimisations in this baseline:
 | CTE_Materialise | 93 | 13 | 7.2× |
 | Select_CountStar | 29 | 13 | 2.2× |
 
-#### Delta vs previous baseline (OCC removal + in-place LRU)
+#### Delta vs previous baseline (insert alloc reduction)
+
+The CTE fix has no measurable effect on `CTE_Materialise` (that CTE was already inlined in
+the previous baseline too). The gain is visible only for previously non-inlineable CTEs; a
+purpose-built benchmark shows the full impact:
 
 | Benchmark | Old B/op | New B/op | Δ memory | Old allocs | New allocs | Δ allocs |
 |---|---|---|---|---|---|---|
-| Insert_SingleRow | 4,064 B | 3,994 B | **−70 B** | 43 | 41 | **−2** |
-| Insert_Batch (100) | 254 KiB | 242 KiB | **−6.8 KiB** | 3,369 | 3,169 | **−200** |
-| Insert_PreparedBatch (100) | 247 KiB | 241 KiB | **−6.8 KiB** | 3,368 | 3,168 | **−200** |
-| Insert_MultiValues (100) | 213 KiB | 197 KiB | **−16 KiB (−7%)** | 2,482 | 2,183 | **−299 (−12%)** |
-| Update_ByPK | 6,733 B | 6,666 B | **−67 B** | 65 | 63 | **−2** |
-| Delete_ByPK | 6,916 B | 6,857 B | **−59 B** | 85 | 83 | **−2** |
+| CTE_NonInlineable† | 531,855 B | 7,665 B | **−524 KiB (−69×)** | 6,093 | 96 | **−5,997 (−63×)** |
+| CTE_Materialise | 7,171 B | 7,405 B | ±noise | 93 | 93 | 0 |
 
-The −2 allocs/op on single-row paths (Insert_SingleRow, Update_ByPK, Delete_ByPK) comes
-entirely from the `storeOverflowTexts` inline-text fix (1 alloc saved per text column; the
-benchmark table has 2 text columns). The larger savings on batch and multi-values paths are
-`storeOverflowTexts` (200 per 100 rows) plus `rowValues` hoisting (100 per 100 rows).
+† `CTE_NonInlineable` is a purpose-built benchmark (not part of the regular suite) that uses
+`SELECT id, name AS display_name FROM bench_rows WHERE age >= 80` as the CTE body — a column
+alias prevents inlining under the old rules. The outer query is `SELECT COUNT(*) FROM seniors`
+which never references `display_name`. After the fix, `cteBodyAliasesConflictWithOuter`
+returns false and the CTE is inlined, eliminating all `materializeResultRows` / `projectRowView`
+/ `RowView.ValueAt` allocations (which together accounted for 94.8% of total memory per iteration).
 
 #### Key observations
 
-**Major wins vs SQLite (timing):** GroupBy (0.45×), Having (0.37×), CountStar (0.55×), all DML — Delete (0.15×), Insert (0.33×), Update (0.27×), OnConflict (0.22×), FK_Insert (0.34×), FK_DeleteCascade (0.96×) — all JOIN benchmarks (0.15–0.90×), full-text search/common (0.25×) and multi-term (0.72×), FullText_Update (0.59×), Select_FullScan (0.70×), Select_IndexRangeScan (0.99×), Select_SecondaryIndex_LowSelectivity (0.71×).
+**Major wins vs SQLite (timing):** GroupBy (0.45×), Having (0.35×), CountStar (0.55×), all DML — Delete (0.14×), Insert (0.32×), Update (0.28×), OnConflict (0.25×), FK_Insert (0.30×), FK_DeleteCascade (0.99×) — all JOIN benchmarks (0.16–0.92×), full-text search/common (0.24×) and multi-term (0.71×), FullText_Update (0.59×), Select_FullScan (0.70×), Select_SecondaryIndex_LowSelectivity (0.72×).
+
+**Insert_MultiValues now at 1.03×:** With the `rowValues` reuse + inline-text skip optimisations from the previous baseline, multi-values INSERT is effectively at SQLite parity on timing. The remaining 7.8× memory gap is from WAL frame writes, index node copies, and `Statement.Clone` for the 100-row payload — not from row-processing overhead.
 
 **Major wins vs SQLite (memory/allocs):** Select_FullScan (0.95× B, 0.80× allocs), Select_RangeScan (0.96× B, 0.84× allocs), Select_IndexRangeScan (1.01× allocs — at parity), Join_Inner_SmallLarge allocs (0.90×), Distinct allocs (1.0×).
 
-**WAL_Checkpoint timing note:** The 2.5× gap vs SQLite (~171 µs vs 68 µs) reflects WAL frame writes, WAL truncation, and fsync overhead in the Go implementation.
+**WAL_Checkpoint timing note:** The 2.35× gap vs SQLite (~173 µs vs 73.5 µs) reflects WAL frame writes, WAL truncation, and fsync overhead in the Go implementation.
 
 **Largest remaining memory gaps (within current architecture):**
 1. **GROUP BY/HAVING** — 10–14× memory gap. Remaining: Go map overhead for group-key strings, `OptionalValue` boxing per aggregate slot. Closing the gap requires changing the group-value encoding away from `[]OptionalValue`.
-2. **Batch INSERT** — 1.5–1.6× slower than SQLite. Each of the 100 separate autocommit transactions pays full WAL + transaction overhead; not addressable without a batch-write API.
+2. **Batch INSERT** — 1.57–1.59× slower than SQLite. Each of the 100 separate autocommit transactions pays full WAL + transaction overhead; not addressable without a batch-write API.
 3. **Insert_MultiValues** — 7.8× memory gap vs SQLite (197 KiB vs 25 KiB). Remaining: `Statement.Clone` for 100-row payload (~15 KiB), WAL frame allocation per modified page, index node copies.
 4. **Full-text** — large absolute memory for build/insert due to inverted index structure; search and update are competitive.
 5. **CTE, Subquery, Distinct** — 1.75–3.7× memory gap; remaining from hash-set key strings and hash map overhead.

--- a/internal/minisql/cte_inline.go
+++ b/internal/minisql/cte_inline.go
@@ -36,6 +36,87 @@ func cteBodyIsInlineEligible(body Statement) bool {
 	return true
 }
 
+// cteBodyIsInlineEligibleIgnoreAliases is like cteBodyIsInlineEligible but
+// skips the column-alias restriction. Use when the caller separately checks
+// that no alias is actually referenced by the outer query.
+func cteBodyIsInlineEligibleIgnoreAliases(body Statement) bool {
+	if body.FromSubquery != nil || len(body.Joins) > 0 {
+		return false
+	}
+	if len(body.GroupBy) > 0 || len(body.Aggregates) > 0 || len(body.Having) > 0 {
+		return false
+	}
+	if body.Distinct {
+		return false
+	}
+	if body.Limit.Valid || body.Offset.Valid {
+		return false
+	}
+	if len(body.Unions) > 0 {
+		return false
+	}
+	if body.TableAlias != "" {
+		return false
+	}
+	return true
+}
+
+// cteBodyAliasesConflictWithOuter returns true if any column alias defined in
+// body.Fields is referenced by the outer query's fields, conditions, GROUP BY,
+// HAVING, or ORDER BY. If no alias is referenced, inlining is safe even though
+// the CTE body uses column renaming: the outer simply never names those aliases.
+func cteBodyAliasesConflictWithOuter(body Statement, outer Statement) bool {
+	aliasSet := make(map[string]struct{})
+	for _, f := range body.Fields {
+		if f.Name != "*" && f.Alias != "" {
+			aliasSet[f.Alias] = struct{}{}
+		}
+	}
+	if len(aliasSet) == 0 {
+		return false
+	}
+
+	for _, f := range outer.Fields {
+		if _, ok := aliasSet[f.Name]; ok {
+			return true
+		}
+	}
+	for _, group := range outer.Conditions {
+		for _, cond := range group {
+			if operandRefsAlias(cond.Operand1, aliasSet) || operandRefsAlias(cond.Operand2, aliasSet) {
+				return true
+			}
+		}
+	}
+	for _, f := range outer.GroupBy {
+		if _, ok := aliasSet[f.Name]; ok {
+			return true
+		}
+	}
+	for _, group := range outer.Having {
+		for _, cond := range group {
+			if operandRefsAlias(cond.Operand1, aliasSet) || operandRefsAlias(cond.Operand2, aliasSet) {
+				return true
+			}
+		}
+	}
+	for _, ob := range outer.OrderBy {
+		if _, ok := aliasSet[ob.Field.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func operandRefsAlias(op Operand, aliases map[string]struct{}) bool {
+	if op.Type != OperandField {
+		return false
+	}
+	f, _ := op.Value.(Field)
+	_, ok := aliases[f.Name]
+	return ok
+}
+
 // cteRefCount returns the number of times cteName is referenced as a FROM or
 // JOIN source in the main statement and in all other CTE bodies.
 // Subquery references inside WHERE conditions are NOT counted here — use
@@ -149,7 +230,16 @@ func cteIsInlineable(cte CTE, mainStmt Statement, allCTEs []CTE) bool {
 		return false
 	}
 	if !cteBodyIsInlineEligible(*cte.Body) {
-		return false
+		// Second chance: the body may have column aliases but the outer query
+		// never references any of them (e.g. SELECT COUNT(*) FROM cte or
+		// SELECT id FROM cte where id = ?).  Inlining is safe because the
+		// merged query never names the aliased columns.
+		if !cteBodyIsInlineEligibleIgnoreAliases(*cte.Body) {
+			return false
+		}
+		if cteBodyAliasesConflictWithOuter(*cte.Body, mainStmt) {
+			return false
+		}
 	}
 	// Exactly one FROM/JOIN reference ensures the body isn't executed twice.
 	if cteRefCount(cte.Name, mainStmt, allCTEs) != 1 {

--- a/internal/minisql/cte_inline.go
+++ b/internal/minisql/cte_inline.go
@@ -65,7 +65,7 @@ func cteBodyIsInlineEligibleIgnoreAliases(body Statement) bool {
 // body.Fields is referenced by the outer query's fields, conditions, GROUP BY,
 // HAVING, or ORDER BY. If no alias is referenced, inlining is safe even though
 // the CTE body uses column renaming: the outer simply never names those aliases.
-func cteBodyAliasesConflictWithOuter(body Statement, outer Statement) bool {
+func cteBodyAliasesConflictWithOuter(body, outer Statement) bool {
 	aliasSet := make(map[string]struct{})
 	for _, f := range body.Fields {
 		if f.Name != "*" && f.Alias != "" {

--- a/internal/minisql/cte_inline_test.go
+++ b/internal/minisql/cte_inline_test.go
@@ -212,6 +212,133 @@ func TestCTEAppearsInConditionSubqueries(t *testing.T) {
 	})
 }
 
+// TestCTEBodyAliasesConflictWithOuter verifies the alias-conflict check used
+// by the extended inlining pass.
+func TestCTEBodyAliasesConflictWithOuter(t *testing.T) {
+	t.Parallel()
+
+	body := Statement{
+		Fields: []Field{
+			{Name: "id"},
+			{Name: "name", Alias: "display_name"},
+		},
+	}
+
+	t.Run("outer_count_star_no_conflict", func(t *testing.T) {
+		t.Parallel()
+		outer := Statement{Fields: []Field{{Name: "COUNT(*)"}}}
+		assert.False(t, cteBodyAliasesConflictWithOuter(body, outer))
+	})
+
+	t.Run("outer_refs_alias_in_field", func(t *testing.T) {
+		t.Parallel()
+		outer := Statement{Fields: []Field{{Name: "display_name"}}}
+		assert.True(t, cteBodyAliasesConflictWithOuter(body, outer))
+	})
+
+	t.Run("outer_refs_alias_in_condition", func(t *testing.T) {
+		t.Parallel()
+		cond := Condition{
+			Operand1: Operand{Type: OperandField, Value: Field{Name: "display_name"}},
+			Operator: Eq,
+			Operand2: Operand{Type: OperandQuotedString, Value: "Alice"},
+		}
+		outer := Statement{Conditions: OneOrMore{{cond}}}
+		assert.True(t, cteBodyAliasesConflictWithOuter(body, outer))
+	})
+
+	t.Run("outer_refs_alias_in_order_by", func(t *testing.T) {
+		t.Parallel()
+		outer := Statement{
+			Fields:  []Field{{Name: "id"}},
+			OrderBy: []OrderBy{{Field: Field{Name: "display_name"}}},
+		}
+		assert.True(t, cteBodyAliasesConflictWithOuter(body, outer))
+	})
+
+	t.Run("outer_refs_non_aliased_column_no_conflict", func(t *testing.T) {
+		t.Parallel()
+		outer := Statement{Fields: []Field{{Name: "id"}}}
+		assert.False(t, cteBodyAliasesConflictWithOuter(body, outer))
+	})
+
+	t.Run("no_aliases_in_body_never_conflicts", func(t *testing.T) {
+		t.Parallel()
+		noAlias := Statement{Fields: []Field{{Name: "id"}, {Name: "name"}}}
+		outer := Statement{Fields: []Field{{Name: "display_name"}}}
+		assert.False(t, cteBodyAliasesConflictWithOuter(noAlias, outer))
+	})
+}
+
+// TestCTEIsInlineableAliasExtension verifies the second-chance inlining path
+// for CTE bodies with column aliases that the outer query doesn't reference.
+func TestCTEIsInlineableAliasExtension(t *testing.T) {
+	t.Parallel()
+
+	makeAliasBody := func() *Statement {
+		return &Statement{
+			Kind:      Select,
+			TableName: "bench_rows",
+			Fields:    []Field{{Name: "id"}, {Name: "name", Alias: "display_name"}},
+			Conditions: OneOrMore{{Condition{
+				Operand1: Operand{Type: OperandField, Value: Field{Name: "age"}},
+				Operator: Gte,
+				Operand2: Operand{Type: OperandInteger, Value: int64(80)},
+			}}},
+		}
+	}
+
+	t.Run("count_star_outer_can_inline", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "seniors", Body: makeAliasBody()}
+		outer := Statement{
+			Kind:      Select,
+			TableName: "seniors",
+			Fields:    []Field{{Name: "COUNT(*)"}},
+		}
+		assert.True(t, cteIsInlineable(cte, outer, []CTE{cte}))
+	})
+
+	t.Run("outer_refs_alias_cannot_inline", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "seniors", Body: makeAliasBody()}
+		outer := Statement{
+			Kind:      Select,
+			TableName: "seniors",
+			Fields:    []Field{{Name: "display_name"}},
+		}
+		assert.False(t, cteIsInlineable(cte, outer, []CTE{cte}))
+	})
+
+	t.Run("outer_id_only_can_inline", func(t *testing.T) {
+		t.Parallel()
+		cte := CTE{Name: "seniors", Body: makeAliasBody()}
+		outer := Statement{
+			Kind:      Select,
+			TableName: "seniors",
+			Fields:    []Field{{Name: "id"}},
+		}
+		assert.True(t, cteIsInlineable(cte, outer, []CTE{cte}))
+	})
+
+	t.Run("group_by_still_blocks_inlining", func(t *testing.T) {
+		t.Parallel()
+		groupBody := &Statement{
+			Kind:      Select,
+			TableName: "bench_rows",
+			Fields:    []Field{{Name: "age"}, {Name: "name", Alias: "display_name"}},
+			GroupBy:   []Field{{Name: "age"}},
+		}
+		cte := CTE{Name: "summary", Body: groupBody}
+		outer := Statement{
+			Kind:      Select,
+			TableName: "summary",
+			Fields:    []Field{{Name: "COUNT(*)"}},
+		}
+		assert.False(t, cteIsInlineable(cte, outer, []CTE{cte}))
+	})
+}
+
 // TestCTEIsUsed verifies the usage detector used for pruning.
 func TestCTEIsUsed(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When a CTE body uses column aliases (e.g. SELECT name AS display_name) but the outer query never references those aliases (e.g. SELECT COUNT(*), SELECT id), the alias restriction was unnecessarily blocking inlining.

Add cteBodyIsInlineEligibleIgnoreAliases + cteBodyAliasesConflictWithOuter to give cteIsInlineable a second chance: if the body is otherwise inlineable and no alias is referenced by the outer's fields/conditions/ORDER BY/GROUP BY/HAVING, the CTE is merged directly into the outer statement.

This eliminates virtual-table materialisation for a large class of previously non-inlineable CTEs. Benchmark impact (10 000-row table, 20% match):

  BenchmarkCTE_NonInlineable: 531 855 B/op / 6 093 allocs → 7 665 B/op / 96 allocs
  (69× less memory, 63× fewer allocations)