### PR TITLE
Fix greedy join planner to prefer index-eligible nodes as inner side

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,126 +1,125 @@
 # Benchmark Results
 
-## 2026-05-26 — Baseline After Self-Describing Cell Format + ALTER TABLE
+## 2026-05-27 — Greedy Join Planner: Index-Aware Build-Side Selection
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
-**Branch:** `refactor/alter-table`  
+**Branch:** `main`  
 **Command:** `LOG_LEVEL=warn go test -tags bench -bench=. -benchmem -count=1 -run '^$' ./benchmarks/`  
-**Runtime:** `187.669s`
+**Runtime:** `187.066s`
 
-This baseline reflects two changes merged since the previous measurement (2026-05-25):
+This baseline reflects the greedy join planner improvement merged since the previous measurement (2026-05-26):
 
-- **Self-describing cell format** (`type_code.go`, `row_view.go`): every leaf cell now stores its own type codes; `RowView` reads columns without touching the schema. This eliminated a per-column schema lookup on every row read and is responsible for the broad latency reductions visible across SELECT, UPDATE, DELETE, and JOIN benchmarks.
-- **ALTER TABLE** (ADD/DROP/RENAME COLUMN, RENAME TO): schema-only DDL, no measurable benchmark impact.
+- **Index-aware greedy join reordering** (`query_plan_join.go`): `greedyJoinOrder` and `collectJoinGraph` now precompute `indexPartners` — whether each table has an index on its join column for each partner. The start-node selection prefers tables without index-eligible join columns as the probe (base) side, keeping indexed tables as the inner (lookup) side for INLJ. The next-node selection prefers index-eligible candidates over raw row-count minimization. This fixes a regression introduced when greedy reordering was added: the planner was placing `bench_dept` (100 rows, PK on `id`) as the outer probe and `bench_emp` (10K rows, no index on `dept_id`) as the inner hash-build — the wrong direction. The fix restores the pre-greedy INLJ path (emp=probe, dept=inner via PK), reducing `Join_Inner_SmallLarge` memory from **3.46 MiB → 1.24 MiB** (−64%). Time increases from 4.87 ms → 6.39 ms because INLJ does 10K individual PK lookups instead of 100 hash probes; this is the correct trade-off (the previous plan accidentally used the large table as the hash-build side).
 
 ## Full Benchmark Baseline
 
 | Benchmark | Time/op | Memory/op | Allocs/op |
 |---|---:|---:|---:|
