### PR TITLE
Optimize inverted index write memory

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,78 @@
 # Benchmark Results
 
+### 2026-05-24 — Inverted-index write-path memory reduction
+
+**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26
+**Settings:** focused inverted-index DML run, `-benchmem`, `-count=1`
+**Branch:** `codex-inverted-index-memory-wins`
+
+Cumulative optimisations in this baseline:
+
+- **Append-only posting-block insert path**: when new row IDs are increasing and the target
+  posting block has room, MiniSQL now appends the delta-encoded posting bytes directly instead
+  of decoding, regrouping, and re-encoding the whole block.
+- **Full-text per-row term aggregation**: INSERT/DELETE maintenance now groups all positions
+  for the same row+term into one posting before touching the inverted index.
+- **Allocation-free inverted page fit checks**: entry/posting page fit checks use byte
+  accounting instead of allocating and marshaling a temporary 4 KiB page.
+- **Reusable JSON path escaper**: JSON inverted term generation reuses a package-level
+  `strings.Replacer` instead of rebuilding it for every path segment.
+
+Command:
+
+```bash
+LOG_LEVEL=warn go test -tags bench -bench='Benchmark(FullText|JSONInverted)_(BuildIndex|Insert_WithIndex|Update_WithIndex|Delete_WithIndex)$' -benchmem -run '^$' -count=1 -memprofile=/tmp/minisql_inverted_dml_after_mem.prof ./benchmarks/
+```
+
+#### Timing
+
+| Benchmark | minisql | sqlite |
+|---|---:|---:|
+| FullText_BuildIndex | 6.26 ms/op | 3.39 ms/op |
+| FullText_Insert_WithIndex | 152 µs/op | 134 µs/op |
+| FullText_Update_WithIndex | 80.1 µs/op | 144 µs/op |
+| FullText_Delete_WithIndex | 226 µs/op | 256 µs/op |
+| JSONInverted_BuildIndex | 5.87 ms/op | — |
+| JSONInverted_Insert_WithIndex | 158 µs/op | — |
+| JSONInverted_Update_WithIndex | 10.7 µs/op | — |
+| JSONInverted_Delete_WithIndex | 354 µs/op | — |
+
+#### Memory (B/op)
+
+| Benchmark | before | after | delta |
+|---|---:|---:|---:|
+| FullText_BuildIndex | 10.7 MiB | 3.0 MiB | −71% |
+| FullText_Insert_WithIndex | 203 KiB | 29.0 KiB | −86% |
+| FullText_Update_WithIndex | 43.3 KiB | 27.4 KiB | −37% |
+| FullText_Delete_WithIndex | 175 KiB | 141 KiB | −20% |
+| JSONInverted_BuildIndex | 55.3 MiB | 5.3 MiB | −90% |
+| JSONInverted_Insert_WithIndex | 1.66 MiB | 153 KiB | −91% |
+| JSONInverted_Update_WithIndex | 10.5 KiB | 9.9 KiB | −5% |
+| JSONInverted_Delete_WithIndex | 1.25 MiB | 1.13 MiB | −8% |
+
+#### Allocs/op
+
+| Benchmark | before | after | delta |
+|---|---:|---:|---:|
+| FullText_BuildIndex | 35,797 | 34,056 | −5% |
+| FullText_Insert_WithIndex | 822 | 226 | −73% |
+| FullText_Update_WithIndex | 231 | 245 | +6% |
+| FullText_Delete_WithIndex | 1,357 | 1,350 | −1% |
+| JSONInverted_BuildIndex | 143,587 | 85,895 | −40% |
+| JSONInverted_Insert_WithIndex | 526 | 214 | −59% |
+| JSONInverted_Update_WithIndex | 85 | 82 | −4% |
+| JSONInverted_Delete_WithIndex | 460 | 392 | −15% |
+
+#### Key observations
+
+The append-only path and allocation-free fit checks remove the worst insert/build allocation
+spikes from the shared inverted-index storage layer. The largest remaining allocation source
+is now delete maintenance, especially JSON deletes, because deletion still decodes existing
+posting blocks into `[]invertedPosting`, removes a row ID, and re-encodes the block. That
+remaining shape is the main evidence for the next segment/tombstone refactor.
+
+---
+
 ### 2026-05-24 — Window function implementation (no regressions)
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -1047,6 +1047,10 @@ func (idx *dedicatedInvertedIndex) insertPostingIntoTreeCell(ctx context.Context
 	}
 
 	block := leaf.InvertedPostPage.Blocks[blockIdx]
