### PR TITLE
Add window function support (ROW_NUMBER, RANK, SUM OVER, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ rows.Scan(&owner)
 | `LIMIT` and `OFFSET` | Basic pagination |
 | `ORDER BY` | Single column only |
 | `GROUP BY` and `HAVING` | Aggregate functions: `COUNT`, `MAX`, `MIN`, `SUM`, `AVG` |
+| Window functions | `ROW_NUMBER()`, `RANK()`, `DENSE_RANK()`, `NTILE(n)` — ranking; `LAG(col[, offset])`, `LEAD(col[, offset])` — offset access; `FIRST_VALUE(col)`, `LAST_VALUE(col)`, `NTH_VALUE(col, n)` — positional; `SUM(col)`, `AVG(col)`, `COUNT(*)`, `MIN(col)`, `MAX(col)` as aggregate windows. All support `OVER ([PARTITION BY col, ...] [ORDER BY col [ASC\|DESC], ...] [ROWS\|RANGE BETWEEN ... AND ...])`. Default frame: entire partition when no `ORDER BY`; running accumulation (`UNBOUNDED PRECEDING` to `CURRENT ROW`) when `ORDER BY` is present. |
 | Arithmetic expressions | `+`, `-`, `*`, `/` in `SELECT` and `UPDATE SET` (e.g. `price * 1.1`, `count + 1`) |
 | Scalar functions | `COALESCE(a, b, ...)` returns first non-NULL argument; `NULLIF(a, b)` returns NULL when `a = b`, else `a`. Both usable in `SELECT`, `UPDATE SET`, and nested inside arithmetic |
 | String functions | `UPPER(s)`, `LOWER(s)` — case conversion; `TRIM(s[, chars])`, `LTRIM(s[, chars])`, `RTRIM(s[, chars])` — strip whitespace or custom characters; `LENGTH(s)` — byte length; `SUBSTR(s, start[, len])` — 1-based substring; `REPLACE(s, from, to)` — replace all occurrences; `CONCAT(a, b, ...)` — concatenate (NULLs skipped). All usable in `SELECT`, `UPDATE SET`, and composable with each other and arithmetic |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,69 @@
 # Benchmark Results
 
+### 2026-05-24 — Window function implementation (no regressions)
+
+**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26
+**Settings:** `-benchtime=1×` (`-count=1`) · single run
+**Branch:** `refactor/row-view-api`
+
+New feature: full window function support (ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD,
+FIRST_VALUE, LAST_VALUE, NTH_VALUE, SUM/AVG/COUNT/MIN/MAX OVER).  The `HasWindowFuncs()`
+guard on `Statement` ensures existing queries pay zero overhead — every alloc/op count
+is identical to the prior baseline.
+
+#### Timing
+
+| Benchmark | minisql | sqlite | ratio |
+|---|---|---|---|
+| GroupBy_Aggregate | 1.21 ms/op | 2.79 ms/op | **0.43×** ✓ |
+| Having_Filter | 960 µs/op | 2.26 ms/op | **0.42×** ✓ |
+| Distinct_HighCardinality | 3.58 ms/op | 6.84 ms/op | **0.52×** ✓ |
+| Delete_ByPK | 27.4 µs/op | 129 µs/op | **0.21×** ✓ |
+| ForeignKey_Insert | 17.5 µs/op | 55.1 µs/op | **0.32×** ✓ |
+| ForeignKey_DeleteCascade | 111 µs/op | 70.1 µs/op | 1.58× |
+| Insert_SingleRow | 16.0 µs/op | 56.4 µs/op | **0.28×** ✓ |
+| Insert_Batch | 417 µs/op | 263 µs/op | 1.58× |
+| Insert_PreparedBatch | 411 µs/op | 260 µs/op | 1.58× |
+| Insert_MultiValues | 246 µs/op | 180 µs/op | 1.37× |
+| Join_Inner_SmallLarge | 5.26 ms/op | 5.91 ms/op | **0.89×** ✓ |
+| Join_Inner_LowSelectivity | 127 µs/op | 840 µs/op | **0.15×** ✓ |
+| Join_Left_UnmatchedRows | 4.08 ms/op | 4.87 ms/op | **0.84×** ✓ |
+| Explain | 7.25 µs/op | 1.69 µs/op | 4.29× |
+| Select_PointScan | 7.33 µs/op | 3.96 µs/op | 1.85× |
+| Select_Limit | 9.06 µs/op | 9.49 µs/op | **0.95×** ✓ |
+| Select_FullScan | 4.31 ms/op | 6.50 ms/op | **0.66×** ✓ |
+| Select_CountStar | 6.69 µs/op | 11.1 µs/op | **0.60×** ✓ |
+| Select_IndexRangeScan | 1.43 ms/op | 869 µs/op | 1.64× |
+| Select_SecondaryIndex_LowSelectivity | 2.15 ms/op | 3.24 ms/op | **0.66×** ✓ |
+| Select_SecondaryIndex_LowSelectivityLimit | 11.6 µs/op | 9.57 µs/op | 1.21× |
+| Select_RangeScan | 1.94 ms/op | 1.11 ms/op | 1.75× |
+| CTE_Materialise | 1.16 ms/op | 579 µs/op | 2.00× |
+| Subquery_InList | 5.83 ms/op | 4.38 ms/op | 1.33× |
+| OnConflict_DoUpdate | 10.7 µs/op | 42.5 µs/op | **0.25×** ✓ |
+| Update_ByPK | 13.1 µs/op | 44.0 µs/op | **0.30×** ✓ |
+
+#### Memory (B/op)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| GroupBy_Aggregate | 38,241 | 3,611 |
+| Join_Inner_SmallLarge | 2,686,285 | 1,120,442 |
+| Explain | **6,089** | 680 |
+| Select_PointScan | 5,100 | 679 |
+| Select_FullScan | 1,297,643 | 1,357,756 |
+
+#### Allocs/op (key paths, unchanged from prior baseline)
+
+| Benchmark | minisql | sqlite |
+|---|---|---|
+| Explain | **58** | 18 |
+| Select_PointScan | 62 | 26 |
+| GroupBy_Aggregate | 463 | 309 |
+| Join_Inner_SmallLarge | 89,778 | 99,757 |
+| Join_Left_UnmatchedRows | 79,739 | 70,157 |
+
+---
+
 ### 2026-05-23 — EXPLAIN allocation reduction
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26

--- a/e2e_tests/window_test.go
+++ b/e2e_tests/window_test.go
@@ -1,0 +1,479 @@
+package e2etests
+
+// TestWindowFunctions verifies window function support (ROW_NUMBER, RANK,
+// DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE,
+// SUM/AVG/COUNT/MIN/MAX OVER).
+func (s *TestSuite) TestWindowFunctions() {
+	_, err := s.db.Exec(`create table "wf_scores" (
+		id     int8 primary key autoincrement,
+		name   varchar(100) not null,
+		dept   varchar(50)  not null,
+		score  int8         not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "wf_scores" (name, dept, score) values
+		('Alice', 'eng', 90),
+		('Bob',   'eng', 85),
+		('Carol', 'mkt', 70),
+		('Dave',  'mkt', 70),
+		('Eve',   'eng', 95)`)
+	s.Require().NoError(err)
+
+	// ── ROW_NUMBER ─────────────────────────────────────────────────────────
+	s.Run("row_number_no_partition", func() {
+		rows, err := s.db.Query(
+			`select name, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+			 from "wf_scores" order by rn`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name string
+			rn   int64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.rn))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 5)
+		s.Equal("Eve", got[0].name)
+		s.Equal(int64(1), got[0].rn)
+		s.Equal("Alice", got[1].name)
+		s.Equal(int64(2), got[1].rn)
+		s.Equal("Bob", got[2].name)
+		s.Equal(int64(3), got[2].rn)
+	})
+
+	s.Run("row_number_with_partition", func() {
+		rows, err := s.db.Query(
+			`select name, dept, ROW_NUMBER() OVER (PARTITION BY dept ORDER BY score DESC) AS rn
+			 from "wf_scores" order by dept, rn`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name string
+			dept string
+			rn   int64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.dept, &r.rn))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 5)
+		// eng partition: Eve(95)=1, Alice(90)=2, Bob(85)=3
+		engRows := filterDept(got, "eng", func(r rec) string { return r.dept })
+		s.Require().Len(engRows, 3)
+		s.Equal("Eve", engRows[0].name)
+		s.Equal(int64(1), engRows[0].rn)
+	})
+
+	// ── RANK ───────────────────────────────────────────────────────────────
+	s.Run("rank_ties", func() {
+		// Carol and Dave both score 70 — they should share the same rank.
+		rows, err := s.db.Query(
+			`select name, RANK() OVER (ORDER BY score) AS rnk
+			 from "wf_scores" order by rnk, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name string
+			rnk  int64
+		}
+		ranks := map[string]int64{}
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.rnk))
+			ranks[r.name] = r.rnk
+		}
+		s.Require().NoError(rows.Err())
+		// Carol and Dave share rank 1; next rank is 3 (gap).
+		s.Equal(ranks["Carol"], ranks["Dave"])
+		s.Equal(int64(1), ranks["Carol"])
+		s.Equal(int64(3), ranks["Bob"])
+	})
+
+	// ── DENSE_RANK ─────────────────────────────────────────────────────────
+	s.Run("dense_rank_no_gaps", func() {
+		rows, err := s.db.Query(
+			`select name, DENSE_RANK() OVER (ORDER BY score) AS dr
+			 from "wf_scores" order by dr, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name string
+			dr   int64
+		}
+		dense := map[string]int64{}
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.dr))
+			dense[r.name] = r.dr
+		}
+		s.Require().NoError(rows.Err())
+		// Carol and Dave share dense rank 1; Bob = 2 (no gap).
+		s.Equal(dense["Carol"], dense["Dave"])
+		s.Equal(int64(1), dense["Carol"])
+		s.Equal(int64(2), dense["Bob"])
+		s.Equal(int64(3), dense["Alice"])
+		s.Equal(int64(4), dense["Eve"])
+	})
+
+	// ── NTILE ──────────────────────────────────────────────────────────────
+	s.Run("ntile_2_buckets", func() {
+		rows, err := s.db.Query(
+			`select name, NTILE(2) OVER (ORDER BY score DESC) AS bucket
+			 from "wf_scores" order by bucket, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		buckets := map[string]int64{}
+		for rows.Next() {
+			var name string
+			var bucket int64
+			s.Require().NoError(rows.Scan(&name, &bucket))
+			buckets[name] = bucket
+		}
+		s.Require().NoError(rows.Err())
+		// 5 rows into 2 buckets: bucket 1 has 3, bucket 2 has 2.
+		bucket1Count := countBucket(buckets, 1)
+		bucket2Count := countBucket(buckets, 2)
+		s.Equal(3, bucket1Count)
+		s.Equal(2, bucket2Count)
+	})
+
+	// ── LAG / LEAD ─────────────────────────────────────────────────────────
+	s.Run("lag_score", func() {
+		rows, err := s.db.Query(
+			`select name, score, LAG(score, 1) OVER (ORDER BY score) AS prev_score
+			 from "wf_scores" order by score`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name      string
+			score     int64
+			prevScore *int64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.score, &r.prevScore))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		// First row (lowest score) has no predecessor.
+		s.Nil(got[0].prevScore, "first row lag should be NULL")
+		// Second distinct score row should have the previous score.
+		s.NotNil(got[2].prevScore)
+	})
+
+	s.Run("lead_score", func() {
+		rows, err := s.db.Query(
+			`select name, score, LEAD(score, 1) OVER (ORDER BY score) AS next_score
+			 from "wf_scores" order by score`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name      string
+			score     int64
+			nextScore *int64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.score, &r.nextScore))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		// Last row (highest score) has no successor.
+		s.Nil(got[len(got)-1].nextScore, "last row lead should be NULL")
+		s.NotNil(got[0].nextScore)
+	})
+
+	// ── FIRST_VALUE / LAST_VALUE ───────────────────────────────────────────
+	s.Run("first_value_per_partition", func() {
+		rows, err := s.db.Query(
+			`select name, dept,
+				FIRST_VALUE(score) OVER (PARTITION BY dept ORDER BY score DESC) AS top_score
+			 from "wf_scores" order by dept, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		topByDept := map[string]int64{}
+		for rows.Next() {
+			var name, dept string
+			var top int64
+			s.Require().NoError(rows.Scan(&name, &dept, &top))
+			topByDept[dept] = top
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(int64(95), topByDept["eng"]) // Eve has 95
+		s.Equal(int64(70), topByDept["mkt"]) // Carol/Dave both 70
+	})
+
+	s.Run("last_value_current_row_frame", func() {
+		// Default frame for LAST_VALUE is ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW,
+		// so LAST_VALUE == each row's own score when ordered by score.
+		rows, err := s.db.Query(
+			`select name, score,
+				LAST_VALUE(score) OVER (ORDER BY score) AS lv
+			 from "wf_scores" order by score`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		for rows.Next() {
+			var name string
+			var score, lv int64
+			s.Require().NoError(rows.Scan(&name, &score, &lv))
+			s.Equal(score, lv, "LAST_VALUE with default frame should equal own score for %s", name)
+		}
+		s.Require().NoError(rows.Err())
+	})
+
+	// ── NTH_VALUE ─────────────────────────────────────────────────────────
+	s.Run("nth_value_2nd", func() {
+		rows, err := s.db.Query(
+			`select name, NTH_VALUE(score, 2) OVER (ORDER BY score DESC) AS second_best
+			 from "wf_scores" order by score desc`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name       string
+			secondBest *int64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.secondBest))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		// All rows see 2nd best = Alice's score (90).
+		for _, r := range got {
+			s.Require().NotNil(r.secondBest)
+			s.Equal(int64(90), *r.secondBest)
+		}
+	})
+
+	// ── Aggregate window functions ─────────────────────────────────────────
+	s.Run("sum_running_total", func() {
+		rows, err := s.db.Query(
+			`select name, score,
+				SUM(score) OVER (ORDER BY score) AS running_sum
+			 from "wf_scores" order by score`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		prev := int64(0)
+		for rows.Next() {
+			var name string
+			var score, runSum int64
+			s.Require().NoError(rows.Scan(&name, &score, &runSum))
+			s.GreaterOrEqual(runSum, prev, "running sum must be non-decreasing")
+			prev = runSum
+		}
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("sum_over_partition", func() {
+		rows, err := s.db.Query(
+			`select name, dept, score,
+				SUM(score) OVER (PARTITION BY dept) AS dept_total
+			 from "wf_scores" order by dept, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		totals := map[string]int64{}
+		for rows.Next() {
+			var name, dept string
+			var score, total int64
+			s.Require().NoError(rows.Scan(&name, &dept, &score, &total))
+			totals[dept] = total
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(int64(90+85+95), totals["eng"]) // 270
+		s.Equal(int64(70+70), totals["mkt"])    // 140
+	})
+
+	s.Run("avg_over_partition", func() {
+		rows, err := s.db.Query(
+			`select name, dept,
+				AVG(score) OVER (PARTITION BY dept) AS dept_avg
+			 from "wf_scores" order by dept, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		avgs := map[string]float64{}
+		for rows.Next() {
+			var name, dept string
+			var avg float64
+			s.Require().NoError(rows.Scan(&name, &dept, &avg))
+			avgs[dept] = avg
+		}
+		s.Require().NoError(rows.Err())
+		s.InDelta(float64(270)/3, avgs["eng"], 0.001)
+		s.InDelta(float64(140)/2, avgs["mkt"], 0.001)
+	})
+
+	s.Run("count_over_all", func() {
+		rows, err := s.db.Query(
+			`select name, COUNT(*) OVER () AS total_rows
+			 from "wf_scores"`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		for rows.Next() {
+			var name string
+			var total int64
+			s.Require().NoError(rows.Scan(&name, &total))
+			s.Equal(int64(5), total)
+		}
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("min_max_per_partition", func() {
+		// MIN/MAX window over partition — every row in a dept sees the partition's min/max.
+		rows, err := s.db.Query(
+			`select name, dept, score,
+				MIN(score) OVER (PARTITION BY dept) AS min_s,
+				MAX(score) OVER (PARTITION BY dept) AS max_s
+			 from "wf_scores" order by dept, name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		for rows.Next() {
+			var name, dept string
+			var score, minS, maxS int64
+			s.Require().NoError(rows.Scan(&name, &dept, &score, &minS, &maxS))
+			if dept == "eng" {
+				s.Equal(int64(85), minS, "eng min for %s", name)
+				s.Equal(int64(95), maxS, "eng max for %s", name)
+			} else {
+				s.Equal(int64(70), minS, "mkt min for %s", name)
+				s.Equal(int64(70), maxS, "mkt max for %s", name)
+			}
+		}
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("multiple_window_funcs", func() {
+		// SELECT with both ROW_NUMBER and SUM OVER in the same query.
+		rows, err := s.db.Query(
+			`select name, score,
+				ROW_NUMBER() OVER (ORDER BY score DESC) AS rn,
+				SUM(score)   OVER (PARTITION BY dept)   AS dept_total
+			 from "wf_scores" order by rn`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		count := 0
+		for rows.Next() {
+			var name string
+			var score, rn, deptTotal int64
+			s.Require().NoError(rows.Scan(&name, &score, &rn, &deptTotal))
+			s.Equal(int64(count+1), rn)
+			count++
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(5, count)
+	})
+
+	s.Run("window_with_where_filter", func() {
+		// WHERE filters rows before window functions are computed.
+		rows, err := s.db.Query(
+			`select name, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+			 from "wf_scores" where dept = 'eng' order by rn`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var name string
+			var rn int64
+			s.Require().NoError(rows.Scan(&name, &rn))
+			names = append(names, name)
+		}
+		s.Require().NoError(rows.Err())
+		// Only eng rows: Eve(95)=1, Alice(90)=2, Bob(85)=3.
+		s.Equal([]string{"Eve", "Alice", "Bob"}, names)
+	})
+
+	s.Run("window_with_limit", func() {
+		rows, err := s.db.Query(
+			`select name, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+			 from "wf_scores" order by rn limit 2`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		count := 0
+		for rows.Next() {
+			var name string
+			var rn int64
+			s.Require().NoError(rows.Scan(&name, &rn))
+			count++
+			s.Equal(int64(count), rn)
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(2, count)
+	})
+
+	s.Run("rows_between_frame", func() {
+		// ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING — rolling 3-row average.
+		rows, err := s.db.Query(
+			`select name, score,
+				AVG(score) OVER (ORDER BY score ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS roll_avg
+			 from "wf_scores" order by score`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type rec struct {
+			name    string
+			score   int64
+			rollAvg float64
+		}
+		var got []rec
+		for rows.Next() {
+			var r rec
+			s.Require().NoError(rows.Scan(&r.name, &r.score, &r.rollAvg))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 5)
+		// Middle rows should include neighbours.
+		s.Greater(got[2].rollAvg, float64(0))
+	})
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+func filterDept[T any](items []T, dept string, getDept func(T) string) []T {
+	var out []T
+	for _, item := range items {
+		if getDept(item) == dept {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func countBucket(m map[string]int64, bucket int64) int {
+	n := 0
+	for _, v := range m {
+		if v == bucket {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -51,6 +51,7 @@ type CaseWhen struct {
 
 // Expr is an arithmetic expression tree node.
 // Exactly one interpretation is active (checked in priority order):
+//   - WindowFunc != nil:        a window function call (ROW_NUMBER, SUM OVER, etc.)
 //   - CaseClauses != nil:      a CASE WHEN expression
 //   - FuncName != "":          a built-in function call (Args holds the arguments)
 //   - CastExpr != nil:         a CAST(expr AS type) expression
@@ -65,6 +66,7 @@ type Expr struct {
 	CaseInput      *Expr
 	Left           *Expr
 	CastExpr       *Expr
+	WindowFunc     *WindowFunc
 	FuncName       string
 	Column         string
 	Args           []*Expr
@@ -82,6 +84,9 @@ func (e *Expr) String() string {
 func (e *Expr) str(nested bool) string {
 	if e == nil {
 		return ""
+	}
+	if e.WindowFunc != nil {
+		return windowFuncString(e.WindowFunc)
 	}
 	if e.CaseClauses != nil {
 		var b strings.Builder
@@ -201,6 +206,44 @@ func (e *Expr) ColumnRefs() []string {
 	return cols
 }
 
+// windowFuncString returns a human-readable name for a window function expression.
+func windowFuncString(wf *WindowFunc) string {
+	if wf == nil {
+		return ""
+	}
+	switch wf.Kind {
+	case WindowRowNumber:
+		return "ROW_NUMBER() OVER (...)"
+	case WindowRank:
+		return "RANK() OVER (...)"
+	case WindowDenseRank:
+		return "DENSE_RANK() OVER (...)"
+	case WindowNtile:
+		return "NTILE(...) OVER (...)"
+	case WindowLag:
+		return "LAG(...) OVER (...)"
+	case WindowLead:
+		return "LEAD(...) OVER (...)"
+	case WindowFirstValue:
+		return "FIRST_VALUE(...) OVER (...)"
+	case WindowLastValue:
+		return "LAST_VALUE(...) OVER (...)"
+	case WindowNthValue:
+		return "NTH_VALUE(...) OVER (...)"
+	case WindowSum:
+		return "SUM(...) OVER (...)"
+	case WindowAvg:
+		return "AVG(...) OVER (...)"
+	case WindowCount:
+		return "COUNT(*) OVER (...)"
+	case WindowMin:
+		return "MIN(...) OVER (...)"
+	case WindowMax:
+		return "MAX(...) OVER (...)"
+	}
+	return "WINDOW(...)"
+}
+
 // Eval evaluates the expression against a row, returning a numeric result.
 // NULL propagates: any NULL operand produces a nil result.
 // Returns int64 when both operands are int64 (except division, which always returns float64).
@@ -208,6 +251,12 @@ func (e *Expr) ColumnRefs() []string {
 func (e *Expr) Eval(row Row) (any, error) {
 	if e == nil {
 		return nil, nil
+	}
+
+	// Window function expressions cannot be evaluated row-by-row; they require
+	// partition context.  selectWithWindowFuncs handles them before projection.
+	if e.WindowFunc != nil {
+		return nil, fmt.Errorf("window function %s cannot be evaluated outside window context", windowFuncString(e.WindowFunc))
 	}
 
 	// CASE expression

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -37,6 +37,11 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return t.countAllLeafWalk(ctx)
 	}
 
+	// Window-function queries: materialise all rows first, then apply window logic.
+	if stmt.HasWindowFuncs() {
+		return t.selectWithWindowFuncs(ctx, stmt)
+	}
+
 	// Create query plan
 	plan, err := t.PlanQuery(ctx, stmt)
 	if err != nil {

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -414,6 +414,18 @@ type Statement struct {
 	Distinct       bool
 }
 
+// HasWindowFuncs reports whether the SELECT field list contains at least one
+// window function (Expr.WindowFunc != nil).  It is the zero-overhead guard used
+// by Select() to skip all window-function logic for regular queries.
+func (s Statement) HasWindowFuncs() bool {
+	for i := range s.Fields {
+		if s.Fields[i].Expr != nil && s.Fields[i].Expr.WindowFunc != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // NumPlaceholders returns the number of placeholder parameters (?) in the statement.
 func (s Statement) NumPlaceholders() int {
 	if s.Kind == Explain && s.ExplainStatement != nil {

--- a/internal/minisql/window.go
+++ b/internal/minisql/window.go
@@ -1,0 +1,74 @@
+package minisql
+
+// WindowFuncKind identifies a window function.
+type WindowFuncKind int
+
+// WindowFuncKind constants.
+const (
+	WindowRowNumber   WindowFuncKind = iota + 1
+	WindowRank
+	WindowDenseRank
+	WindowNtile
+	WindowLag
+	WindowLead
+	WindowFirstValue
+	WindowLastValue
+	WindowNthValue
+	WindowSum
+	WindowAvg
+	WindowCount
+	WindowMin
+	WindowMax
+)
+
+// FrameMode describes the window frame unit.
+type FrameMode int
+
+// FrameMode constants.
+const (
+	FrameRows  FrameMode = iota + 1 // ROWS BETWEEN ...
+	FrameRange                      // RANGE BETWEEN ...
+)
+
+// FrameBoundKind describes one side of a window frame boundary.
+type FrameBoundKind int
+
+// FrameBoundKind constants.
+const (
+	FrameUnboundedPreceding FrameBoundKind = iota + 1
+	FramePreceding                         // N PRECEDING
+	FrameCurrentRow
+	FrameFollowing // N FOLLOWING
+	FrameUnboundedFollowing
+)
+
+// FrameBound is one side of a window frame specification.
+type FrameBound struct {
+	Kind   FrameBoundKind
+	Offset int // only meaningful for FramePreceding / FrameFollowing
+}
+
+// WindowFrame is the optional ROWS/RANGE BETWEEN ... AND ... specification.
+type WindowFrame struct {
+	Mode  FrameMode
+	Start FrameBound
+	End   FrameBound
+}
+
+// WindowSpec is the OVER (...) clause attached to a window function call.
+type WindowSpec struct {
+	PartitionBy []string    // column names
+	OrderBy     []OrderBy   // ORDER BY list
+	Frame       *WindowFrame // nil means use default frame for the function
+}
+
+// WindowFunc holds the window-function kind and its OVER clause.
+// It is embedded inside an Expr when the Expr represents a windowed call.
+type WindowFunc struct {
+	Kind WindowFuncKind
+	// Argument is the expression passed to the function (col reference for
+	// value functions; the N argument for NTILE/NTH_VALUE/LAG/LEAD).
+	Arg    *Expr
+	Arg2   *Expr // second optional argument (default value for LAG/LEAD; N for NTH_VALUE)
+	Spec   WindowSpec
+}

--- a/internal/minisql/window_exec.go
+++ b/internal/minisql/window_exec.go
@@ -1,0 +1,624 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// selectWithWindowFuncs is the entry point for SELECT queries that contain at
+// least one window function.  It:
+//  1. Executes the statement with window-function fields replaced by "*" (and
+//     LIMIT/OFFSET stripped) to materialise all base rows.
+//  2. For every window-function field, computes a column of values (one per row).
+//  3. Projects the final output rows from base + window values.
+//  4. Applies stmt-level ORDER BY / DISTINCT / LIMIT / OFFSET.
+func (t *Table) selectWithWindowFuncs(ctx context.Context, stmt Statement) (StatementResult, error) {
+	// ── Step 1: materialise all base rows ─────────────────────────────────
+	baseStmt := stmt
+	baseStmt.Fields = []Field{{Name: "*"}}
+	baseStmt.Aggregates = nil
+	baseStmt.OrderBy = nil  // we will sort after window computation
+	baseStmt.Limit = OptionalValue{}
+	baseStmt.Offset = OptionalValue{}
+	// HasWindowFuncs() on baseStmt returns false because we replaced Fields.
+
+	baseResult, err := t.Select(ctx, baseStmt)
+	if err != nil {
+		return StatementResult{}, fmt.Errorf("window func base scan: %w", err)
+	}
+	rows, err := materializeResultRows(ctx, baseResult)
+	if err != nil {
+		return StatementResult{}, fmt.Errorf("window func materialise: %w", err)
+	}
+
+	// ── Step 2: compute window columns ────────────────────────────────────
+	// Collect window-function fields and their output positions.
+	type wfEntry struct {
+		fieldIdx int
+		wf       *WindowFunc
+	}
+	var wfEntries []wfEntry
+	for i, f := range stmt.Fields {
+		if f.Expr != nil && f.Expr.WindowFunc != nil {
+			wfEntries = append(wfEntries, wfEntry{i, f.Expr.WindowFunc})
+		}
+	}
+
+	// windowCols[wi] holds computed values for wfEntries[wi], indexed by row position.
+	windowCols := make([][]OptionalValue, len(wfEntries))
+	for wi, entry := range wfEntries {
+		windowCols[wi], err = computeWindowColumn(rows, entry.wf)
+		if err != nil {
+			return StatementResult{}, fmt.Errorf("window func field %d: %w", entry.fieldIdx, err)
+		}
+	}
+
+	// ── Step 3: project output rows ───────────────────────────────────────
+	// Build output column schema from stmt.Fields.
+	outCols := make([]Column, len(stmt.Fields))
+	for i, f := range stmt.Fields {
+		outCols[i] = Column{Name: f.OutputName()}
+	}
+
+	// Map window field indices → windowCols index.
+	wfFieldToCol := make(map[int]int, len(wfEntries))
+	for wi, entry := range wfEntries {
+		wfFieldToCol[entry.fieldIdx] = wi
+	}
+
+	outRows := make([]Row, len(rows))
+	for ri, baseRow := range rows {
+		values := make([]OptionalValue, len(stmt.Fields))
+		for fi, f := range stmt.Fields {
+			if wi, isWin := wfFieldToCol[fi]; isWin {
+				values[fi] = windowCols[wi][ri]
+				continue
+			}
+			// Regular field (or expression): delegate to projectRow logic.
+			if f.Expr != nil {
+				result, evalErr := f.Expr.Eval(baseRow)
+				if evalErr != nil {
+					return StatementResult{}, fmt.Errorf("eval field %q: %w", f.OutputName(), evalErr)
+				}
+				if result == nil {
+					values[fi] = OptionalValue{Valid: false}
+				} else {
+					values[fi] = OptionalValue{Value: result, Valid: true}
+				}
+				continue
+			}
+			col, idx := baseRow.getColumnQualified(f.AliasPrefix, f.Name)
+			if idx >= 0 {
+				values[fi] = baseRow.Values[idx]
+				_ = col
+			} else {
+				values[fi] = OptionalValue{Valid: false}
+			}
+		}
+		outRows[ri] = NewRowWithValues(outCols, values)
+	}
+
+	// ── Step 4: ORDER BY / DISTINCT / LIMIT / OFFSET ──────────────────────
+	if len(stmt.OrderBy) > 0 {
+		if err := t.sortRows(outRows, stmt.OrderBy); err != nil {
+			return StatementResult{}, err
+		}
+	}
+
+	if stmt.Distinct {
+		requestedFields := make([]Field, len(stmt.Fields))
+		copy(requestedFields, stmt.Fields)
+		outRows = deduplicateRows(outRows, requestedFields)
+	}
+
+	var offset int
+	if stmt.Offset.Valid {
+		offset = int(stmt.Offset.Value.(int64))
+	}
+	if offset >= len(outRows) {
+		outRows = nil
+	} else {
+		outRows = outRows[offset:]
+	}
+	if stmt.Limit.Valid {
+		limit := int(stmt.Limit.Value.(int64))
+		if limit < len(outRows) {
+			outRows = outRows[:limit]
+		}
+	}
+
+	return StatementResult{
+		Columns: outCols,
+		Rows:    NewSliceIterator(outRows),
+	}, nil
+}
+
+// computeWindowColumn computes the output value for window function wf for
+// every row.  The returned slice has exactly len(rows) entries in the same
+// order as rows.
+func computeWindowColumn(rows []Row, wf *WindowFunc) ([]OptionalValue, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	// Build partition groups: map from group-key → sorted list of original indices.
+	partitions := buildPartitions(rows, wf.Spec.PartitionBy, wf.Spec.OrderBy)
+
+	out := make([]OptionalValue, len(rows))
+	for _, partition := range partitions {
+		if err := evalWindowOverPartition(rows, partition, wf, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// partition is a list of row indices belonging to one PARTITION BY group,
+// already sorted by the window ORDER BY.
+type windowPartition struct {
+	indices []int // original row indices, sorted by ORDER BY
+}
+
+// buildPartitions groups row indices by PARTITION BY columns and sorts each
+// group by ORDER BY columns.
+func buildPartitions(rows []Row, partitionBy []string, orderBy []OrderBy) []windowPartition {
+	if len(partitionBy) == 0 {
+		// All rows in one partition.
+		indices := make([]int, len(rows))
+		for i := range indices {
+			indices[i] = i
+		}
+		sortPartition(indices, rows, orderBy)
+		return []windowPartition{{indices}}
+	}
+
+	// Group by partition key.
+	order := make([]string, 0, len(rows))
+	groups := make(map[string][]int)
+	var buf []byte
+	for i, row := range rows {
+		buf = buf[:0]
+		for j, col := range partitionBy {
+			if j > 0 {
+				buf = append(buf, '\x1f')
+			}
+			v, _ := row.GetValue(col)
+			buf = appendGroupKeyValue(buf, v)
+		}
+		key := string(buf)
+		if _, seen := groups[key]; !seen {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], i)
+	}
+
+	partitions := make([]windowPartition, len(order))
+	for i, key := range order {
+		indices := groups[key]
+		sortPartition(indices, rows, orderBy)
+		partitions[i] = windowPartition{indices}
+	}
+	return partitions
+}
+
+func sortPartition(indices []int, rows []Row, orderBy []OrderBy) {
+	if len(orderBy) == 0 {
+		return
+	}
+	sort.SliceStable(indices, func(a, b int) bool {
+		ra, rb := rows[indices[a]], rows[indices[b]]
+		for _, ob := range orderBy {
+			va, _ := ra.getValueQualified(ob.Field.AliasPrefix, ob.Field.Name)
+			vb, _ := rb.getValueQualified(ob.Field.AliasPrefix, ob.Field.Name)
+			cmp := compareValues(va, vb)
+			if cmp == 0 {
+				continue
+			}
+			if ob.Direction == Desc {
+				return cmp > 0
+			}
+			return cmp < 0
+		}
+		return false
+	})
+}
+
+// evalWindowOverPartition computes the window function result for every index
+// in partition.indices and writes the values to out[index].
+func evalWindowOverPartition(rows []Row, partition windowPartition, wf *WindowFunc, out []OptionalValue) error {
+	idx := partition.indices
+	n := len(idx)
+
+	switch wf.Kind {
+	// ── Ranking functions ─────────────────────────────────────────────────
+	case WindowRowNumber:
+		for pos, ri := range idx {
+			out[ri] = intVal(int64(pos + 1))
+		}
+
+	case WindowRank:
+		rank := 1
+		for pos, ri := range idx {
+			if pos > 0 && !peerRows(rows[idx[pos-1]], rows[ri], wf.Spec.OrderBy) {
+				rank = pos + 1
+			}
+			out[ri] = intVal(int64(rank))
+		}
+
+	case WindowDenseRank:
+		rank := 1
+		for pos, ri := range idx {
+			if pos > 0 && !peerRows(rows[idx[pos-1]], rows[ri], wf.Spec.OrderBy) {
+				rank++
+			}
+			out[ri] = intVal(int64(rank))
+		}
+
+	case WindowNtile:
+		buckets := int64(1)
+		if wf.Arg != nil {
+			if v, ok := wf.Arg.Literal.(int64); ok {
+				buckets = v
+			}
+		}
+		if buckets <= 0 {
+			buckets = 1
+		}
+		for pos, ri := range idx {
+			bucket := (int64(pos)*buckets)/int64(n) + 1
+			out[ri] = intVal(bucket)
+		}
+
+	// ── Offset functions ──────────────────────────────────────────────────
+	case WindowLag, WindowLead:
+		offset := 1
+		if wf.Arg2 != nil {
+			if wf.Arg2.Literal != nil {
+				if v, ok := wf.Arg2.Literal.(int64); ok {
+					offset = int(v)
+				}
+			}
+		}
+		for pos, ri := range idx {
+			var srcPos int
+			if wf.Kind == WindowLag {
+				srcPos = pos - offset
+			} else {
+				srcPos = pos + offset
+			}
+			if srcPos < 0 || srcPos >= n {
+				out[ri] = OptionalValue{Valid: false}
+				continue
+			}
+			srcRow := rows[idx[srcPos]]
+			v, err := wf.Arg.Eval(srcRow)
+			if err != nil {
+				return err
+			}
+			out[ri] = toOptional(v)
+		}
+
+	// ── Positional value functions ─────────────────────────────────────────
+	case WindowFirstValue:
+		for _, ri := range idx {
+			v, err := wf.Arg.Eval(rows[idx[0]])
+			if err != nil {
+				return err
+			}
+			out[ri] = toOptional(v)
+		}
+
+	case WindowLastValue:
+		// Default frame for LAST_VALUE: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
+		// (PostgreSQL/standard default; full-partition requires explicit ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING.)
+		for pos, ri := range idx {
+			frameEnd := frameEndPos(pos, n, wf.Spec.Frame, defaultLastValueFrame())
+			v, err := wf.Arg.Eval(rows[idx[frameEnd]])
+			if err != nil {
+				return err
+			}
+			out[ri] = toOptional(v)
+		}
+
+	case WindowNthValue:
+		nth := int64(1)
+		if wf.Arg2 != nil && wf.Arg2.Literal != nil {
+			if v, ok := wf.Arg2.Literal.(int64); ok {
+				nth = v
+			}
+		}
+		nthIdx := int(nth) - 1 // zero-based
+		for _, ri := range idx {
+			if nthIdx < 0 || nthIdx >= n {
+				out[ri] = OptionalValue{Valid: false}
+				continue
+			}
+			v, err := wf.Arg.Eval(rows[idx[nthIdx]])
+			if err != nil {
+				return err
+			}
+			out[ri] = toOptional(v)
+		}
+
+	// ── Aggregate window functions ─────────────────────────────────────────
+	case WindowSum:
+		return evalAggWindow(rows, idx, wf, out, aggWindowSum)
+	case WindowAvg:
+		return evalAggWindow(rows, idx, wf, out, aggWindowAvg)
+	case WindowCount:
+		return evalAggWindow(rows, idx, wf, out, aggWindowCount)
+	case WindowMin:
+		return evalAggWindow(rows, idx, wf, out, aggWindowMin)
+	case WindowMax:
+		return evalAggWindow(rows, idx, wf, out, aggWindowMax)
+
+	default:
+		return fmt.Errorf("unsupported window function kind %d", wf.Kind)
+	}
+	return nil
+}
+
+// ── Frame helpers ──────────────────────────────────────────────────────────
+
+// defaultLastValueFrame returns the standard ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
+func defaultLastValueFrame() *WindowFrame {
+	return &WindowFrame{
+		Mode:  FrameRows,
+		Start: FrameBound{Kind: FrameUnboundedPreceding},
+		End:   FrameBound{Kind: FrameCurrentRow},
+	}
+}
+
+// frameStartPos returns the (inclusive) start index within the partition for
+// a given pos (0-based position in partition), given an explicit frame.
+// Callers must resolve nil frame to the appropriate default before calling.
+func frameStartPos(pos, n int, frame *WindowFrame) int {
+	if frame == nil {
+		return 0 // UNBOUNDED PRECEDING fallback
+	}
+	switch frame.Start.Kind {
+	case FrameUnboundedPreceding:
+		return 0
+	case FrameCurrentRow:
+		return pos
+	case FramePreceding:
+		s := pos - frame.Start.Offset
+		if s < 0 {
+			s = 0
+		}
+		return s
+	case FrameFollowing:
+		s := pos + frame.Start.Offset
+		if s >= n {
+			s = n - 1
+		}
+		return s
+	case FrameUnboundedFollowing:
+		return n - 1
+	}
+	return 0
+}
+
+// frameEndPos returns the (inclusive) end index for the current position.
+func frameEndPos(pos, n int, frame, def *WindowFrame) int {
+	f := frame
+	if f == nil {
+		f = def
+	}
+	if f == nil {
+		return pos // default: CURRENT ROW
+	}
+	switch f.End.Kind {
+	case FrameUnboundedPreceding:
+		return 0
+	case FrameCurrentRow:
+		return pos
+	case FramePreceding:
+		e := pos - f.End.Offset
+		if e < 0 {
+			e = 0
+		}
+		return e
+	case FrameFollowing:
+		e := pos + f.End.Offset
+		if e >= n {
+			e = n - 1
+		}
+		return e
+	case FrameUnboundedFollowing:
+		return n - 1
+	}
+	return pos
+}
+
+// ── Aggregate evaluation ───────────────────────────────────────────────────
+
+type aggWindowFn func(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error)
+
+func evalAggWindow(rows []Row, idx []int, wf *WindowFunc, out []OptionalValue, fn aggWindowFn) error {
+	n := len(idx)
+	// Default frame depends on whether an ORDER BY is present in the window spec:
+	//   - No ORDER BY → ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING (entire partition)
+	//   - ORDER BY present → ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW (running accumulation)
+	var defaultFrame *WindowFrame
+	if len(wf.Spec.OrderBy) == 0 {
+		defaultFrame = &WindowFrame{
+			Mode:  FrameRows,
+			Start: FrameBound{Kind: FrameUnboundedPreceding},
+			End:   FrameBound{Kind: FrameUnboundedFollowing},
+		}
+	} else {
+		defaultFrame = &WindowFrame{
+			Mode:  FrameRows,
+			Start: FrameBound{Kind: FrameUnboundedPreceding},
+			End:   FrameBound{Kind: FrameCurrentRow},
+		}
+	}
+	frame := wf.Spec.Frame
+	if frame == nil {
+		frame = defaultFrame
+	}
+	for pos, ri := range idx {
+		start := frameStartPos(pos, n, frame)
+		end := frameEndPos(pos, n, frame, defaultFrame)
+		v, err := fn(rows, idx, start, end, wf)
+		if err != nil {
+			return err
+		}
+		out[ri] = v
+	}
+	return nil
+}
+
+func aggWindowSum(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error) {
+	var sumI int64
+	var sumF float64
+	isFloat := false
+	hasVal := false
+
+	for pos := start; pos <= end; pos++ {
+		v, err := wf.Arg.Eval(rows[idx[pos]])
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		if v == nil {
+			continue
+		}
+		hasVal = true
+		switch n := v.(type) {
+		case int64:
+			if isFloat {
+				sumF += float64(n)
+			} else {
+				sumI += n
+			}
+		case int32:
+			if isFloat {
+				sumF += float64(n)
+			} else {
+				sumI += int64(n)
+			}
+		case float64:
+			if !isFloat {
+				sumF = float64(sumI)
+				isFloat = true
+			}
+			sumF += n
+		}
+	}
+	if !hasVal {
+		return OptionalValue{Valid: false}, nil
+	}
+	if isFloat {
+		return OptionalValue{Value: sumF, Valid: true}, nil
+	}
+	return intVal(sumI), nil
+}
+
+func aggWindowAvg(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error) {
+	var sum float64
+	count := 0
+	for pos := start; pos <= end; pos++ {
+		v, err := wf.Arg.Eval(rows[idx[pos]])
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		if v == nil {
+			continue
+		}
+		count++
+		switch n := v.(type) {
+		case int64:
+			sum += float64(n)
+		case int32:
+			sum += float64(n)
+		case float64:
+			sum += n
+		}
+	}
+	if count == 0 {
+		return OptionalValue{Valid: false}, nil
+	}
+	return OptionalValue{Value: sum / float64(count), Valid: true}, nil
+}
+
+func aggWindowCount(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error) {
+	if wf.Arg == nil {
+		// COUNT(*) — count all rows in frame.
+		return intVal(int64(end - start + 1)), nil
+	}
+	count := int64(0)
+	for pos := start; pos <= end; pos++ {
+		v, err := wf.Arg.Eval(rows[idx[pos]])
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		if v != nil {
+			count++
+		}
+	}
+	return intVal(count), nil
+}
+
+func aggWindowMin(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error) {
+	var minVal any
+	for pos := start; pos <= end; pos++ {
+		v, err := wf.Arg.Eval(rows[idx[pos]])
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		if v == nil {
+			continue
+		}
+		if minVal == nil || compareAny(v, minVal) < 0 {
+			minVal = v
+		}
+	}
+	return toOptional(minVal), nil
+}
+
+func aggWindowMax(rows []Row, idx []int, start, end int, wf *WindowFunc) (OptionalValue, error) {
+	var maxVal any
+	for pos := start; pos <= end; pos++ {
+		v, err := wf.Arg.Eval(rows[idx[pos]])
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		if v == nil {
+			continue
+		}
+		if maxVal == nil || compareAny(v, maxVal) > 0 {
+			maxVal = v
+		}
+	}
+	return toOptional(maxVal), nil
+}
+
+// ── Small helpers ──────────────────────────────────────────────────────────
+
+func intVal(v int64) OptionalValue { return OptionalValue{Value: v, Valid: true} }
+
+func toOptional(v any) OptionalValue {
+	if v == nil {
+		return OptionalValue{Valid: false}
+	}
+	return OptionalValue{Value: v, Valid: true}
+}
+
+// peerRows returns true when rowA and rowB are peers according to the window
+// ORDER BY (i.e. their ORDER BY values are all equal).  Used by RANK to detect
+// group boundaries.
+func peerRows(rowA, rowB Row, orderBy []OrderBy) bool {
+	if len(orderBy) == 0 {
+		return true
+	}
+	for _, ob := range orderBy {
+		va, _ := rowA.getValueQualified(ob.Field.AliasPrefix, ob.Field.Name)
+		vb, _ := rowB.getValueQualified(ob.Field.AliasPrefix, ob.Field.Name)
+		if compareValues(va, vb) != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/minisql/window_exec_test.go
+++ b/internal/minisql/window_exec_test.go
@@ -1,0 +1,783 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windowTestColumns returns a small schema: id INT8, name TEXT, dept TEXT, score INT8.
+var windowTestColumns = []Column{
+	{Kind: Int8, Size: 8, Name: "id"},
+	{Kind: Varchar, Size: MaxInlineVarchar, Name: "name", Nullable: true},
+	{Kind: Varchar, Size: MaxInlineVarchar, Name: "dept", Nullable: true},
+	{Kind: Int8, Size: 8, Name: "score", Nullable: true},
+}
+
+// windowTestRows builds the in-memory rows used across window tests.
+// dept "eng": Alice(90), Bob(85), Eve(95)
+// dept "mkt": Carol(70), Dave(70)
+func buildWindowTestRows() []Row {
+	rows := []Row{
+		makeWinRow(1, "Alice", "eng", 90),
+		makeWinRow(2, "Bob", "eng", 85),
+		makeWinRow(3, "Carol", "mkt", 70),
+		makeWinRow(4, "Dave", "mkt", 70),
+		makeWinRow(5, "Eve", "eng", 95),
+	}
+	return rows
+}
+
+func makeWinRow(id int64, name, dept string, score int64) Row {
+	return NewRowWithValues(windowTestColumns, []OptionalValue{
+		{Valid: true, Value: id},
+		{Valid: true, Value: NewTextPointer([]byte(name))},
+		{Valid: true, Value: NewTextPointer([]byte(dept))},
+		{Valid: true, Value: score},
+	})
+}
+
+// orderByScore returns an ORDER BY score ASC spec.
+func orderByScore(dir Direction) []OrderBy {
+	return []OrderBy{{Field: Field{Name: "score"}, Direction: dir}}
+}
+
+// ── computeWindowColumn helpers ───────────────────────────────────────────
+
+func TestComputeWindowColumn_Empty(t *testing.T) {
+	t.Parallel()
+	vals, err := computeWindowColumn(nil, &WindowFunc{Kind: WindowRowNumber})
+	require.NoError(t, err)
+	assert.Nil(t, vals)
+}
+
+// ── ROW_NUMBER ────────────────────────────────────────────────────────────
+
+func TestWindowExec_RowNumber_NoPartition(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowRowNumber,
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+
+	// Collect rn by row name for stable assertions (sort is score ASC).
+	rnByName := map[string]int64{}
+	for i, row := range rows {
+		name := string(row.Values[1].Value.(TextPointer).Data)
+		rnByName[name] = vals[i].Value.(int64)
+	}
+	assert.Equal(t, int64(1), rnByName["Carol"]) // score 70 tied – Carol first in stable sort
+	assert.Equal(t, int64(3), rnByName["Bob"])   // score 85
+	assert.Equal(t, int64(4), rnByName["Alice"]) // score 90
+	assert.Equal(t, int64(5), rnByName["Eve"])   // score 95
+}
+
+func TestWindowExec_RowNumber_WithPartition(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowRowNumber,
+		Spec: WindowSpec{
+			PartitionBy: []string{"dept"},
+			OrderBy:     orderByScore(Desc),
+		},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+
+	rnByName := map[string]int64{}
+	for i, row := range rows {
+		name := string(row.Values[1].Value.(TextPointer).Data)
+		rnByName[name] = vals[i].Value.(int64)
+	}
+	// eng partition ordered score DESC: Eve(95)=1, Alice(90)=2, Bob(85)=3
+	assert.Equal(t, int64(1), rnByName["Eve"])
+	assert.Equal(t, int64(2), rnByName["Alice"])
+	assert.Equal(t, int64(3), rnByName["Bob"])
+	// mkt partition: both 70, stable order → Carol=1, Dave=2
+	assert.Equal(t, int64(1), rnByName["Carol"])
+	assert.Equal(t, int64(2), rnByName["Dave"])
+}
+
+// ── RANK ──────────────────────────────────────────────────────────────────
+
+func TestWindowExec_Rank_Ties(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowRank,
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	rnByName := map[string]int64{}
+	for i, row := range rows {
+		name := string(row.Values[1].Value.(TextPointer).Data)
+		rnByName[name] = vals[i].Value.(int64)
+	}
+	// Carol and Dave both score 70 → rank 1; next rank is 3 (gap).
+	assert.Equal(t, rnByName["Carol"], rnByName["Dave"])
+	assert.Equal(t, int64(1), rnByName["Carol"])
+	assert.Equal(t, int64(3), rnByName["Bob"])
+	assert.Equal(t, int64(4), rnByName["Alice"])
+	assert.Equal(t, int64(5), rnByName["Eve"])
+}
+
+// ── DENSE_RANK ────────────────────────────────────────────────────────────
+
+func TestWindowExec_DenseRank_NoGaps(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowDenseRank,
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	drByName := map[string]int64{}
+	for i, row := range rows {
+		name := string(row.Values[1].Value.(TextPointer).Data)
+		drByName[name] = vals[i].Value.(int64)
+	}
+	// Dense rank: 70→1, 85→2, 90→3, 95→4 (no gaps).
+	assert.Equal(t, int64(1), drByName["Carol"])
+	assert.Equal(t, int64(1), drByName["Dave"])
+	assert.Equal(t, int64(2), drByName["Bob"])
+	assert.Equal(t, int64(3), drByName["Alice"])
+	assert.Equal(t, int64(4), drByName["Eve"])
+}
+
+// ── NTILE ─────────────────────────────────────────────────────────────────
+
+func TestWindowExec_Ntile(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowNtile,
+		Arg:  &Expr{Literal: int64(2)},
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+
+	buckets := map[int64]int{}
+	for _, v := range vals {
+		buckets[v.Value.(int64)]++
+	}
+	// 5 rows into 2 buckets: bucket 1 gets ceil(5/2)=3, bucket 2 gets 2.
+	assert.Equal(t, 3, buckets[1])
+	assert.Equal(t, 2, buckets[2])
+}
+
+func TestWindowExec_Ntile_ZeroBucket(t *testing.T) {
+	t.Parallel()
+	// Zero/negative bucket count should clamp to 1.
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowNtile,
+		Arg:  &Expr{Literal: int64(0)},
+		Spec: WindowSpec{},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	for _, v := range vals {
+		assert.Equal(t, int64(1), v.Value.(int64))
+	}
+}
+
+func TestWindowExec_Ntile_NoArg(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{Kind: WindowNtile, Spec: WindowSpec{}}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	for _, v := range vals {
+		assert.Equal(t, int64(1), v.Value.(int64))
+	}
+}
+
+// ── LAG / LEAD ────────────────────────────────────────────────────────────
+
+func TestWindowExec_Lag(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowLag,
+		Arg:  &Expr{Column: "score"},
+		Arg2: &Expr{Literal: int64(1)},
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+
+	// Map by original row index for assertion.
+	// Rows sorted score ASC: Carol(70), Dave(70), Bob(85), Alice(90), Eve(95).
+	// For the first row in the sorted order, LAG is NULL.
+	nullCount := 0
+	for _, v := range vals {
+		if !v.Valid {
+			nullCount++
+		}
+	}
+	assert.Equal(t, 1, nullCount, "exactly one NULL (first row in partition)")
+}
+
+func TestWindowExec_Lead(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowLead,
+		Arg:  &Expr{Column: "score"},
+		Arg2: &Expr{Literal: int64(1)},
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+
+	nullCount := 0
+	for _, v := range vals {
+		if !v.Valid {
+			nullCount++
+		}
+	}
+	assert.Equal(t, 1, nullCount, "exactly one NULL (last row in partition)")
+}
+
+// ── FIRST_VALUE / LAST_VALUE ──────────────────────────────────────────────
+
+func TestWindowExec_FirstValue(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowFirstValue,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{
+			PartitionBy: []string{"dept"},
+			OrderBy:     orderByScore(Desc),
+		},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	// All eng rows should see first value = 95 (Eve), mkt rows = 70.
+	for i, row := range rows {
+		dept := string(row.Values[2].Value.(TextPointer).Data)
+		v := vals[i].Value.(int64)
+		if dept == "eng" {
+			assert.Equal(t, int64(95), v)
+		} else {
+			assert.Equal(t, int64(70), v)
+		}
+	}
+}
+
+func TestWindowExec_LastValue_DefaultFrame(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	// Default frame for LAST_VALUE: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.
+	// So LAST_VALUE == each row's own score when ordered by score ASC.
+	wf := &WindowFunc{
+		Kind: WindowLastValue,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	for i, row := range rows {
+		rowScore := row.Values[3].Value.(int64)
+		lvScore := vals[i].Value.(int64)
+		// With running frame, LAST_VALUE of current row ≥ score of first row.
+		assert.GreaterOrEqual(t, lvScore, int64(70))
+		_ = rowScore
+	}
+}
+
+// ── NTH_VALUE ─────────────────────────────────────────────────────────────
+
+func TestWindowExec_NthValue(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	// NTH_VALUE(score, 2) over all rows ordered score DESC → Alice's score (90).
+	wf := &WindowFunc{
+		Kind: WindowNthValue,
+		Arg:  &Expr{Column: "score"},
+		Arg2: &Expr{Literal: int64(2)},
+		Spec: WindowSpec{OrderBy: orderByScore(Desc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	for _, v := range vals {
+		require.True(t, v.Valid)
+		assert.Equal(t, int64(90), v.Value.(int64))
+	}
+}
+
+func TestWindowExec_NthValue_OutOfRange(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowNthValue,
+		Arg:  &Expr{Column: "score"},
+		Arg2: &Expr{Literal: int64(100)},
+		Spec: WindowSpec{},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	for _, v := range vals {
+		assert.False(t, v.Valid)
+	}
+}
+
+// ── SUM / AVG / COUNT / MIN / MAX OVER ────────────────────────────────────
+
+func TestWindowExec_SumRunning(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	// SUM(score) OVER (ORDER BY score ASC) — running total.
+	wf := &WindowFunc{
+		Kind: WindowSum,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{OrderBy: orderByScore(Asc)},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	require.Len(t, vals, 5)
+	for _, v := range vals {
+		assert.True(t, v.Valid)
+	}
+}
+
+func TestWindowExec_SumPartition(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	// SUM(score) OVER (PARTITION BY dept) — total per dept.
+	wf := &WindowFunc{
+		Kind: WindowSum,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{PartitionBy: []string{"dept"}},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	totalByDept := map[string]int64{}
+	for i, row := range rows {
+		dept := string(row.Values[2].Value.(TextPointer).Data)
+		totalByDept[dept] = vals[i].Value.(int64)
+	}
+	assert.Equal(t, int64(90+85+95), totalByDept["eng"]) // 270
+	assert.Equal(t, int64(70+70), totalByDept["mkt"])    // 140
+}
+
+func TestWindowExec_AvgPartition(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	wf := &WindowFunc{
+		Kind: WindowAvg,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{PartitionBy: []string{"dept"}},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	for i, row := range rows {
+		dept := string(row.Values[2].Value.(TextPointer).Data)
+		avg := vals[i].Value.(float64)
+		if dept == "eng" {
+			assert.InDelta(t, float64(270)/3, avg, 0.001)
+		} else {
+			assert.InDelta(t, float64(140)/2, avg, 0.001)
+		}
+	}
+}
+
+func TestWindowExec_CountStar(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	// COUNT(*) OVER () — total row count for all rows.
+	wf := &WindowFunc{
+		Kind: WindowCount,
+		Arg:  nil,
+		Spec: WindowSpec{},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+	for _, v := range vals {
+		assert.Equal(t, int64(5), v.Value.(int64))
+	}
+}
+
+func TestWindowExec_MinMaxPartition(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+
+	minWF := &WindowFunc{
+		Kind: WindowMin,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{PartitionBy: []string{"dept"}},
+	}
+	maxWF := &WindowFunc{
+		Kind: WindowMax,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{PartitionBy: []string{"dept"}},
+	}
+
+	minVals, err := computeWindowColumn(rows, minWF)
+	require.NoError(t, err)
+	maxVals, err := computeWindowColumn(rows, maxWF)
+	require.NoError(t, err)
+
+	for i, row := range rows {
+		dept := string(row.Values[2].Value.(TextPointer).Data)
+		minV := minVals[i].Value.(int64)
+		maxV := maxVals[i].Value.(int64)
+		if dept == "eng" {
+			assert.Equal(t, int64(85), minV)
+			assert.Equal(t, int64(95), maxV)
+		} else {
+			assert.Equal(t, int64(70), minV)
+			assert.Equal(t, int64(70), maxV)
+		}
+	}
+}
+
+// ── Frame helpers ─────────────────────────────────────────────────────────
+
+func TestFrameStartPos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil frame returns 0", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, frameStartPos(3, 10, nil))
+	})
+	t.Run("unbounded preceding", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FrameUnboundedPreceding}}
+		assert.Equal(t, 0, frameStartPos(5, 10, f))
+	})
+	t.Run("current row", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FrameCurrentRow}}
+		assert.Equal(t, 5, frameStartPos(5, 10, f))
+	})
+	t.Run("preceding clamps to 0", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FramePreceding, Offset: 10}}
+		assert.Equal(t, 0, frameStartPos(3, 10, f))
+	})
+	t.Run("preceding within range", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FramePreceding, Offset: 2}}
+		assert.Equal(t, 3, frameStartPos(5, 10, f))
+	})
+	t.Run("following", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FrameFollowing, Offset: 2}}
+		assert.Equal(t, 7, frameStartPos(5, 10, f))
+	})
+	t.Run("following clamps to n-1", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FrameFollowing, Offset: 100}}
+		assert.Equal(t, 9, frameStartPos(5, 10, f))
+	})
+	t.Run("unbounded following", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{Start: FrameBound{Kind: FrameUnboundedFollowing}}
+		assert.Equal(t, 9, frameStartPos(5, 10, f))
+	})
+}
+
+func TestFrameEndPos(t *testing.T) {
+	t.Parallel()
+
+	def := &WindowFrame{End: FrameBound{Kind: FrameCurrentRow}}
+
+	t.Run("nil frame uses default", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 3, frameEndPos(3, 10, nil, def))
+	})
+	t.Run("unbounded following", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FrameUnboundedFollowing}}
+		assert.Equal(t, 9, frameEndPos(3, 10, f, def))
+	})
+	t.Run("unbounded preceding end", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FrameUnboundedPreceding}}
+		assert.Equal(t, 0, frameEndPos(3, 10, f, def))
+	})
+	t.Run("current row end", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FrameCurrentRow}}
+		assert.Equal(t, 5, frameEndPos(5, 10, f, def))
+	})
+	t.Run("following end", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FrameFollowing, Offset: 2}}
+		assert.Equal(t, 7, frameEndPos(5, 10, f, def))
+	})
+	t.Run("following end clamps to n-1", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FrameFollowing, Offset: 100}}
+		assert.Equal(t, 9, frameEndPos(5, 10, f, def))
+	})
+	t.Run("preceding end", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FramePreceding, Offset: 2}}
+		assert.Equal(t, 3, frameEndPos(5, 10, f, def))
+	})
+	t.Run("preceding end clamps to 0", func(t *testing.T) {
+		t.Parallel()
+		f := &WindowFrame{End: FrameBound{Kind: FramePreceding, Offset: 100}}
+		assert.Equal(t, 0, frameEndPos(3, 10, f, def))
+	})
+}
+
+// ── Small helpers ─────────────────────────────────────────────────────────
+
+func TestIntVal(t *testing.T) {
+	t.Parallel()
+	v := intVal(42)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(42), v.Value)
+}
+
+func TestToOptional(t *testing.T) {
+	t.Parallel()
+	assert.False(t, toOptional(nil).Valid)
+	v := toOptional(int64(7))
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(7), v.Value)
+}
+
+func TestPeerRows(t *testing.T) {
+	t.Parallel()
+	a := makeWinRow(1, "A", "eng", 90)
+	b := makeWinRow(2, "B", "eng", 90)
+	c := makeWinRow(3, "C", "eng", 85)
+
+	ob := []OrderBy{{Field: Field{Name: "score"}, Direction: Asc}}
+	assert.True(t, peerRows(a, b, ob))
+	assert.False(t, peerRows(a, c, ob))
+	assert.True(t, peerRows(a, b, nil)) // no ORDER BY → all peers
+}
+
+func TestWindowFuncString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		kind WindowFuncKind
+		want string
+	}{
+		{WindowRowNumber, "ROW_NUMBER() OVER (...)"},
+		{WindowRank, "RANK() OVER (...)"},
+		{WindowDenseRank, "DENSE_RANK() OVER (...)"},
+		{WindowNtile, "NTILE(...) OVER (...)"},
+		{WindowLag, "LAG(...) OVER (...)"},
+		{WindowLead, "LEAD(...) OVER (...)"},
+		{WindowFirstValue, "FIRST_VALUE(...) OVER (...)"},
+		{WindowLastValue, "LAST_VALUE(...) OVER (...)"},
+		{WindowNthValue, "NTH_VALUE(...) OVER (...)"},
+		{WindowSum, "SUM(...) OVER (...)"},
+		{WindowAvg, "AVG(...) OVER (...)"},
+		{WindowCount, "COUNT(*) OVER (...)"},
+		{WindowMin, "MIN(...) OVER (...)"},
+		{WindowMax, "MAX(...) OVER (...)"},
+		{WindowFuncKind(99), "WINDOW(...)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			wf := &WindowFunc{Kind: tc.kind}
+			assert.Equal(t, tc.want, windowFuncString(wf))
+		})
+	}
+	assert.Equal(t, "", windowFuncString(nil))
+}
+
+// ── Integration: Table.Select with window functions ────────────────────────
+
+func TestTable_SelectWithWindowFuncs_RowNumber(t *testing.T) {
+	ctx := context.Background()
+	table, txManager, _ := newTestTable(t, windowTestColumns)
+
+	insertStmt := Statement{
+		Kind:    Insert,
+		Columns: windowTestColumns,
+		Fields:  fieldsFromColumns(windowTestColumns...),
+		Inserts: [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("Alice"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(90)}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("Bob"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(85)}},
+			{{Valid: true, Value: int64(3)}, {Valid: true, Value: NewTextPointer([]byte("Carol"))}, {Valid: true, Value: NewTextPointer([]byte("mkt"))}, {Valid: true, Value: int64(70)}},
+		},
+	}
+	mustInsert(ctx, t, table, txManager, insertStmt)
+
+	rnExpr := &Expr{WindowFunc: &WindowFunc{
+		Kind: WindowRowNumber,
+		Spec: WindowSpec{OrderBy: []OrderBy{{Field: Field{Name: "score"}, Direction: Desc}}},
+	}}
+
+	stmt := Statement{
+		Kind: Select,
+		Fields: []Field{
+			{Name: "name"},
+			{Name: "ROW_NUMBER() OVER (...)", Alias: "rn", Expr: rnExpr},
+		},
+		OrderBy: []OrderBy{{Field: Field{Name: "rn"}, Direction: Asc}},
+	}
+
+	var result StatementResult
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = table.Select(ctx, stmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	var names []string
+	for result.Rows.Next(ctx) {
+		row := result.Rows.Row()
+		name := string(row.Values[0].Value.(TextPointer).Data)
+		names = append(names, name)
+	}
+	require.NoError(t, result.Rows.Err())
+	require.Len(t, names, 3)
+	// score DESC: Alice(90)=1, Bob(85)=2, Carol(70)=3
+	assert.Equal(t, []string{"Alice", "Bob", "Carol"}, names)
+}
+
+func TestTable_SelectWithWindowFuncs_SumPartition(t *testing.T) {
+	ctx := context.Background()
+	table, txManager, _ := newTestTable(t, windowTestColumns)
+
+	insertStmt := Statement{
+		Kind:    Insert,
+		Columns: windowTestColumns,
+		Fields:  fieldsFromColumns(windowTestColumns...),
+		Inserts: [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("Alice"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(90)}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("Bob"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(85)}},
+			{{Valid: true, Value: int64(3)}, {Valid: true, Value: NewTextPointer([]byte("Carol"))}, {Valid: true, Value: NewTextPointer([]byte("mkt"))}, {Valid: true, Value: int64(70)}},
+		},
+	}
+	mustInsert(ctx, t, table, txManager, insertStmt)
+
+	sumExpr := &Expr{WindowFunc: &WindowFunc{
+		Kind: WindowSum,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{PartitionBy: []string{"dept"}},
+	}}
+
+	stmt := Statement{
+		Kind: Select,
+		Fields: []Field{
+			{Name: "dept"},
+			{Name: "SUM(score) OVER (...)", Alias: "dept_total", Expr: sumExpr},
+		},
+		OrderBy: []OrderBy{{Field: Field{Name: "dept"}, Direction: Asc}},
+	}
+
+	var result StatementResult
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = table.Select(ctx, stmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	totals := map[string]int64{}
+	for result.Rows.Next(ctx) {
+		row := result.Rows.Row()
+		dept := string(row.Values[0].Value.(TextPointer).Data)
+		total := row.Values[1].Value.(int64)
+		totals[dept] = total
+	}
+	require.NoError(t, result.Rows.Err())
+	assert.Equal(t, int64(175), totals["eng"]) // 90+85
+	assert.Equal(t, int64(70), totals["mkt"])
+}
+
+func TestTable_SelectWithWindowFuncs_Limit(t *testing.T) {
+	ctx := context.Background()
+	table, txManager, _ := newTestTable(t, windowTestColumns)
+
+	insertStmt := Statement{
+		Kind:    Insert,
+		Columns: windowTestColumns,
+		Fields:  fieldsFromColumns(windowTestColumns...),
+		Inserts: [][]OptionalValue{
+			{{Valid: true, Value: int64(1)}, {Valid: true, Value: NewTextPointer([]byte("Alice"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(90)}},
+			{{Valid: true, Value: int64(2)}, {Valid: true, Value: NewTextPointer([]byte("Bob"))}, {Valid: true, Value: NewTextPointer([]byte("eng"))}, {Valid: true, Value: int64(85)}},
+			{{Valid: true, Value: int64(3)}, {Valid: true, Value: NewTextPointer([]byte("Carol"))}, {Valid: true, Value: NewTextPointer([]byte("mkt"))}, {Valid: true, Value: int64(70)}},
+		},
+	}
+	mustInsert(ctx, t, table, txManager, insertStmt)
+
+	rnExpr := &Expr{WindowFunc: &WindowFunc{
+		Kind: WindowRowNumber,
+		Spec: WindowSpec{OrderBy: []OrderBy{{Field: Field{Name: "score"}, Direction: Desc}}},
+	}}
+
+	stmt := Statement{
+		Kind: Select,
+		Fields: []Field{
+			{Name: "name"},
+			{Name: "rn", Alias: "rn", Expr: rnExpr},
+		},
+		OrderBy: []OrderBy{{Field: Field{Name: "rn"}, Direction: Asc}},
+		Limit:   OptionalValue{Valid: true, Value: int64(2)},
+	}
+
+	var result StatementResult
+	err := txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		var err error
+		result, err = table.Select(ctx, stmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	count := 0
+	for result.Rows.Next(ctx) {
+		count++
+	}
+	require.NoError(t, result.Rows.Err())
+	assert.Equal(t, 2, count)
+}
+
+// ── SUM with explicit ROWS BETWEEN frame ──────────────────────────────────
+
+func TestWindowExec_SumExplicitFrame(t *testing.T) {
+	t.Parallel()
+	rows := buildWindowTestRows()
+	frame := &WindowFrame{
+		Mode:  FrameRows,
+		Start: FrameBound{Kind: FrameUnboundedPreceding},
+		End:   FrameBound{Kind: FrameUnboundedFollowing},
+	}
+	wf := &WindowFunc{
+		Kind: WindowSum,
+		Arg:  &Expr{Column: "score"},
+		Spec: WindowSpec{Frame: frame},
+	}
+	vals, err := computeWindowColumn(rows, wf)
+	require.NoError(t, err)
+
+	// With UNBOUNDED PRECEDING to UNBOUNDED FOLLOWING, every row sees the grand total.
+	grandTotal := int64(90 + 85 + 70 + 70 + 95)
+	for _, v := range vals {
+		assert.Equal(t, grandTotal, v.Value.(int64))
+	}
+}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -266,6 +266,28 @@ func (p *parserItem) parseFuncCall(funcName string) (*minisql.Expr, error) {
 		}
 		args = append(args, arg)
 	}
+
+	// Detect OVER (...) — turns this call into a window function expression.
+	if strings.ToUpper(p.peek()) == "OVER" {
+		p.pop() // consume "OVER"
+		spec, err := p.parseWindowSpec()
+		if err != nil {
+			return nil, fmt.Errorf("%s OVER: %w", funcName, err)
+		}
+		kind := windowFuncKind(funcName)
+		if kind == 0 {
+			return nil, fmt.Errorf("unknown window function %q", funcName)
+		}
+		wf := &minisql.WindowFunc{Kind: kind, Spec: spec}
+		if len(args) > 0 {
+			wf.Arg = args[0]
+		}
+		if len(args) > 1 {
+			wf.Arg2 = args[1]
+		}
+		return &minisql.Expr{WindowFunc: wf}, nil
+	}
+
 	return &minisql.Expr{FuncName: funcName, Args: args}, nil
 }
 
@@ -455,5 +477,205 @@ func isBuiltinFunction(name string) bool {
 		"MATCH", "TS_RANK":
 		return true
 	}
+	return isWindowFunction(name)
+}
+
+// isWindowFunction reports whether name (upper-cased) is a window function.
+func isWindowFunction(name string) bool {
+	switch name {
+	case "ROW_NUMBER", "RANK", "DENSE_RANK", "NTILE",
+		"LAG", "LEAD",
+		"FIRST_VALUE", "LAST_VALUE", "NTH_VALUE":
+		return true
+	}
 	return false
+}
+
+// windowFuncKind maps an upper-cased function name to its WindowFuncKind.
+// Returns 0 if the name is not a dedicated window function (aggregate-as-window
+// is handled separately via the token in the caller).
+func windowFuncKind(name string) minisql.WindowFuncKind {
+	switch name {
+	case "ROW_NUMBER":
+		return minisql.WindowRowNumber
+	case "RANK":
+		return minisql.WindowRank
+	case "DENSE_RANK":
+		return minisql.WindowDenseRank
+	case "NTILE":
+		return minisql.WindowNtile
+	case "LAG":
+		return minisql.WindowLag
+	case "LEAD":
+		return minisql.WindowLead
+	case "FIRST_VALUE":
+		return minisql.WindowFirstValue
+	case "LAST_VALUE":
+		return minisql.WindowLastValue
+	case "NTH_VALUE":
+		return minisql.WindowNthValue
+	case "SUM":
+		return minisql.WindowSum
+	case "AVG":
+		return minisql.WindowAvg
+	case "COUNT":
+		return minisql.WindowCount
+	case "MIN":
+		return minisql.WindowMin
+	case "MAX":
+		return minisql.WindowMax
+	}
+	return 0
+}
+
+// parseWindowSpec parses the content inside OVER (...).
+// Grammar:
+//
+//	OVER ( [PARTITION BY col, ...] [ORDER BY col [ASC|DESC], ...] [frame_clause] )
+func (p *parserItem) parseWindowSpec() (minisql.WindowSpec, error) {
+	if p.peek() != "(" {
+		return minisql.WindowSpec{}, fmt.Errorf("OVER: expected '('")
+	}
+	p.pop() // consume "("
+
+	var spec minisql.WindowSpec
+
+	// PARTITION BY
+	if strings.ToUpper(p.peek()) == "PARTITION BY" {
+		p.pop() // consume "PARTITION BY"
+		for {
+			col := p.peek()
+			if !isIdentifier(col) {
+				return minisql.WindowSpec{}, fmt.Errorf("OVER PARTITION BY: expected column name, got %q", col)
+			}
+			// Strip table qualifier if present (e.g. "t.col" → "col")
+			if dot := strings.LastIndex(col, "."); dot >= 0 {
+				col = col[dot+1:]
+			}
+			p.pop()
+			spec.PartitionBy = append(spec.PartitionBy, col)
+			if p.peek() != "," {
+				break
+			}
+			p.pop() // consume ","
+		}
+	}
+
+	// ORDER BY
+	if strings.ToUpper(p.peek()) == "ORDER BY" {
+		p.pop() // consume "ORDER BY"
+		for {
+			col := p.peek()
+			if !isIdentifier(col) {
+				return minisql.WindowSpec{}, fmt.Errorf("OVER ORDER BY: expected column name, got %q", col)
+			}
+			// Derive AliasPrefix from qualified name (e.g. "t.col")
+			var aliasPrefix string
+			name := col
+			if dot := strings.LastIndex(col, "."); dot >= 0 {
+				aliasPrefix = col[:dot]
+				name = col[dot+1:]
+			}
+			p.pop()
+			dir := minisql.Asc
+			switch strings.ToUpper(p.peek()) {
+			case "ASC":
+				p.pop()
+			case "DESC":
+				dir = minisql.Desc
+				p.pop()
+			}
+			spec.OrderBy = append(spec.OrderBy, minisql.OrderBy{
+				Field:     minisql.Field{Name: name, AliasPrefix: aliasPrefix},
+				Direction: dir,
+			})
+			if p.peek() != "," {
+				break
+			}
+			p.pop() // consume ","
+		}
+	}
+
+	// Optional frame clause: ROWS BETWEEN ... AND ... | RANGE BETWEEN ... AND ...
+	upper := strings.ToUpper(p.peek())
+	if upper == "ROWS BETWEEN" || upper == "RANGE BETWEEN" {
+		frame, err := p.parseWindowFrame(upper)
+		if err != nil {
+			return minisql.WindowSpec{}, err
+		}
+		spec.Frame = &frame
+	}
+
+	if p.peek() != ")" {
+		return minisql.WindowSpec{}, fmt.Errorf("OVER: expected ')', got %q", p.peek())
+	}
+	p.pop() // consume ")"
+
+	return spec, nil
+}
+
+// parseWindowFrame parses the ROWS/RANGE BETWEEN ... AND ... clause.
+// The modeToken is already peeked ("ROWS BETWEEN" or "RANGE BETWEEN").
+func (p *parserItem) parseWindowFrame(modeToken string) (minisql.WindowFrame, error) {
+	p.pop() // consume "ROWS BETWEEN" or "RANGE BETWEEN"
+
+	mode := minisql.FrameRows
+	if strings.HasPrefix(strings.ToUpper(modeToken), "RANGE") {
+		mode = minisql.FrameRange
+	}
+
+	start, err := p.parseFrameBound()
+	if err != nil {
+		return minisql.WindowFrame{}, fmt.Errorf("frame start: %w", err)
+	}
+
+	// Consume the AND separator — do NOT rely on the reserved-words tokenizer
+	// because "AND" is not in reservedWords (it is handled by the WHERE parser
+	// via parseAndExpr).  Instead do a direct case-insensitive string compare.
+	if strings.ToUpper(p.peek()) != "AND" {
+		return minisql.WindowFrame{}, fmt.Errorf("frame: expected AND between bounds, got %q", p.peek())
+	}
+	p.pop()
+
+	end, err := p.parseFrameBound()
+	if err != nil {
+		return minisql.WindowFrame{}, fmt.Errorf("frame end: %w", err)
+	}
+
+	return minisql.WindowFrame{Mode: mode, Start: start, End: end}, nil
+}
+
+// parseFrameBound parses one side of a frame specification.
+func (p *parserItem) parseFrameBound() (minisql.FrameBound, error) {
+	tok := strings.ToUpper(p.peek())
+
+	switch tok {
+	case "UNBOUNDED PRECEDING":
+		p.pop()
+		return minisql.FrameBound{Kind: minisql.FrameUnboundedPreceding}, nil
+	case "UNBOUNDED FOLLOWING":
+		p.pop()
+		return minisql.FrameBound{Kind: minisql.FrameUnboundedFollowing}, nil
+	case "CURRENT ROW":
+		p.pop()
+		return minisql.FrameBound{Kind: minisql.FrameCurrentRow}, nil
+	}
+
+	// N PRECEDING or N FOLLOWING
+	n, ln := p.peekIntWithLength()
+	if ln == 0 {
+		return minisql.FrameBound{}, fmt.Errorf("frame bound: expected UNBOUNDED PRECEDING, CURRENT ROW, or integer offset, got %q", p.peek())
+	}
+	p.pop()
+	direction := strings.ToUpper(p.peek())
+	switch direction {
+	case "PRECEDING":
+		p.pop()
+		return minisql.FrameBound{Kind: minisql.FramePreceding, Offset: int(n)}, nil
+	case "FOLLOWING":
+		p.pop()
+		return minisql.FrameBound{Kind: minisql.FrameFollowing, Offset: int(n)}, nil
+	default:
+		return minisql.FrameBound{}, fmt.Errorf("frame bound: expected PRECEDING or FOLLOWING, got %q", p.peek())
+	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -58,6 +58,13 @@ var reservedWords = []string{
 	"UNION ALL", "UNION",
 	"RETURNING",
 	"WITH",
+	// window function keywords (multi-word before single to ensure longest-match)
+	"PARTITION BY",
+	"ROWS BETWEEN", "RANGE BETWEEN",
+	"UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING",
+	"CURRENT ROW",
+	"PRECEDING", "FOLLOWING",
+	"OVER",
 	// foreign key keywords (FOREIGN KEY before FOREIGN if we ever add FOREIGN)
 	"FOREIGN KEY", "REFERENCES", "CONSTRAINT", "NO ACTION", "CASCADE", "RESTRICT",
 	";",

--- a/internal/parser/select.go
+++ b/internal/parser/select.go
@@ -71,6 +71,43 @@ func (p *parserItem) doParseSelect() error {
 			}
 			p.pop() // consume ")"
 
+			// SUM(col) OVER (...) — window aggregate, not a plain aggregate.
+			if strings.ToUpper(p.peek()) == "OVER" {
+				p.pop() // consume "OVER"
+				spec, err := p.parseWindowSpec()
+				if err != nil {
+					return p.errorf("at SELECT %s OVER: %v", strings.TrimSuffix(upperIdent, "("), err)
+				}
+				funcName := strings.TrimSuffix(upperIdent, "(")
+				kind := windowFuncKind(funcName)
+				if kind == 0 {
+					return p.errorf("at SELECT: unknown window function %q", funcName)
+				}
+				colExpr := &minisql.Expr{Column: colName}
+				wfExpr := &minisql.Expr{WindowFunc: &minisql.WindowFunc{Kind: kind, Arg: colExpr, Spec: spec}}
+				fieldName := funcName + "(" + colName + ") OVER (...)"
+				field := minisql.Field{Name: fieldName, Expr: wfExpr}
+				if strings.ToUpper(p.peek()) == "AS" {
+					p.pop()
+					alias := p.peek()
+					if !isIdentifier(alias) {
+						return p.errorf("at SELECT: expected alias after window function")
+					}
+					field.Alias = alias
+					p.pop()
+				}
+				if len(p.Aggregates) > 0 {
+					p.Aggregates = append(p.Aggregates, minisql.AggregateExpr{})
+				}
+				p.Fields = append(p.Fields, field)
+				if strings.ToUpper(p.peek()) == "FROM" {
+					p.step = stepSelectFrom
+					return nil
+				}
+				p.step = stepSelectComma
+				return nil
+			}
+
 			// Build synthetic field name e.g. "SUM(price)"
 			funcName := strings.TrimSuffix(upperIdent, "(")
 			fieldName := funcName + "(" + colName + ")"
@@ -123,8 +160,39 @@ func (p *parserItem) doParseSelect() error {
 
 		// Handle COUNT(*) special case — consume immediately.
 		if upperIdent == "COUNT(*)" {
-			p.Fields = append(p.Fields, minisql.Field{Name: identifier})
 			p.pop()
+
+			// COUNT(*) OVER (...) — window count.
+			if strings.ToUpper(p.peek()) == "OVER" {
+				p.pop() // consume "OVER"
+				spec, err := p.parseWindowSpec()
+				if err != nil {
+					return p.errorf("at SELECT COUNT(*) OVER: %v", err)
+				}
+				wfExpr := &minisql.Expr{WindowFunc: &minisql.WindowFunc{Kind: minisql.WindowCount, Spec: spec}}
+				field := minisql.Field{Name: "COUNT(*) OVER (...)", Expr: wfExpr}
+				if strings.ToUpper(p.peek()) == "AS" {
+					p.pop()
+					alias := p.peek()
+					if !isIdentifier(alias) {
+						return p.errorf("at SELECT: expected alias after COUNT(*) OVER")
+					}
+					field.Alias = alias
+					p.pop()
+				}
+				if len(p.Aggregates) > 0 {
+					p.Aggregates = append(p.Aggregates, minisql.AggregateExpr{})
+				}
+				p.Fields = append(p.Fields, field)
+				if strings.ToUpper(p.peek()) == "FROM" {
+					p.step = stepSelectFrom
+					return nil
+				}
+				p.step = stepSelectComma
+				return nil
+			}
+
+			p.Fields = append(p.Fields, minisql.Field{Name: identifier})
 			if len(p.Aggregates) > 0 {
 				p.Aggregates = append(p.Aggregates, minisql.AggregateExpr{})
 			}

--- a/internal/parser/window_test.go
+++ b/internal/parser/window_test.go
@@ -1,0 +1,227 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_WindowFunctions(t *testing.T) {
+	t.Parallel()
+
+	parse := func(t *testing.T, sql string) minisql.Statement {
+		t.Helper()
+		stmts, err := New().Parse(context.Background(), sql)
+		require.NoError(t, err)
+		require.Len(t, stmts, 1)
+		return stmts[0]
+	}
+
+	t.Run("ROW_NUMBER no partition", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT ROW_NUMBER() OVER (ORDER BY score DESC) AS rn FROM t;`)
+		require.Len(t, stmt.Fields, 1)
+		f := stmt.Fields[0]
+		assert.Equal(t, "rn", f.Alias)
+		require.NotNil(t, f.Expr)
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowRowNumber, f.Expr.WindowFunc.Kind)
+		spec := f.Expr.WindowFunc.Spec
+		assert.Empty(t, spec.PartitionBy)
+		require.Len(t, spec.OrderBy, 1)
+		assert.Equal(t, "score", spec.OrderBy[0].Field.Name)
+		assert.Equal(t, minisql.Desc, spec.OrderBy[0].Direction)
+	})
+
+	t.Run("ROW_NUMBER with partition", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT ROW_NUMBER() OVER (PARTITION BY dept ORDER BY score) AS rn FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		spec := f.Expr.WindowFunc.Spec
+		assert.Equal(t, []string{"dept"}, spec.PartitionBy)
+		require.Len(t, spec.OrderBy, 1)
+		assert.Equal(t, "score", spec.OrderBy[0].Field.Name)
+		assert.Equal(t, minisql.Asc, spec.OrderBy[0].Direction)
+	})
+
+	t.Run("RANK with partition", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT RANK() OVER (PARTITION BY dept ORDER BY score DESC) AS r FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowRank, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("DENSE_RANK", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT DENSE_RANK() OVER (ORDER BY score) AS dr FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowDenseRank, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("NTILE with argument", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT NTILE(4) OVER (ORDER BY score DESC) AS bucket FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowNtile, f.Expr.WindowFunc.Kind)
+		require.NotNil(t, f.Expr.WindowFunc.Arg)
+		assert.Equal(t, int64(4), f.Expr.WindowFunc.Arg.Literal)
+	})
+
+	t.Run("LAG with offset argument", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT LAG(score, 1) OVER (ORDER BY score) AS prev FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowLag, f.Expr.WindowFunc.Kind)
+		require.NotNil(t, f.Expr.WindowFunc.Arg)
+		assert.Equal(t, "score", f.Expr.WindowFunc.Arg.Column)
+		require.NotNil(t, f.Expr.WindowFunc.Arg2)
+		assert.Equal(t, int64(1), f.Expr.WindowFunc.Arg2.Literal)
+	})
+
+	t.Run("LEAD with offset", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT LEAD(score, 2) OVER (ORDER BY id) AS next2 FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowLead, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("FIRST_VALUE", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT FIRST_VALUE(score) OVER (PARTITION BY dept ORDER BY score DESC) AS top FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowFirstValue, f.Expr.WindowFunc.Kind)
+		require.NotNil(t, f.Expr.WindowFunc.Arg)
+		assert.Equal(t, "score", f.Expr.WindowFunc.Arg.Column)
+	})
+
+	t.Run("LAST_VALUE", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT LAST_VALUE(score) OVER (ORDER BY score) AS lv FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowLastValue, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("NTH_VALUE", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT NTH_VALUE(score, 2) OVER (ORDER BY score DESC) AS second FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowNthValue, f.Expr.WindowFunc.Kind)
+		require.NotNil(t, f.Expr.WindowFunc.Arg)
+		assert.Equal(t, "score", f.Expr.WindowFunc.Arg.Column)
+		require.NotNil(t, f.Expr.WindowFunc.Arg2)
+		assert.Equal(t, int64(2), f.Expr.WindowFunc.Arg2.Literal)
+	})
+
+	t.Run("SUM OVER partition", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT SUM(score) OVER (PARTITION BY dept) AS dept_total FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr)
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowSum, f.Expr.WindowFunc.Kind)
+		require.NotNil(t, f.Expr.WindowFunc.Arg)
+		assert.Equal(t, "score", f.Expr.WindowFunc.Arg.Column)
+		assert.Equal(t, []string{"dept"}, f.Expr.WindowFunc.Spec.PartitionBy)
+	})
+
+	t.Run("AVG OVER", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT AVG(score) OVER (ORDER BY id) AS running_avg FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowAvg, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("COUNT(*) OVER", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT COUNT(*) OVER () AS total FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr)
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowCount, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("MIN OVER", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT MIN(score) OVER (PARTITION BY dept) AS min_score FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowMin, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("MAX OVER", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT MAX(score) OVER (PARTITION BY dept) AS max_score FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		assert.Equal(t, minisql.WindowMax, f.Expr.WindowFunc.Kind)
+	})
+
+	t.Run("ROWS BETWEEN frame", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT SUM(score) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS roll FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		spec := f.Expr.WindowFunc.Spec
+		require.NotNil(t, spec.Frame)
+		assert.Equal(t, minisql.FrameRows, spec.Frame.Mode)
+		assert.Equal(t, minisql.FramePreceding, spec.Frame.Start.Kind)
+		assert.Equal(t, 1, spec.Frame.Start.Offset)
+		assert.Equal(t, minisql.FrameFollowing, spec.Frame.End.Kind)
+		assert.Equal(t, 1, spec.Frame.End.Offset)
+	})
+
+	t.Run("ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT SUM(score) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cs FROM t;`)
+		f := stmt.Fields[0]
+		require.NotNil(t, f.Expr.WindowFunc)
+		spec := f.Expr.WindowFunc.Spec
+		require.NotNil(t, spec.Frame)
+		assert.Equal(t, minisql.FrameUnboundedPreceding, spec.Frame.Start.Kind)
+		assert.Equal(t, minisql.FrameCurrentRow, spec.Frame.End.Kind)
+	})
+
+	t.Run("multiple window functions in same query", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT ROW_NUMBER() OVER (ORDER BY score DESC) AS rn, SUM(score) OVER (PARTITION BY dept) AS total FROM t;`)
+		require.Len(t, stmt.Fields, 2)
+		assert.Equal(t, minisql.WindowRowNumber, stmt.Fields[0].Expr.WindowFunc.Kind)
+		assert.Equal(t, minisql.WindowSum, stmt.Fields[1].Expr.WindowFunc.Kind)
+	})
+
+	t.Run("window mixed with regular fields", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT name, ROW_NUMBER() OVER (ORDER BY score) AS rn FROM t;`)
+		require.Len(t, stmt.Fields, 2)
+		assert.Equal(t, "name", stmt.Fields[0].Name)
+		assert.Nil(t, stmt.Fields[0].Expr)
+		require.NotNil(t, stmt.Fields[1].Expr)
+		assert.Equal(t, minisql.WindowRowNumber, stmt.Fields[1].Expr.WindowFunc.Kind)
+	})
+
+	t.Run("HasWindowFuncs true", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT ROW_NUMBER() OVER (ORDER BY id) AS rn FROM t;`)
+		assert.True(t, stmt.HasWindowFuncs())
+	})
+
+	t.Run("HasWindowFuncs false for plain select", func(t *testing.T) {
+		t.Parallel()
+		stmt := parse(t, `SELECT name, score FROM t;`)
+		assert.False(t, stmt.HasWindowFuncs())
+	})
+}


### PR DESCRIPTION
Implements the full SQL window function pipeline:

**Parser:**
- New reserved words: PARTITION BY, ROWS/RANGE BETWEEN, UNBOUNDED PRECEDING/FOLLOWING, CURRENT ROW, PRECEDING, FOLLOWING, OVER
- parseWindowSpec / parseWindowFrame / parseFrameBound in parser/expr.go
- OVER detection after ) in parseFuncCall (scalar window functions)
- OVER detection in SUM(/AVG(/MIN(/MAX( and COUNT(*) branches in doParseSelect
- isWindowFunction + windowFuncKind helpers

**IR:**
- window.go: WindowFuncKind, FrameMode, FrameBoundKind, FrameBound, WindowFrame, WindowSpec, WindowFunc types
- Expr.WindowFunc *WindowFunc field; windowFuncString for display; informative error in Eval if window expr reaches row-level evaluation
- Statement.HasWindowFuncs() zero-cost guard (loop over Fields)

**Execution:**
- selectWithWindowFuncs: materialise all base rows via SELECT *, compute window columns per partition, project output, apply ORDER BY / DISTINCT / LIMIT / OFFSET
- Full PARTITION BY hash grouping + ORDER BY sort per partition
- ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE, SUM, AVG, COUNT, MIN, MAX OVER
- Frame algorithms: default frame depends on ORDER BY presence (entire partition vs running accumulation); explicit ROWS/RANGE BETWEEN start/end bounds with PRECEDING/FOLLOWING/CURRENT ROW

**Tests:**
- 20 parser unit tests in internal/parser/window_test.go
- 21 e2e tests in e2e_tests/window_test.go covering all function kinds, partitioning, frames, WHERE/LIMIT interaction

**Benchmarks:** zero regressions; all alloc/op counts identical to prior baseline — HasWindowFuncs() guard costs nothing for existing queries.