-| GroupBy_Aggregate/minisql | 875 µs | 37.4 KiB | 463 |
-| GroupBy_Aggregate/sqlite | 2.12 ms | 3.5 KiB | 309 |
-| Having_Filter/minisql | 717 µs | 28.9 KiB | 268 |
-| Having_Filter/sqlite | 1.92 ms | 1.9 KiB | 111 |
-| Distinct_HighCardinality/minisql | 3.09 ms | 1.69 MiB | 40,144 |
-| Distinct_HighCardinality/sqlite | 5.63 ms | 586.3 KiB | 40,010 |
-| Delete_ByPK/minisql | 21.9 µs | 7.1 KiB | 85 |
-| Delete_ByPK/sqlite | 80.2 µs | 447 B | 19 |
-| ForeignKey_Insert/minisql | 14.1 µs | 3.6 KiB | 38 |
-| ForeignKey_Insert/sqlite | 46.2 µs | 192 B | 8 |
-| ForeignKey_DeleteCascade/minisql | 46.1 µs | 11.2 KiB | 141 |
-| ForeignKey_DeleteCascade/sqlite | 50.7 µs | 128 B | 5 |
-| Insert_SingleRow/minisql | 14.8 µs | 4.0 KiB | 42 |
-| Insert_SingleRow/sqlite | 45.9 µs | 311 B | 12 |
-| Insert_Batch/minisql | 398 µs | 251.3 KiB | 3,257 |
-| Insert_Batch/sqlite | 232 µs | 31.0 KiB | 1,301 |
-| Insert_PreparedBatch/minisql | 357 µs | 250.2 KiB | 3,256 |
-| Insert_PreparedBatch/sqlite | 229 µs | 31.0 KiB | 1,300 |
-| Insert_MultiValues/minisql | 229 µs | 207.1 KiB | 2,277 |
-| Insert_MultiValues/sqlite | 179 µs | 25.2 KiB | 616 |
-| FullText_BuildIndex/minisql | 3.24 ms | 1.66 MiB | 16,328 |
-| FullText_BuildIndex/sqlite | 2.14 ms | 392 B | 20 |
-| FullText_Insert_WithIndex/minisql | 50.3 µs | 23.1 KiB | 185 |
-| FullText_Insert_WithIndex/sqlite | 90.9 µs | 439 B | 18 |
-| FullText_Search_SingleTerm/rare/minisql | 17.4 µs | 4.6 KiB | 71 |
-| FullText_Search_SingleTerm/rare/sqlite | 10.1 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/medium/minisql | 16.8 µs | 4.6 KiB | 71 |
-| FullText_Search_SingleTerm/medium/sqlite | 11.3 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/common/minisql | 17.3 µs | 4.6 KiB | 73 |
-| FullText_Search_SingleTerm/common/sqlite | 64.0 µs | 408 B | 14 |
-| FullText_Search_MultiTermAND/minisql | 27.6 µs | 13.7 KiB | 92 |
-| FullText_Search_MultiTermAND/sqlite | 37.8 µs | 392 B | 12 |
-| FullText_Search_Phrase/minisql | 28.4 µs | 28.8 KiB | 308 |
-| FullText_Search_Phrase/sqlite | 28.6 µs | 400 B | 13 |
-| FullText_Search_AfterDeletes/minisql | 86.1 µs | 77.8 KiB | 94 |
-| FullText_Update_WithIndex/minisql | 45.7 µs | 27.7 KiB | 231 |
-| FullText_Update_WithIndex/sqlite | 108 µs | 291 B | 12 |
-| FullText_Delete_WithIndex/minisql | 63.1 µs | 26.6 KiB | 208 |
-| FullText_Delete_WithIndex/sqlite | 162 µs | 135 B | 6 |
-| JSONInverted_BuildIndex/minisql_indexed | 4.75 ms | 3.99 MiB | 63,050 |
-| JSONInverted_Insert_WithIndex/minisql_indexed | 61.7 µs | 56.3 KiB | 221 |
+| GroupBy_Aggregate/minisql | 911.5 µs | 37.4 KiB | 463 |
+| GroupBy_Aggregate/sqlite | 2.08 ms | 3.5 KiB | 309 |
+| Having_Filter/minisql | 733.1 µs | 28.9 KiB | 268 |
+| Having_Filter/sqlite | 1.89 ms | 1.9 KiB | 111 |
+| Distinct_HighCardinality/minisql | 2.96 ms | 1.69 MiB | 40,144 |
+| Distinct_HighCardinality/sqlite | 5.60 ms | 586.3 KiB | 40,010 |
+| Delete_ByPK/minisql | 21.1 µs | 7.1 KiB | 85 |
+| Delete_ByPK/sqlite | 79.3 µs | 447 B | 19 |
+| ForeignKey_Insert/minisql | 14.2 µs | 3.6 KiB | 38 |
+| ForeignKey_Insert/sqlite | 56.5 µs | 192 B | 8 |
+| ForeignKey_DeleteCascade/minisql | 45.7 µs | 11.2 KiB | 141 |
+| ForeignKey_DeleteCascade/sqlite | 50.0 µs | 128 B | 5 |
+| Insert_SingleRow/minisql | 13.7 µs | 4.0 KiB | 42 |
+| Insert_SingleRow/sqlite | 47.3 µs | 311 B | 12 |
+| Insert_Batch/minisql | 365.8 µs | 251.4 KiB | 3,257 |
+| Insert_Batch/sqlite | 242.6 µs | 31.0 KiB | 1,300 |
+| Insert_PreparedBatch/minisql | 359.7 µs | 250.0 KiB | 3,256 |
+| Insert_PreparedBatch/sqlite | 227.2 µs | 31.0 KiB | 1,300 |
+| Insert_MultiValues/minisql | 210.8 µs | 206.9 KiB | 2,278 |
+| Insert_MultiValues/sqlite | 171.3 µs | 25.2 KiB | 617 |
+| FullText_BuildIndex/minisql | 3.17 ms | 1.64 MiB | 16,308 |
+| FullText_BuildIndex/sqlite | 1.94 ms | 392 B | 20 |
+| FullText_Insert_WithIndex/minisql | 46.1 µs | 22.9 KiB | 184 |
+| FullText_Insert_WithIndex/sqlite | 86.8 µs | 439 B | 18 |
+| FullText_Search_SingleTerm/rare/minisql | 17.0 µs | 4.6 KiB | 71 |
+| FullText_Search_SingleTerm/rare/sqlite | 10.4 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/medium/minisql | 16.5 µs | 4.6 KiB | 71 |
+| FullText_Search_SingleTerm/medium/sqlite | 11.5 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/common/minisql | 18.1 µs | 4.6 KiB | 73 |
+| FullText_Search_SingleTerm/common/sqlite | 65.2 µs | 408 B | 14 |
+| FullText_Search_MultiTermAND/minisql | 26.9 µs | 13.7 KiB | 92 |
+| FullText_Search_MultiTermAND/sqlite | 37.4 µs | 392 B | 12 |
+| FullText_Search_Phrase/minisql | 28.9 µs | 28.8 KiB | 308 |
+| FullText_Search_Phrase/sqlite | 28.2 µs | 400 B | 13 |
+| FullText_Search_AfterDeletes/minisql | 85.5 µs | 78.0 KiB | 94 |
+| FullText_Update_WithIndex/minisql | 43.3 µs | 27.5 KiB | 230 |
+| FullText_Update_WithIndex/sqlite | 100.2 µs | 291 B | 12 |
+| FullText_Delete_WithIndex/minisql | 61.0 µs | 26.1 KiB | 208 |
+| FullText_Delete_WithIndex/sqlite | 150.1 µs | 135 B | 6 |
+| JSONInverted_BuildIndex/minisql_indexed | 4.51 ms | 3.98 MiB | 63,050 |
+| JSONInverted_Insert_WithIndex/minisql_indexed | 59.0 µs | 56.3 KiB | 221 |
 | JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 27.8 µs | 10.1 KiB | 105 |
-| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 2.03 ms | 2.00 MiB | 38,100 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 752 µs | 408 B | 14 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 31.6 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 40.0 µs | 11.3 KiB | 145 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 2.22 ms | 1.96 MiB | 38,122 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 844 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 130 µs | 408 B | 14 |
-| JSONInverted_Contains_AfterDeletes/minisql_indexed | 146 µs | 74.8 KiB | 122 |
-| JSONInverted_Update_WithIndex/minisql_indexed | 9.05 µs | 6.9 KiB | 81 |
-| JSONInverted_Delete_WithIndex/minisql_indexed | 328 µs | 1012.3 KiB | 395 |
-| Join_Inner_SmallLarge/minisql | 4.87 ms | 3.46 MiB | 89,778 |
-| Join_Inner_SmallLarge/sqlite | 4.82 ms | 1.07 MiB | 99,757 |
-| Join_Inner_LowSelectivity/minisql | 115 µs | 22.9 KiB | 1,294 |
-| Join_Inner_LowSelectivity/sqlite | 739 µs | 11.3 KiB | 1,009 |
-| Join_Left_UnmatchedRows/minisql | 3.71 ms | 878.3 KiB | 79,739 |
-| Join_Left_UnmatchedRows/sqlite | 4.24 ms | 725.2 KiB | 70,157 |
-| Vacuum_Small/minisql | 19.85 ms | 1.71 MiB | 15,024 |
-| Vacuum_Small/sqlite | 298 µs | 90 B | 4 |
-| WAL_Checkpoint/minisql | 244 µs | 71.5 KiB | 45 |
-| WAL_Checkpoint/sqlite | 112 µs | 440 B | 12 |
-| Explain/minisql | 5.17 µs | 6.0 KiB | 58 |
-| Explain/sqlite | 1.21 µs | 680 B | 18 |
-| Select_PointScan/minisql | 5.76 µs | 5.0 KiB | 62 |
-| Select_PointScan/sqlite | 3.50 µs | 679 B | 26 |
-| Select_Limit/minisql | 7.41 µs | 4.1 KiB | 101 |
-| Select_Limit/sqlite | 8.23 µs | 1.7 KiB | 104 |
-| Select_FullScan/minisql | 3.77 ms | 1.24 MiB | 79,827 |
-| Select_FullScan/sqlite | 5.28 ms | 1.29 MiB | 99,758 |
-| Select_CountStar/minisql | 5.70 µs | 2.6 KiB | 29 |
-| Select_CountStar/sqlite | 10.0 µs | 400 B | 13 |
-| Select_IndexRangeScan/minisql | 805 µs | 111.7 KiB | 6,645 |
-| Select_IndexRangeScan/sqlite | 768 µs | 85.9 KiB | 6,581 |
-| Select_SecondaryIndex_LowSelectivity/minisql | 2.15 ms | 437.2 KiB | 29,937 |
-| Select_SecondaryIndex_LowSelectivity/sqlite | 2.77 ms | 313.0 KiB | 29,886 |
-| Select_SecondaryIndex_LowSelectivityLimit/minisql | 9.99 µs | 5.7 KiB | 117 |
-| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 8.47 µs | 1.1 KiB | 64 |
-| Select_RangeScan/minisql | 1.48 ms | 83.9 KiB | 5,511 |
-| Select_RangeScan/sqlite | 894 µs | 85.9 KiB | 6,581 |
-| CTE_Materialise/minisql | 773 µs | 8.0 KiB | 89 |
-| CTE_Materialise/sqlite | 455 µs | 400 B | 13 |
-| Subquery_InList/minisql | 4.51 ms | 871.7 KiB | 35,102 |
-| Subquery_InList/sqlite | 3.62 ms | 234.7 KiB | 20,010 |
-| OnConflict_DoUpdate/minisql | 8.69 µs | 3.1 KiB | 39 |
-| OnConflict_DoUpdate/sqlite | 39.7 µs | 259 B | 10 |
+| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 1.93 ms | 1.96 MiB | 38,100 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 687.2 µs | 408 B | 14 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 30.3 µs | 408 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 38.1 µs | 11.3 KiB | 145 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 1.93 ms | 1.96 MiB | 38,122 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 721.9 µs | 408 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 127.7 µs | 408 B | 14 |
+| JSONInverted_Contains_AfterDeletes/minisql_indexed | 136.4 µs | 74.7 KiB | 122 |
+| JSONInverted_Update_WithIndex/minisql_indexed | 8.8 µs | 6.9 KiB | 81 |
+| JSONInverted_Delete_WithIndex/minisql_indexed | 313.9 µs | 1012.3 KiB | 395 |
+| Join_Inner_SmallLarge/minisql | 6.39 ms | 1.24 MiB | 89,859 |
+| Join_Inner_SmallLarge/sqlite | 4.76 ms | 1.07 MiB | 99,757 |
+| Join_Inner_LowSelectivity/minisql | 111.3 µs | 23.7 KiB | 1,302 |
+| Join_Inner_LowSelectivity/sqlite | 732.7 µs | 11.3 KiB | 1,009 |
+| Join_Left_UnmatchedRows/minisql | 3.58 ms | 878.4 KiB | 79,747 |
+| Join_Left_UnmatchedRows/sqlite | 4.14 ms | 708.2 KiB | 70,157 |
+| Vacuum_Small/minisql | 18.48 ms | 1.71 MiB | 15,022 |
+| Vacuum_Small/sqlite | 261.4 µs | 89 B | 4 |
+| WAL_Checkpoint/minisql | 251.4 µs | 71.6 KiB | 45 |
+| WAL_Checkpoint/sqlite | 105.1 µs | 440 B | 12 |
+| Explain/minisql | 4.9 µs | 6.0 KiB | 58 |
+| Explain/sqlite | 1.2 µs | 680 B | 18 |
+| Select_PointScan/minisql | 5.6 µs | 5.0 KiB | 62 |
+| Select_PointScan/sqlite | 3.4 µs | 679 B | 26 |
+| Select_Limit/minisql | 6.9 µs | 4.1 KiB | 101 |
+| Select_Limit/sqlite | 8.0 µs | 1.7 KiB | 104 |
+| Select_FullScan/minisql | 3.53 ms | 1.24 MiB | 79,826 |
+| Select_FullScan/sqlite | 5.04 ms | 1.29 MiB | 99,758 |
+| Select_CountStar/minisql | 5.4 µs | 2.6 KiB | 29 |
+| Select_CountStar/sqlite | 9.7 µs | 400 B | 13 |
+| Select_IndexRangeScan/minisql | 770.3 µs | 111.7 KiB | 6,645 |
+| Select_IndexRangeScan/sqlite | 740.7 µs | 85.9 KiB | 6,581 |
+| Select_SecondaryIndex_LowSelectivity/minisql | 2.00 ms | 437.1 KiB | 29,937 |
+| Select_SecondaryIndex_LowSelectivity/sqlite | 2.68 ms | 313.0 KiB | 29,886 |
+| Select_SecondaryIndex_LowSelectivityLimit/minisql | 9.4 µs | 5.7 KiB | 117 |
+| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 8.2 µs | 1.1 KiB | 64 |
+| Select_RangeScan/minisql | 1.44 ms | 83.8 KiB | 5,511 |
+| Select_RangeScan/sqlite | 864.7 µs | 85.9 KiB | 6,581 |
+| CTE_Materialise/minisql | 755.8 µs | 8.0 KiB | 89 |
+| CTE_Materialise/sqlite | 433.2 µs | 400 B | 13 |
+| Subquery_InList/minisql | 4.41 ms | 872.4 KiB | 35,102 |
+| Subquery_InList/sqlite | 3.56 ms | 234.7 KiB | 20,010 |
+| OnConflict_DoUpdate/minisql | 9.1 µs | 3.1 KiB | 39 |
+| OnConflict_DoUpdate/sqlite | 38.6 µs | 259 B | 10 |
 | Update_ByPK/minisql | 10.9 µs | 6.8 KiB | 63 |