+	if updatedCell, ok, err := idx.appendPostingToTreeBlock(ctx, cell, leaf, blockIdx, block, posting); ok || err != nil {
+		return updatedCell, ok, err
+	}
+
 	mode, blockPostings, err := decodeInvertedPostingList(block.Payload)
 	if err != nil {
 		return invertedEntryCell{}, false, err
@@ -1091,6 +1095,56 @@ func (idx *dedicatedInvertedIndex) insertPostingIntoTreeCell(ctx context.Context
 	updatedCell := cell
 	updatedCell.DocFreq = uint32(int(updatedCell.DocFreq) + newDocFreq - oldDocFreq)
 	updatedCell.PostingCount = uint32(int(updatedCell.PostingCount) + int(newPostingCount) - int(oldPostingCount))
+	return updatedCell, true, nil
+}
+
+// appendPostingToTreeBlock extends the rightmost matching posting block without
+// decoding/re-encoding it. It handles the common INSERT/CREATE INDEX case where
+// row IDs arrive in increasing order.
+func (idx *dedicatedInvertedIndex) appendPostingToTreeBlock(
+	ctx context.Context,
+	cell invertedEntryCell,
+	leaf *Page,
+	blockIdx int,
+	block invertedPostingBlock,
+	posting invertedPosting,
+) (invertedEntryCell, bool, error) {
+	if posting.RowID <= block.LastRowID {
+		return invertedEntryCell{}, false, nil
+	}
+	if idx.mode == invertedPostingModePositions && len(posting.Positions) == 0 {
+		return invertedEntryCell{}, false, nil
+	}
+
+	appendPayload, postingCount := encodeTrailingInvertedPosting(idx.mode, block.LastRowID, posting)
+	if len(block.Payload)+len(appendPayload) > invertedPostingBlockPayloadMax {
+		return invertedEntryCell{}, false, nil
+	}
+	if invertedPostingPageUsedBytes(leaf.InvertedPostPage)+uint64(len(appendPayload)) > uint64(invertedPageBodySize(leaf.Index)) {
+		return invertedEntryCell{}, false, nil
+	}
+
+	page, err := idx.pager.ModifyPage(ctx, leaf.Index)
+	if err != nil {
+		return invertedEntryCell{}, false, fmt.Errorf("modify inverted posting leaf %d: %w", leaf.Index, err)
+	}
+	postingPage := page.InvertedPostPage
+	if postingPage == nil || postingPage.Header.Level != 0 || blockIdx >= len(postingPage.Blocks) {
+		return invertedEntryCell{}, false, fmt.Errorf("inverted posting page %d changed during append", leaf.Index)
+	}
+
+	block = postingPage.Blocks[blockIdx]
+	block.Payload = append(block.Payload, appendPayload...)
+	block.LastRowID = posting.RowID
+	block.PostingCount += postingCount
+	postingPage.Blocks[blockIdx] = block
+
+	if err := idx.refreshPostingAncestors(ctx, page.Index); err != nil {
+		return invertedEntryCell{}, false, err
+	}
+	updatedCell := cell
+	updatedCell.DocFreq += 1
+	updatedCell.PostingCount += postingCount
 	return updatedCell, true, nil
 }
 
@@ -2220,12 +2274,8 @@ func removeInvertedPosting(mode invertedPostingMode, postings []invertedPosting,
 
 // ensureInvertedEntryPageFits verifies an entry page can marshal into pageSize.
 func ensureInvertedEntryPageFits(page *invertedEntryPage, pageSize int) error {
-	buf := make([]byte, pageSize)
-	if err := page.Marshal(buf); err != nil {
-		if errors.Is(err, errInvertedIndexEntryPageFull) {
-			return err
-		}
-		return err
+	if invertedEntryPageUsedBytes(page) > uint64(pageSize) {
+		return errInvertedIndexEntryPageFull
 	}
 	return nil
 }
@@ -2257,8 +2307,10 @@ func invertedEntryPageUsedBytes(page *invertedEntryPage) uint64 {
 
 // ensureInvertedPostingPageFits verifies a posting page can marshal into pageSize.
 func ensureInvertedPostingPageFits(page *invertedPostingPage, pageSize int) error {
-	buf := make([]byte, pageSize)
-	return page.Marshal(buf)
+	if invertedPostingPageUsedBytes(page) > uint64(pageSize) {
+		return fmt.Errorf("inverted posting page has insufficient free space")
+	}
+	return nil
 }
 
 // invertedPostingPageUnderfull reports whether a posting page should be repaired after delete.

--- a/internal/minisql/inverted_posting.go
+++ b/internal/minisql/inverted_posting.go
@@ -75,6 +75,36 @@ func encodeGroupedInvertedPostingList(mode invertedPostingMode, grouped []invert
 	return buf, nil
 }
 
+// encodeTrailingInvertedPosting serializes one posting that follows prevRowID
+// inside an existing block payload. The caller guarantees posting.RowID is newer.
+func encodeTrailingInvertedPosting(mode invertedPostingMode, prevRowID RowID, posting invertedPosting) ([]byte, uint32) {
+	var tmp [binary.MaxVarintLen64]byte
+	buf := make([]byte, 0, binary.MaxVarintLen64*(2+len(posting.Positions)))
+
+	n := binary.PutUvarint(tmp[:], uint64(posting.RowID-prevRowID))
+	buf = append(buf, tmp[:n]...)
+	if mode == invertedPostingModeRowIDs {
+		return buf, 1
+	}
+
+	positions := append([]uint32(nil), posting.Positions...)
+	slices.Sort(positions)
+	positions = slices.Compact(positions)
+	n = binary.PutUvarint(tmp[:], uint64(len(positions)))
+	buf = append(buf, tmp[:n]...)
+	var prevPosition uint32
+	for i, position := range positions {
+		positionDelta := uint64(position)
+		if i > 0 {
+			positionDelta = uint64(position - prevPosition)
+		}
+		n = binary.PutUvarint(tmp[:], positionDelta)
+		buf = append(buf, tmp[:n]...)
+		prevPosition = position
+	}
+	return buf, uint32(len(positions))
+}
+
 // decodeInvertedPostingList decodes the v1 row-grouped posting codec and
 // returns the encoded mode together with sorted postings.
 func decodeInvertedPostingList(encoded []byte) (invertedPostingMode, []invertedPosting, error) {

--- a/internal/minisql/json_inverted.go
+++ b/internal/minisql/json_inverted.go
@@ -14,6 +14,13 @@ func jsonInvertedTermColumn() Column {
 	return Column{Name: "__json_term__", Kind: Varchar, Size: MaxIndexKeySize}
 }
 
+var jsonInvertedPathReplacer = strings.NewReplacer(
+	`\`, `\\`,
+	`.`, `\.`,
+	`[`, `\[`,
+	`]`, `\]`,
+)
+
 // jsonContains reports whether doc contains query using JSON subset semantics.
 // Objects must contain every queried key recursively, arrays must contain every
 // queried element, and scalar values must match by JSON type and value.
@@ -190,13 +197,7 @@ func joinJSONInvertedPath(parent, key string) string {
 // jsonInvertedPathSegment escapes path separator characters inside object keys
 // so similarly named paths generate different term strings.
 func jsonInvertedPathSegment(segment string) string {
-	replacer := strings.NewReplacer(
-		`\`, `\\`,
-		`.`, `\.`,
-		`[`, `\[`,
-		`]`, `\]`,
-	)
-	return replacer.Replace(segment)
+	return jsonInvertedPathReplacer.Replace(segment)
 }
 
 // jsonInvertedScalarTerm encodes a scalar JSON value with a type prefix, keeping

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -249,9 +249,9 @@ func (t *Table) insertFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 	if err != nil {
 		return err
 	}
-	for _, token := range tokens {
-		posting := invertedPosting{RowID: rowID, Positions: []uint32{token.Position}}
-		if err := secondaryIndex.InvertedIndex.Insert(ctx, token.Term, posting); err != nil {
+	postings := fullTextPostingsByTerm(rowID, tokens)
+	for term, posting := range postings {
+		if err := secondaryIndex.InvertedIndex.Insert(ctx, term, posting); err != nil {
 			return fmt.Errorf("failed to insert token for full-text index %s: %w", secondaryIndex.Name, err)
 		}
 	}
@@ -320,9 +320,9 @@ func (t *Table) deleteFullTextIndexKeys(ctx context.Context, secondaryIndex Seco
 	if err != nil {
 		return err
 	}
-	for _, token := range tokens {
-		posting := invertedPosting{RowID: rowID, Positions: []uint32{token.Position}}
-		if err := secondaryIndex.InvertedIndex.Delete(ctx, token.Term, posting); err != nil {
+	postings := fullTextPostingsByTerm(rowID, tokens)
+	for term, posting := range postings {
+		if err := secondaryIndex.InvertedIndex.Delete(ctx, term, posting); err != nil {
 			return fmt.Errorf("failed to delete token for full-text index %s: %w", secondaryIndex.Name, err)
 		}
 	}
@@ -334,6 +334,10 @@ func fullTextPostingsByTermForRow(secondaryIndex SecondaryIndex, rowID RowID, ro
 	if err != nil {
 		return nil, err
 	}
+	return fullTextPostingsByTerm(rowID, tokens), nil
+}
+
+func fullTextPostingsByTerm(rowID RowID, tokens []textSearchTokenPosition) map[string]invertedPosting {
 	postings := make(map[string]invertedPosting, len(tokens))
 	for _, token := range tokens {
 		posting := postings[token.Term]
@@ -346,7 +350,7 @@ func fullTextPostingsByTermForRow(secondaryIndex SecondaryIndex, rowID RowID, ro
 		posting.Positions = slices.Compact(posting.Positions)
 		postings[term] = posting
 	}
-	return postings, nil
+	return postings
 }
 
 func (t *Table) insertInvertedIndexKeys(ctx context.Context, secondaryIndex SecondaryIndex, rowID RowID, row Row) error {


### PR DESCRIPTION
**FTS/JSON index memory profiling immediate wins:**

1. Aggregate FTS per-row insert/delete by term.
insertFullTextIndexKeys and deleteFullTextIndexKeys currently call Insert/Delete once per token occurrence. They should build one invertedPosting{RowID, Positions} per term, like fullTextPostingsByTermForRow already does for update. This should reduce repeated decode/re-encode for repeated terms in a document.
2. Replace page-fit marshal checks with byte accounting.
ensureInvertedEntryPageFits and ensureInvertedPostingPageFits allocate a 4 KiB buffer and marshal just to answer “does this fit?”. Existing *_UsedBytes helpers are already close. This will not solve MiB-scale JSON insert alone, but it removes noisy churn across both indexes.
3. Hoist JSON path replacer.
jsonInvertedPathSegment creates a new strings.Replacer per path segment. In JSON profiles this showed up clearly. Make it package-level. Small code change, real but not architectural.
4. Add append-only fast path for increasing RowIDs.
This is the most important incremental step. For insert/build where posting.RowID > block.LastRowID, append encoded delta bytes directly to the last matching block if it fits. Avoid decodeInvertedPostingList, groupInvertedPostings, and makeInvertedPostingBlocks for the common “append newest row to term” case. This benefits both FTS and JSON.