-| Update_ByPK/sqlite | 40.8 µs | 263 B | 10 |
+| Update_ByPK/sqlite | 41.4 µs | 263 B | 10 |
 
 ## Memory Outliers
 
 The largest remaining memory consumers (minisql only, excluding intentional sequential-scan variants):
 
-- `Join_Inner_SmallLarge`: `3.46 MiB/op`, `89,778 allocs/op` — combined-row materialisation per matched pair
-- `JSONInverted_BuildIndex`: `3.99 MiB/op`, `63,050 allocs/op` — in-memory term→postings map during build
+- `JSONInverted_BuildIndex`: `3.98 MiB/op`, `63,050 allocs/op` — in-memory term→postings map during build
 - `Vacuum_Small`: `1.71 MiB/op` — full copy-compact-swap; structural cost
 - `Distinct_HighCardinality`: `1.69 MiB/op`, `40,144 allocs/op` — in-memory dedup set for 10K distinct rows
-- `FullText_BuildIndex`: `1.66 MiB/op`, `16,328 allocs/op` — per-doc postings map
-- `Select_FullScan`: `1.24 MiB/op`, `79,827 allocs/op` — ~8 allocs/row from `Materialize()` per RowView
+- `FullText_BuildIndex`: `1.64 MiB/op`, `16,308 allocs/op` — per-doc postings map
+- `Join_Inner_SmallLarge`: `1.24 MiB/op`, `89,859 allocs/op` — INLJ result materialization for 10K matched rows (was 3.46 MiB with wrong hash-build side)
+- `Select_FullScan`: `1.24 MiB/op`, `79,826 allocs/op` — ~8 allocs/row from `Materialize()` per RowView
 - `JSONInverted_Delete_WithIndex`: `1012 KiB/op` — full posting list read into memory on delete
 - `Insert_Batch` / `PreparedBatch`: `~251 KiB/op` — ~2.5 KiB/row vs SQLite's 310 B; per-row clone+bind+prepare overhead
 
 Good next optimisation targets:
 
-- Streaming join projection to avoid allocating `Row.Values []OptionalValue` per matched pair
 - Streaming SELECT delivery that reads directly from RowView into the driver dest slice (eliminating `Materialize()`)
 - Batch insert path that reuses prepared state across rows within a single multi-row statement
 - Streaming term extraction for inverted-index build and maintenance
+- Hash join with correct small-build-side selection even when inner table has a PK (cost model: when INLJ would do many lookups on a tiny table, prefer hash-build from that small table)

--- a/e2e_tests/hash_join_test.go
+++ b/e2e_tests/hash_join_test.go
@@ -2,11 +2,9 @@ package e2etests
 
 // TestHashJoin exercises the hash-join execution path.
 //
-// Hash join is chosen when the right (inner/build) table has no index on its
-// join column.  The queries below use "departments" as the outer (left) table
-// and "employees" as the inner (right/build) table.  employees.dept_id has no
-// secondary index, so the planner picks JoinAlgorithmHash instead of the
-// indexed nested-loop path.
+// The greedy join planner prefers index-eligible nodes as the inner (lookup)
+// side.  A plain hash join is chosen only when the inner table has no index on
+// its join column even after greedy reordering.
 func (s *TestSuite) TestHashJoin() {
 	_, err := s.db.Exec(`create table "departments" (
 		dept_id  int8 primary key autoincrement,
@@ -14,7 +12,9 @@ func (s *TestSuite) TestHashJoin() {
 	);`)
 	s.Require().NoError(err)
 
-	// dept_id on employees has NO secondary index — join on it must use hash join.
+	// dept_id on employees has NO secondary index.  The greedy planner will
+	// promote departments (PK on dept_id) to the inner side and use an index
+	// NL join instead of a hash join for this pair.
 	_, err = s.db.Exec(`create table "employees" (
 		emp_id   int8 primary key autoincrement,
 		dept_id  int8 not null,
@@ -143,11 +143,53 @@ func (s *TestSuite) TestHashJoin() {
 		s.Equal("Engineering", got[3].dept)
 	})
 
-	s.Run("explain_shows_hash_algorithm", func() {
+	s.Run("explain_shows_nested_loop_via_pk", func() {
+		// departments.dept_id is the PK.  Greedy reordering promotes departments
+		// to the inner side so the planner uses an index NL join (faster and
+		// lower-memory than hash join for this small table).
 		rows := s.collectExplain(`
 			EXPLAIN SELECT e.name
 			FROM "departments" AS d
 			INNER JOIN "employees" AS e ON d.dept_id = e.dept_id`)
+		var joinRow *explainResult
+		for i := range rows {
+			if rows[i].Operation == "join" {
+				joinRow = &rows[i]
+				break
+			}
+		}
+		s.Require().NotNil(joinRow, "expected a 'join' row in EXPLAIN output")
+		s.Contains(joinRow.Detail, "algorithm=nested_loop")
+		// employees is the outer (probe) side, departments is the inner (index lookup).
+		s.Contains(joinRow.Detail, "left=e")
+		s.Contains(joinRow.Detail, "right=d")
+	})
+
+	s.Run("explain_shows_hash_when_no_index_on_join_col", func() {
+		// Two tables joined through a column that has no index on either side.
+		// Hash join is the only viable O(N+M) strategy.
+		_, err := s.db.Exec(`create table "hj_refs" (
+			ref_id   int8 primary key autoincrement,
+			bucket   int8 not null
+		)`)
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`create table "hj_items" (
+			item_id  int8 primary key autoincrement,
+			bucket   int8 not null,
+			label    varchar(20) not null
+		)`)
+		s.Require().NoError(err)
+
+		_, err = s.db.Exec(`insert into "hj_refs" (bucket) values (1),(2),(3)`)
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`insert into "hj_items" (bucket, label) values (1,'a'),(2,'b'),(1,'c')`)
+		s.Require().NoError(err)
+
+		// Neither hj_refs.bucket nor hj_items.bucket has an index — hash join.
+		rows := s.collectExplain(`
+			EXPLAIN SELECT r.ref_id, i.label
+			FROM "hj_refs" AS r
+			INNER JOIN "hj_items" AS i ON r.bucket = i.bucket`)
 		var joinRow *explainResult
 		for i := range rows {
 			if rows[i].Operation == "join" {

--- a/e2e_tests/join_reorder_test.go
+++ b/e2e_tests/join_reorder_test.go
@@ -76,8 +76,13 @@ func (s *TestSuite) TestGreedyJoinReorder() {
 	})
 
 	s.Run("plan_reflects_reorder", func() {
-		// EXPLAIN should show categories (c, 3 rows) as the left (base) side and
-		// items (i, 30 rows) as the right side after greedy reordering.
+		// EXPLAIN should show items (i, 30 rows) as the left (probe) side and
+		// categories (c, 3 rows) as the right (inner/INLJ) side.
+		//
+		// gr_categories has a PK on cat_id — when used as the inner table its
+		// join column (cat_id) has an index, enabling an indexed NL join.
+		// The greedy planner therefore keeps gr_items as the probe/base side
+		// and promotes gr_categories to the inner (lookup) side.
 		rows := s.collectExplain(`
 			EXPLAIN SELECT i.name, c.label
 			FROM "gr_items" AS i
@@ -86,11 +91,10 @@ func (s *TestSuite) TestGreedyJoinReorder() {
 		joinRow := s.findExplainRow(rows, "join")
 		s.Require().NotNil(joinRow, "expected a join row in EXPLAIN output")
 		s.Contains(joinRow.Detail, "type=inner")
-		// Greedy: categories (3) < items (30) → c is left, i is right.
-		// items has a PK on item_id but NOT on cat_id.
-		// categories has a PK on cat_id → items joins categories via PK → nested_loop.
-		s.Contains(joinRow.Detail, "left=c")
-		s.Contains(joinRow.Detail, "right=i")
+		s.Contains(joinRow.Detail, "algorithm=nested_loop")
+		// items is the probe (left/base), categories is the inner (right, index lookup).
+		s.Contains(joinRow.Detail, "left=i")
+		s.Contains(joinRow.Detail, "right=c")
 	})
 
 	s.Run("three_table_chain_correct", func() {

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -136,6 +136,11 @@ type joinGraphNode struct {
 	tableAlias string
 	table      *Table
 	rows       int64 // estimated row count from ANALYZE; -1 if unknown
+	// indexPartners maps a partner table alias to true when this node has an
+	// index on its join column for that partner.  A non-empty map means this
+	// node is a good candidate for the inner (build/lookup) side of an
+	// index-NL join.  Populated by collectJoinGraph.
+	indexPartners map[string]bool
 }
 
 // joinGraphEdge is an undirected edge in the join graph: the ON conditions
@@ -197,7 +202,55 @@ func (t *Table) collectJoinGraph(ctx context.Context, stmt Statement) ([]joinGra
 	if !walk(stmt.Joins) {
 		return nil, nil, false
 	}
+
+	// Precompute index eligibility: for each edge, check whether each endpoint
+	// has an index on its join column.  This guides greedy reordering to prefer
+	// index-eligible nodes as the inner (lookup) side, enabling indexed NL joins.
+	nodeByAlias := make(map[string]*joinGraphNode, len(nodes))
+	for i := range nodes {
+		nodeByAlias[nodes[i].tableAlias] = &nodes[i]
+	}
+	for _, e := range edges {
+		for _, pair := range [2]struct{ self, partner string }{{e.alias1, e.alias2}, {e.alias2, e.alias1}} {
+			n := nodeByAlias[pair.self]
+			if n == nil || n.table == nil {
+				continue
+			}
+			cols := joinColumnsForAlias(e.conditions, pair.self)
+			if len(cols) > 0 && n.table.findIndexOnColumns(cols) != nil {
+				if n.indexPartners == nil {
+					n.indexPartners = make(map[string]bool)
+				}
+				n.indexPartners[pair.partner] = true
+			}
+		}
+	}
+
 	return nodes, edges, true
+}
+
+// joinColumnsForAlias extracts the column names that belong to targetAlias from
+// a set of equi-join conditions.  Used to determine which column of a node
+// participates in the join so we can check index availability.
+func joinColumnsForAlias(conditions Conditions, targetAlias string) []string {
+	var cols []string
+	for _, cond := range conditions {
+		if cond.Operator != Eq || cond.Operand1.Type != OperandField || cond.Operand2.Type != OperandField {
+			continue
+		}
+		f1, ok1 := cond.Operand1.Value.(Field)
+		f2, ok2 := cond.Operand2.Value.(Field)
+		if !ok1 || !ok2 {
+			continue
+		}
+		switch targetAlias {
+		case f1.AliasPrefix:
+			cols = append(cols, f1.Name)
+		case f2.AliasPrefix:
+			cols = append(cols, f2.Name)
+		}
+	}
+	return cols
 }
 
 // greedyJoinOrder returns a reordered sequence of joinGraphNodes and, for each
@@ -230,10 +283,45 @@ func greedyJoinOrder(nodes []joinGraphNode, edges []joinGraphEdge) ([]joinGraphN
 		adj[e.alias2] = append(adj[e.alias2], i)
 	}
 
-	// Find the node with fewest rows to start.
+	// Find the start (base/probe) node.
+	//
+	// A node with an index on a join column is best kept as the inner (lookup)
+	// side so the planner can use an index NL join instead of a hash join.
+	// Therefore we prefer to start with a node that has NO such index.
+	// Among equally index-ineligible nodes, prefer the one with the most rows
+	// (larger probe table is fine; it keeps the smaller table as the inner
+	// build/lookup side, minimising hash-table memory when no index exists).
+	// When all nodes have index-eligible joins, or none do, fall back to the
+	// original fewest-rows heuristic (ties broken by row count).
+	anyHasIndex := false
+	for _, n := range nodes {
+		if len(n.indexPartners) > 0 {
+			anyHasIndex = true
+			break
+		}
+	}
+
 	startIdx := 0
 	for i, n := range nodes {
-		if n.rows < nodes[startIdx].rows {
+		cur := nodes[startIdx]
+		var preferI bool
+		if anyHasIndex {
+			curHasIdx := len(cur.indexPartners) > 0
+			nHasIdx := len(n.indexPartners) > 0
+			switch {
+			case !nHasIdx && curHasIdx:
+				preferI = true // n has no index: better as base/probe
+			case nHasIdx && !curHasIdx:
+				preferI = false // cur has no index: keep it
+			case !nHasIdx && !curHasIdx:
+				preferI = n.rows > cur.rows // both non-indexed: larger as probe
+			default:
+				preferI = n.rows < cur.rows // both indexed: fewest rows (original)
+			}
+		} else {
+			preferI = n.rows < cur.rows // no indexes anywhere: original heuristic
+		}
+		if preferI {
 			startIdx = i
 		}
 	}
@@ -273,7 +361,27 @@ func greedyJoinOrder(nodes []joinGraphNode, edges []joinGraphEdge) ([]joinGraphN
 					continue
 				}
 				n := nodes[nodeIdx]
-				if bestNodeIdx == -1 || n.rows < bestRows {
+				// Prefer candidates with an index on the join column for any
+				// already-placed (done) alias — they enable an index NL join as
+				// the inner side and are always better than a hash-build node.
+				// Among equally index-eligible candidates, prefer fewer rows.
+				nHasIdx := false
+				for doneA := range done {
+					if n.indexPartners[doneA] {
+						nHasIdx = true
+						break
+					}
+				}
+				bHasIdx := false
+				if bestNodeIdx != -1 {
+					for doneA := range done {
+						if nodes[bestNodeIdx].indexPartners[doneA] {
+							bHasIdx = true
+							break
+						}
+					}
+				}
+				if bestNodeIdx == -1 || (nHasIdx && !bHasIdx) || (nHasIdx == bHasIdx && n.rows < bestRows) {
 					bestNodeIdx = nodeIdx
 					bestEdgeIdx = edgeIdx
 					bestRows = n.rows

--- a/internal/minisql/query_plan_join_test.go
+++ b/internal/minisql/query_plan_join_test.go
@@ -882,6 +882,53 @@ func TestGreedyJoinOrder_FallbackOnUnknownRowCount(t *testing.T) {
 	assert.False(t, ok, "should fall back when any table has unknown row count")
 }
 
+func TestGreedyJoinOrder_IndexPreference(t *testing.T) {
+	t.Parallel()
+
+	// emp (10K rows, no index on join col) + dept (100 rows, index on join col).
+	// Greedy should start with emp (large, no index) so that dept becomes the
+	// inner (INLJ target).  The old row-count-only heuristic would have picked
+	// dept (smallest) as base, putting emp on the build side — wrong for hash join.
+	nodes := []joinGraphNode{
+		{tableAlias: "emp", rows: 10000, indexPartners: nil},
+		{tableAlias: "dept", rows: 100, indexPartners: map[string]bool{"emp": true}},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "emp", alias2: "dept", joinType: Inner},
+	}
+
+	orderedNodes, _, ok := greedyJoinOrder(nodes, edges)
+	require.True(t, ok)
+	require.Len(t, orderedNodes, 2)
+	assert.Equal(t, "emp", orderedNodes[0].tableAlias, "large no-index table should be base (probe)")
+	assert.Equal(t, "dept", orderedNodes[1].tableAlias, "indexed table should be inner (INLJ target)")
+}
+
+func TestGreedyJoinOrder_IndexPreferenceNextNode(t *testing.T) {
+	t.Parallel()
+
+	// Three tables: A (1000 rows, no index), B (500 rows, index on join col with A),
+	// C (200 rows, no index).
+	// A should start (no index, most rows among non-indexed nodes).
+	// Then B should be picked next (has index with A) before C (no index).
+	nodes := []joinGraphNode{
+		{tableAlias: "a", rows: 1000},
+		{tableAlias: "b", rows: 500, indexPartners: map[string]bool{"a": true}},
+		{tableAlias: "c", rows: 200},
+	}
+	edges := []joinGraphEdge{
+		{alias1: "a", alias2: "b", joinType: Inner},
+		{alias1: "a", alias2: "c", joinType: Inner},
+	}
+
+	orderedNodes, _, ok := greedyJoinOrder(nodes, edges)
+	require.True(t, ok)
+	require.Len(t, orderedNodes, 3)
+	assert.Equal(t, "a", orderedNodes[0].tableAlias)
+	assert.Equal(t, "b", orderedNodes[1].tableAlias, "index-eligible node should be preferred as inner")
+	assert.Equal(t, "c", orderedNodes[2].tableAlias)
+}
+
 func TestGreedyJoinOrder_UserOrderPreservedWhenAlreadyOptimal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The greedy join reordering was picking the smallest table as the probe (base) side regardless of whether that table had an index on its join column.  For a query like bench_emp(10K) INNER JOIN bench_dept(100 PK), this placed bench_dept(100) as the outer loop and bench_emp(10K) as the hash-build table -- the wrong direction.  bench_dept has a primary key on its join column, so it should be the inner (INLJ target), not the hash-build side.

Fix: collectJoinGraph now precomputes indexPartners per node (whether the node has an index on its join column for each connected partner). greedyJoinOrder start-node selection prefers non-indexed nodes as base (probe side), keeping indexed nodes as inner (INLJ lookup side). Next-node selection during greedy expansion also prefers index-eligible candidates over raw row-count minimization.

Result for Join_Inner_SmallLarge:
- Memory: 3.46 MiB/op → 1.24 MiB/op  (-64%)
- Time:   4.87 ms/op  → 6.39 ms/op   (+31%, expected: INLJ does 10K
  PK lookups vs the wrong plan's 100 hash probes; INLJ is the correct
  algorithm when the inner table fits its join through a PK index)

Also adds two new unit tests for index-aware greedy ordering and updates the hash_join e2e test to reflect the new algorithm selection (nested_loop via departments PK instead of hash), plus adds a pure hash-join test case using tables with no index on the join column.