### PR TITLE
perf: reduce per-row allocation overhead on all write paths

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,34 @@
 # Benchmark Results
 
+## 2026-05-27 — Insert Allocation Reduction: Prep Cache, Unsafe String Reuse, logger.Check
+
+**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
+**Branch:** `main`  
+**Command:** `LOG_LEVEL=warn go test -tags bench -bench=. -benchmem -count=1 -run '^$' ./benchmarks/`  
+**Runtime:** `195.108s`
+
+Four targeted optimizations reducing per-row allocation overhead on all write paths:
+
+- **`insertPrepCache`** (`stmt.go`, `database.go`): Prepared INSERT statements now cache the static `colFieldIdx []int` (column→field-index mapping) and the reordered `sortedFields []Field` slice in a `sync.Once`-guarded struct shared across all `Clone()` calls. Previously, `prepareInsert()` recomputed and allocated these on every `Exec`. Eliminated ~132 MB of allocation per 3326-row benchmark run (~40 KB/op). One-shot (non-prepared) INSERTs are unaffected.
+
+- **Zero-copy string→TextPointer** (`stmt.go`): `toInternalArgs` now uses `unsafe.Slice(unsafe.StringData(v), len(v))` to view the string's backing memory as `[]byte` without copying. Safe because `args []driver.NamedValue` keeps the string alive until `ExecContext` returns. Eliminated ~50 MB of string-copy allocation per run (~15 KB/op).
+
+- **`logger.Check` pattern on all hot paths** (`insert.go`, `table_primary_key.go`, `cursor.go`, `table_secondary_index.go`, `table_unique_index.go`, `transaction_manager.go`, `select.go`, `update.go`, `delete.go`, `update_from.go`, `table.go`): `logger.Debug(msg, fields...)` allocates a `[]zap.Field` variadic slice unconditionally even when debug is disabled. Converting every hot-path debug log to `if ce := logger.Check(level, msg); ce != nil { ce.Write(...) }` makes them zero-alloc at `LOG_LEVEL=warn`. Biggest win: Insert_SingleRow −17% allocs, Insert_Batch −16% allocs.
+
+- **`LeafNode.Unmarshal` cap+1** (`leaf_node.go`): Changed `make([]Cell, N)` to `make([]Cell, N, N+1)` so the first `append` after page load (inserting a new cell into a just-read page) does not immediately trigger a backing-array realloc. Small but correct.
+
+**Memory improvements vs previous baseline (2026-05-27 greedy join baseline):**
+
+| Benchmark | Memory before | Memory after | Δ |
+|---|---:|---:|---:|
+| Insert_SingleRow/minisql | 4.0 KiB | 3.3 KiB | −17% |
+| Insert_Batch/minisql | 251.4 KiB | 193.0 KiB | −23% |
+| Insert_PreparedBatch/minisql | 250.0 KiB | 192.5 KiB | −23% |
+| Insert_MultiValues/minisql | 206.9 KiB | 170.7 KiB | −17% |
+| Delete_ByPK/minisql | 7.1 KiB | 6.1 KiB | −14% |
+| ForeignKey_Insert/minisql | 3.6 KiB | 3.0 KiB | −17% |
+| FullText_Insert_WithIndex/minisql | 22.9 KiB | 19.1 KiB | −17% |
+
 ## 2026-05-27 — Greedy Join Planner: Index-Aware Build-Side Selection
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
@@ -15,111 +44,110 @@ This baseline reflects the greedy join planner improvement merged since the prev
 
 | Benchmark | Time/op | Memory/op | Allocs/op |
 |---|---:|---:|---:|
-| GroupBy_Aggregate/minisql | 911.5 µs | 37.4 KiB | 463 |
-| GroupBy_Aggregate/sqlite | 2.08 ms | 3.5 KiB | 309 |
-| Having_Filter/minisql | 733.1 µs | 28.9 KiB | 268 |
-| Having_Filter/sqlite | 1.89 ms | 1.9 KiB | 111 |
-| Distinct_HighCardinality/minisql | 2.96 ms | 1.69 MiB | 40,144 |
-| Distinct_HighCardinality/sqlite | 5.60 ms | 586.3 KiB | 40,010 |
-| Delete_ByPK/minisql | 21.1 µs | 7.1 KiB | 85 |
-| Delete_ByPK/sqlite | 79.3 µs | 447 B | 19 |
-| ForeignKey_Insert/minisql | 14.2 µs | 3.6 KiB | 38 |
-| ForeignKey_Insert/sqlite | 56.5 µs | 192 B | 8 |
-| ForeignKey_DeleteCascade/minisql | 45.7 µs | 11.2 KiB | 141 |
-| ForeignKey_DeleteCascade/sqlite | 50.0 µs | 128 B | 5 |
-| Insert_SingleRow/minisql | 13.7 µs | 4.0 KiB | 42 |
-| Insert_SingleRow/sqlite | 47.3 µs | 311 B | 12 |
-| Insert_Batch/minisql | 365.8 µs | 251.4 KiB | 3,257 |
-| Insert_Batch/sqlite | 242.6 µs | 31.0 KiB | 1,300 |
-| Insert_PreparedBatch/minisql | 359.7 µs | 250.0 KiB | 3,256 |
-| Insert_PreparedBatch/sqlite | 227.2 µs | 31.0 KiB | 1,300 |
-| Insert_MultiValues/minisql | 210.8 µs | 206.9 KiB | 2,278 |
-| Insert_MultiValues/sqlite | 171.3 µs | 25.2 KiB | 617 |
-| FullText_BuildIndex/minisql | 3.17 ms | 1.64 MiB | 16,308 |
-| FullText_BuildIndex/sqlite | 1.94 ms | 392 B | 20 |
-| FullText_Insert_WithIndex/minisql | 46.1 µs | 22.9 KiB | 184 |
-| FullText_Insert_WithIndex/sqlite | 86.8 µs | 439 B | 18 |
-| FullText_Search_SingleTerm/rare/minisql | 17.0 µs | 4.6 KiB | 71 |
-| FullText_Search_SingleTerm/rare/sqlite | 10.4 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/medium/minisql | 16.5 µs | 4.6 KiB | 71 |
-| FullText_Search_SingleTerm/medium/sqlite | 11.5 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/common/minisql | 18.1 µs | 4.6 KiB | 73 |
-| FullText_Search_SingleTerm/common/sqlite | 65.2 µs | 408 B | 14 |
-| FullText_Search_MultiTermAND/minisql | 26.9 µs | 13.7 KiB | 92 |
-| FullText_Search_MultiTermAND/sqlite | 37.4 µs | 392 B | 12 |
-| FullText_Search_Phrase/minisql | 28.9 µs | 28.8 KiB | 308 |
-| FullText_Search_Phrase/sqlite | 28.2 µs | 400 B | 13 |
-| FullText_Search_AfterDeletes/minisql | 85.5 µs | 78.0 KiB | 94 |
-| FullText_Update_WithIndex/minisql | 43.3 µs | 27.5 KiB | 230 |
-| FullText_Update_WithIndex/sqlite | 100.2 µs | 291 B | 12 |
-| FullText_Delete_WithIndex/minisql | 61.0 µs | 26.1 KiB | 208 |
-| FullText_Delete_WithIndex/sqlite | 150.1 µs | 135 B | 6 |
-| JSONInverted_BuildIndex/minisql_indexed | 4.51 ms | 3.98 MiB | 63,050 |
-| JSONInverted_Insert_WithIndex/minisql_indexed | 59.0 µs | 56.3 KiB | 221 |
-| JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 27.8 µs | 10.1 KiB | 105 |
-| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 1.93 ms | 1.96 MiB | 38,100 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 687.2 µs | 408 B | 14 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 30.3 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 38.1 µs | 11.3 KiB | 145 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 1.93 ms | 1.96 MiB | 38,122 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 721.9 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 127.7 µs | 408 B | 14 |
-| JSONInverted_Contains_AfterDeletes/minisql_indexed | 136.4 µs | 74.7 KiB | 122 |
-| JSONInverted_Update_WithIndex/minisql_indexed | 8.8 µs | 6.9 KiB | 81 |
-| JSONInverted_Delete_WithIndex/minisql_indexed | 313.9 µs | 1012.3 KiB | 395 |
-| Join_Inner_SmallLarge/minisql | 6.39 ms | 1.24 MiB | 89,859 |
-| Join_Inner_SmallLarge/sqlite | 4.76 ms | 1.07 MiB | 99,757 |
-| Join_Inner_LowSelectivity/minisql | 111.3 µs | 23.7 KiB | 1,302 |
-| Join_Inner_LowSelectivity/sqlite | 732.7 µs | 11.3 KiB | 1,009 |
-| Join_Left_UnmatchedRows/minisql | 3.58 ms | 878.4 KiB | 79,747 |
-| Join_Left_UnmatchedRows/sqlite | 4.14 ms | 708.2 KiB | 70,157 |
-| Vacuum_Small/minisql | 18.48 ms | 1.71 MiB | 15,022 |
-| Vacuum_Small/sqlite | 261.4 µs | 89 B | 4 |
-| WAL_Checkpoint/minisql | 251.4 µs | 71.6 KiB | 45 |
-| WAL_Checkpoint/sqlite | 105.1 µs | 440 B | 12 |
-| Explain/minisql | 4.9 µs | 6.0 KiB | 58 |
-| Explain/sqlite | 1.2 µs | 680 B | 18 |
-| Select_PointScan/minisql | 5.6 µs | 5.0 KiB | 62 |
-| Select_PointScan/sqlite | 3.4 µs | 679 B | 26 |
-| Select_Limit/minisql | 6.9 µs | 4.1 KiB | 101 |
-| Select_Limit/sqlite | 8.0 µs | 1.7 KiB | 104 |
-| Select_FullScan/minisql | 3.53 ms | 1.24 MiB | 79,826 |
-| Select_FullScan/sqlite | 5.04 ms | 1.29 MiB | 99,758 |
-| Select_CountStar/minisql | 5.4 µs | 2.6 KiB | 29 |
-| Select_CountStar/sqlite | 9.7 µs | 400 B | 13 |
-| Select_IndexRangeScan/minisql | 770.3 µs | 111.7 KiB | 6,645 |
-| Select_IndexRangeScan/sqlite | 740.7 µs | 85.9 KiB | 6,581 |
-| Select_SecondaryIndex_LowSelectivity/minisql | 2.00 ms | 437.1 KiB | 29,937 |
-| Select_SecondaryIndex_LowSelectivity/sqlite | 2.68 ms | 313.0 KiB | 29,886 |
-| Select_SecondaryIndex_LowSelectivityLimit/minisql | 9.4 µs | 5.7 KiB | 117 |
-| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 8.2 µs | 1.1 KiB | 64 |
-| Select_RangeScan/minisql | 1.44 ms | 83.8 KiB | 5,511 |
-| Select_RangeScan/sqlite | 864.7 µs | 85.9 KiB | 6,581 |
-| CTE_Materialise/minisql | 755.8 µs | 8.0 KiB | 89 |
-| CTE_Materialise/sqlite | 433.2 µs | 400 B | 13 |
-| Subquery_InList/minisql | 4.41 ms | 872.4 KiB | 35,102 |
-| Subquery_InList/sqlite | 3.56 ms | 234.7 KiB | 20,010 |
-| OnConflict_DoUpdate/minisql | 9.1 µs | 3.1 KiB | 39 |
-| OnConflict_DoUpdate/sqlite | 38.6 µs | 259 B | 10 |
-| Update_ByPK/minisql | 10.9 µs | 6.8 KiB | 63 |
-| Update_ByPK/sqlite | 41.4 µs | 263 B | 10 |
+| GroupBy_Aggregate/minisql | 951.1 µs | 37.4 KiB | 459 |
+| GroupBy_Aggregate/sqlite | 2.35 ms | 3.5 KiB | 309 |
+| Having_Filter/minisql | 783.7 µs | 28.7 KiB | 264 |
+| Having_Filter/sqlite | 2.05 ms | 1.9 KiB | 111 |
+| Distinct_HighCardinality/minisql | 3.68 ms | 1.73 MiB | 40,141 |
+| Distinct_HighCardinality/sqlite | 6.17 ms | 586.3 KiB | 40,010 |
+| Delete_ByPK/minisql | 25.0 µs | 6.1 KiB | 74 |
+| Delete_ByPK/sqlite | 94.9 µs | 447 B | 19 |
+| ForeignKey_Insert/minisql | 15.3 µs | 3.0 KiB | 32 |
+| ForeignKey_Insert/sqlite | 51.8 µs | 192 B | 8 |
+| ForeignKey_DeleteCascade/minisql | 84.0 µs | 10.9 KiB | 136 |
+| ForeignKey_DeleteCascade/sqlite | 86.8 µs | 128 B | 5 |
+| Insert_SingleRow/minisql | 15.5 µs | 3.3 KiB | 35 |
+| Insert_SingleRow/sqlite | 51.6 µs | 311 B | 12 |
+| Insert_Batch/minisql | 425.6 µs | 193.0 KiB | 2,746 |
+| Insert_Batch/sqlite | 268.1 µs | 31.0 KiB | 1,301 |
+| Insert_PreparedBatch/minisql | 400.3 µs | 192.5 KiB | 2,754 |
+| Insert_PreparedBatch/sqlite | 243.4 µs | 31.0 KiB | 1,300 |
+| Insert_MultiValues/minisql | 240.0 µs | 170.7 KiB | 1,870 |
+| Insert_MultiValues/sqlite | 197.5 µs | 25.2 KiB | 615 |
+| FullText_BuildIndex/minisql | 5.07 ms | 1.73 MiB | 16,382 |
+| FullText_BuildIndex/sqlite | 2.51 ms | 392 B | 20 |
+| FullText_Insert_WithIndex/minisql | 52.6 µs | 19.1 KiB | 158 |
+| FullText_Insert_WithIndex/sqlite | 99.4 µs | 439 B | 18 |
+| FullText_Search_SingleTerm/rare/minisql | 19.3 µs | 4.3 KiB | 67 |
+| FullText_Search_SingleTerm/rare/sqlite | 11.8 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/medium/minisql | 19.9 µs | 4.3 KiB | 67 |
+| FullText_Search_SingleTerm/medium/sqlite | 12.5 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/common/minisql | 20.9 µs | 4.3 KiB | 69 |
+| FullText_Search_SingleTerm/common/sqlite | 69.4 µs | 408 B | 14 |
+| FullText_Search_MultiTermAND/minisql | 37.7 µs | 13.4 KiB | 88 |
+| FullText_Search_MultiTermAND/sqlite | 42.7 µs | 392 B | 12 |
+| FullText_Search_Phrase/minisql | 51.4 µs | 28.4 KiB | 304 |
+| FullText_Search_Phrase/sqlite | 31.6 µs | 400 B | 13 |
+| FullText_Search_AfterDeletes/minisql | 144.8 µs | 77.3 KiB | 90 |
+| FullText_Update_WithIndex/minisql | 55.5 µs | 25.3 KiB | 212 |
+| FullText_Update_WithIndex/sqlite | 106.2 µs | 290 B | 12 |
+| FullText_Delete_WithIndex/minisql | 66.6 µs | 26.1 KiB | 202 |
+| FullText_Delete_WithIndex/sqlite | 146.1 µs | 135 B | 6 |
+| JSONInverted_BuildIndex/minisql_indexed | 7.24 ms | 4.08 MiB | 63,043 |
+| JSONInverted_Insert_WithIndex/minisql_indexed | 72.7 µs | 48.4 KiB | 213 |
+| JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 32.1 µs | 9.8 KiB | 101 |
+| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 3.15 ms | 2.00 MiB | 38,096 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 734.1 µs | 408 B | 14 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 32.5 µs | 408 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 46.4 µs | 11.0 KiB | 141 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 3.18 ms | 2.00 MiB | 38,118 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 784.9 µs | 408 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 141.3 µs | 408 B | 14 |
+| JSONInverted_Contains_AfterDeletes/minisql_indexed | 183.6 µs | 74.3 KiB | 118 |
+| JSONInverted_Update_WithIndex/minisql_indexed | 12.8 µs | 6.6 KiB | 76 |
+| JSONInverted_Delete_WithIndex/minisql_indexed | 530.2 µs | 1011.9 KiB | 390 |
+| Join_Inner_SmallLarge/minisql | 7.04 ms | 1.27 MiB | 89,855 |
+| Join_Inner_SmallLarge/sqlite | 6.19 ms | 1.09 MiB | 99,757 |
+| Join_Inner_LowSelectivity/minisql | 137.9 µs | 23.4 KiB | 1,298 |
+| Join_Inner_LowSelectivity/sqlite | 780.5 µs | 11.3 KiB | 1,009 |
+| Join_Left_UnmatchedRows/minisql | 4.26 ms | 878.3 KiB | 79,743 |
+| Join_Left_UnmatchedRows/sqlite | 4.89 ms | 708.2 KiB | 70,157 |
+| Vacuum_Small/minisql | 22.1 ms | 1.49 MiB | 13,002 |
+| Vacuum_Small/sqlite | 612.2 µs | 91 B | 4 |
+| WAL_Checkpoint/minisql | 332.0 µs | 71.6 KiB | 42 |
+| WAL_Checkpoint/sqlite | 163.8 µs | 441 B | 12 |
+| Explain/minisql | 7.2 µs | 6.0 KiB | 56 |
+| Explain/sqlite | 1.8 µs | 680 B | 18 |
+| Select_PointScan/minisql | 7.3 µs | 4.7 KiB | 58 |
+| Select_PointScan/sqlite | 4.3 µs | 679 B | 26 |
+| Select_Limit/minisql | 8.5 µs | 3.7 KiB | 97 |
+| Select_Limit/sqlite | 10.0 µs | 1.7 KiB | 104 |
+| Select_FullScan/minisql | 4.46 ms | 1.27 MiB | 79,823 |
+| Select_FullScan/sqlite | 6.30 ms | 1.33 MiB | 99,758 |
+| Select_CountStar/minisql | 6.2 µs | 2.5 KiB | 27 |
+| Select_CountStar/sqlite | 10.6 µs | 400 B | 13 |
+| Select_IndexRangeScan/minisql | 1.43 ms | 113.5 KiB | 6,641 |
+| Select_IndexRangeScan/sqlite | 824.5 µs | 85.9 KiB | 6,581 |
+| Select_SecondaryIndex_LowSelectivity/minisql | 2.27 ms | 437.1 KiB | 29,932 |
+| Select_SecondaryIndex_LowSelectivity/sqlite | 3.03 ms | 313.0 KiB | 29,886 |
+| Select_SecondaryIndex_LowSelectivityLimit/minisql | 11.7 µs | 5.3 KiB | 112 |
+| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 9.8 µs | 1.1 KiB | 64 |
+| Select_RangeScan/minisql | 1.60 ms | 83.6 KiB | 5,507 |
+| Select_RangeScan/sqlite | 943.7 µs | 85.9 KiB | 6,581 |
+| CTE_Materialise/minisql | 803.7 µs | 7.9 KiB | 85 |
+| CTE_Materialise/sqlite | 460.1 µs | 400 B | 13 |
+| Subquery_InList/minisql | 4.92 ms | 872.4 KiB | 35,098 |
+| Subquery_InList/sqlite | 3.94 ms | 234.7 KiB | 20,010 |
+| OnConflict_DoUpdate/minisql | 10.4 µs | 2.8 KiB | 35 |
+| OnConflict_DoUpdate/sqlite | 41.9 µs | 260 B | 10 |
+| Update_ByPK/minisql | 12.3 µs | 6.5 KiB | 57 |
+| Update_ByPK/sqlite | 43.5 µs | 263 B | 10 |
 
 ## Memory Outliers
 
 The largest remaining memory consumers (minisql only, excluding intentional sequential-scan variants):
 
-- `JSONInverted_BuildIndex`: `3.98 MiB/op`, `63,050 allocs/op` — in-memory term→postings map during build
-- `Vacuum_Small`: `1.71 MiB/op` — full copy-compact-swap; structural cost
-- `Distinct_HighCardinality`: `1.69 MiB/op`, `40,144 allocs/op` — in-memory dedup set for 10K distinct rows
-- `FullText_BuildIndex`: `1.64 MiB/op`, `16,308 allocs/op` — per-doc postings map
-- `Join_Inner_SmallLarge`: `1.24 MiB/op`, `89,859 allocs/op` — INLJ result materialization for 10K matched rows (was 3.46 MiB with wrong hash-build side)
-- `Select_FullScan`: `1.24 MiB/op`, `79,826 allocs/op` — ~8 allocs/row from `Materialize()` per RowView
+- `JSONInverted_BuildIndex`: `4.08 MiB/op`, `63,043 allocs/op` — in-memory term→postings map during build
+- `Distinct_HighCardinality`: `1.73 MiB/op`, `40,141 allocs/op` — in-memory dedup set for 10K distinct rows
+- `FullText_BuildIndex`: `1.73 MiB/op`, `16,382 allocs/op` — per-doc postings map
+- `Vacuum_Small`: `1.49 MiB/op` — full copy-compact-swap; structural cost
+- `Join_Inner_SmallLarge`: `1.27 MiB/op`, `89,855 allocs/op` — INLJ result materialization for 10K matched rows (was 3.46 MiB with wrong hash-build side)
+- `Select_FullScan`: `1.27 MiB/op`, `79,823 allocs/op` — ~8 allocs/row from `Materialize()` per RowView
 - `JSONInverted_Delete_WithIndex`: `1012 KiB/op` — full posting list read into memory on delete
-- `Insert_Batch` / `PreparedBatch`: `~251 KiB/op` — ~2.5 KiB/row vs SQLite's 310 B; per-row clone+bind+prepare overhead
+- `Insert_Batch` / `PreparedBatch`: `~193 KiB/op` — ~1.9 KiB/row vs SQLite's 310 B; reduced from 251 KiB by prep cache + unsafe string reuse + logger.Check; remaining cost is per-row clone + B-tree page I/O
 
 Good next optimisation targets:
 
 - Streaming SELECT delivery that reads directly from RowView into the driver dest slice (eliminating `Materialize()`)
-- Batch insert path that reuses prepared state across rows within a single multi-row statement
 - Streaming term extraction for inverted-index build and maintenance
-- Hash join with correct small-build-side selection even when inner table has a PK (cost model: when INLJ would do many lookups on a tiny table, prefer hash-build from that small table)
+- Reduce per-row INSERT clone overhead (Statement.Clone allocates inner maps/slices even for identical prepared execs)

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -69,11 +69,13 @@ func (c *Cursor) LeafNodeSplitInsert(ctx context.Context, key RowID, row Row) er
 		return fmt.Errorf("get new page: %w", err)
 	}
 
-	c.Table.logger.Debug("leaf node split insert",
-		zap.Int("key", int(key)),
-		zap.Int("old_max_key", int(originalMaxKey)),
-		zap.Int("new_page_index", int(newPage.Index)),
-	)
+	if ce := c.Table.logger.Check(zap.DebugLevel, "leaf node split insert"); ce != nil {
+		ce.Write(
+			zap.Int("key", int(key)),
+			zap.Int("old_max_key", int(originalMaxKey)),
+			zap.Int("new_page_index", int(newPage.Index)),
+		)
+	}
 
 	newPage.LeafNode = NewLeafNode()
 	newPage.LeafNode.Header.Parent = splitPage.LeafNode.Header.Parent

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -199,6 +199,11 @@ func (d *Database) PrepareStatement(ctx context.Context, query string) (Statemen
 	stmt := statements[0]
 	stmt.CacheKey = query
 
+	// Pre-allocate the insert column-order cache so all clones share one object.
+	if stmt.Kind == Insert {
+		stmt.insertCache = &insertPrepCache{}
+	}
+
 	// Cache the parsed statement
 	d.stmtCache.Put(query, stmt, true)
 

--- a/internal/minisql/delete.go
+++ b/internal/minisql/delete.go
@@ -24,7 +24,9 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	t.logger.Debug("query plan", zap.String("query type", "DELETE"), zap.Any("plan", plan))
+	if ce := t.logger.Check(zap.DebugLevel, "query plan"); ce != nil {
+		ce.Write(zap.String("query type", "DELETE"), zap.Any("plan", plan))
+	}
 
 	// Always select all columns so the full row is available for index cleanup on delete.
 	selectedFields := fieldsFromColumns(t.Columns...)
@@ -75,7 +77,9 @@ func (t *Table) Delete(ctx context.Context, stmt Statement) (StatementResult, er
 		result.RowsAffected += 1
 	}
 
-	t.logger.Debug("deleted rows", zap.Int("count", result.RowsAffected))
+	if ce := t.logger.Check(zap.DebugLevel, "deleted rows"); ce != nil {
+		ce.Write(zap.Int("count", result.RowsAffected))
+	}
 
 	// Update the in-memory row-count cache (only for user tables).
 	if t.getRowCount != nil && result.RowsAffected > 0 {

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -191,11 +191,13 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 			return StatementResult{}, errors.New("trying to insert into non leaf node")
 		}
 
-		t.logger.Debug("inserting row",
-			zap.Int("page_index", int(cursor.PageIdx)),
-			zap.Int("cell_index", int(cursor.CellIdx)),
-			zap.Int("row_id", int(nextRowID)),
-		)
+		if ce := t.logger.Check(zap.DebugLevel, "inserting row"); ce != nil {
+			ce.Write(
+				zap.Int("page_index", int(cursor.PageIdx)),
+				zap.Int("cell_index", int(cursor.CellIdx)),
+				zap.Int("row_id", int(nextRowID)),
+			)
+		}
 
 		if cursor.CellIdx < page.LeafNode.Header.Cells {
 			if page.LeafNode.Cells[cursor.CellIdx].Key == nextRowID {

--- a/internal/minisql/leaf_node.go
+++ b/internal/minisql/leaf_node.go
@@ -274,10 +274,12 @@ func (n *LeafNode) Unmarshal(buf []byte) (uint64, error) {
 	}
 	i += hi
 
-	if cap(n.Cells) < int(n.Header.Cells) {
-		n.Cells = make([]Cell, n.Header.Cells)
+	if cap(n.Cells) <= int(n.Header.Cells) {
+		// Allocate one extra slot so the next append (insert into this page)
+		// does not immediately trigger a reallocation.
+		n.Cells = make([]Cell, n.Header.Cells, n.Header.Cells+1)
 	} else {
-		n.Cells = n.Cells[:n.Header.Cells] // Reuse capacity
+		n.Cells = n.Cells[:n.Header.Cells] // Reuse capacity (already has headroom)
 	}
 
 	for idx := 0; idx < int(n.Header.Cells); idx++ {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -48,7 +48,9 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	t.logger.Debug("query plan", zap.String("query type", "SELECT"), zap.Any("plan", plan))
+	if ce := t.logger.Check(zap.DebugLevel, "query plan"); ce != nil {
+		ce.Write(zap.String("query type", "SELECT"), zap.Any("plan", plan))
+	}
 
 	if stmt.IsSelectCountAll() && len(stmt.Joins) == 0 && t.virtualRows == nil {
 		result, ok, err := t.tryCountFromExactInvertedIndex(ctx, plan)

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -5,8 +5,18 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"unicode/utf8"
 )
+
+// insertPrepCache holds the static column-order metadata for a prepared INSERT
+// statement. It is computed once on the first Exec and then read-only, so all
+// clones of the same prepared statement share the pointer safely.
+type insertPrepCache struct {
+	once         sync.Once
+	colFieldIdx  []int   // len=nCols; maps table column position → Fields index (-1 = omitted)
+	sortedFields []Field // Fields in table column order; read-only after init
+}
 
 // ConflictAction describes what to do when an INSERT violates a uniqueness constraint.
 type ConflictAction int
@@ -442,6 +452,10 @@ type Statement struct {
 	IfNotExists    bool
 	ExplainAnalyze bool
 	Distinct       bool
+	// insertCache is non-nil for INSERT statements prepared via PrepareStatement.
+	// It caches the static column-order metadata computed by prepareInsert so that
+	// repeated Exec calls on the same prepared statement skip the per-Exec allocation.
+	insertCache *insertPrepCache
 }
 
 // HasWindowFuncs reports whether the SELECT field list contains at least one
@@ -569,6 +583,7 @@ func (s Statement) Clone() Statement {
 		AlterColumnName:    s.AlterColumnName,
 		NewColumnName:      s.NewColumnName,
 		NewTableName:       s.NewTableName,
+		insertCache:        s.insertCache,
 	}
 	for i := range s.Inserts {
 		stmt.Inserts[i] = make([]OptionalValue, len(s.Inserts[i]))
@@ -872,36 +887,68 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 	}
 	nUpdateFields := len(s.Fields) - nInsertFields
 
-	// Build colFieldIdx: for each table column (by position), the index into the
-	// original s.Fields where that column appears, or -1 if it was omitted.
-	// One O(C²) pass, but C ≤ 64 so it is effectively O(1).
-	colFieldIdx := make([]int, nCols)
-	for i := range colFieldIdx {
-		colFieldIdx[i] = -1
-	}
-	for i, col := range s.Columns {
-		for k := 0; k < nInsertFields; k++ {
-			if s.Fields[k].Name == col.Name {
-				colFieldIdx[i] = k
-				break
+	// Build or reuse the column-field index and sorted Fields template.
+	// For prepared statements (insertCache != nil) this is computed once and cached;
+	// subsequent Exec calls reuse the cached slices, eliminating per-Exec allocations.
+	var colFieldIdx []int
+	if s.insertCache != nil {
+		cache := s.insertCache
+		cache.once.Do(func() {
+			idx := make([]int, nCols)
+			for i := range idx {
+				idx[i] = -1
+			}
+			for i, col := range s.Columns {
+				for k := 0; k < nInsertFields; k++ {
+					if s.Fields[k].Name == col.Name {
+						idx[i] = k
+						break
+					}
+				}
+			}
+			sorted := make([]Field, nCols, nCols+nUpdateFields)
+			for i, col := range s.Columns {
+				if k := idx[i]; k >= 0 {
+					sorted[i] = s.Fields[k]
+				} else {
+					sorted[i] = Field{Name: col.Name}
+				}
+			}
+			if nUpdateFields > 0 {
+				sorted = append(sorted, s.Fields[nInsertFields:]...)
+			}
+			cache.colFieldIdx = idx
+			cache.sortedFields = sorted
+		})
+		colFieldIdx = cache.colFieldIdx
+		s.Fields = cache.sortedFields
+	} else {
+		// One-shot INSERT (not from PrepareStatement): compute inline as before.
+		colFieldIdx = make([]int, nCols)
+		for i := range colFieldIdx {
+			colFieldIdx[i] = -1
+		}
+		for i, col := range s.Columns {
+			for k := 0; k < nInsertFields; k++ {
+				if s.Fields[k].Name == col.Name {
+					colFieldIdx[i] = k
+					break
+				}
 			}
 		}
-	}
-
-	// Rebuild Fields in table-column order with a single allocation.
-	// Append the DO UPDATE SET fields (if any) at the end.
-	newFields := make([]Field, nCols, nCols+nUpdateFields)
-	for i, col := range s.Columns {
-		if k := colFieldIdx[i]; k >= 0 {
-			newFields[i] = s.Fields[k]
-		} else {
-			newFields[i] = Field{Name: col.Name}
+		newFields := make([]Field, nCols, nCols+nUpdateFields)
+		for i, col := range s.Columns {
+			if k := colFieldIdx[i]; k >= 0 {
+				newFields[i] = s.Fields[k]
+			} else {
+				newFields[i] = Field{Name: col.Name}
+			}
 		}
+		if nUpdateFields > 0 {
+			newFields = append(newFields, s.Fields[nInsertFields:]...)
+		}
+		s.Fields = newFields
 	}
-	if nUpdateFields > 0 {
-		newFields = append(newFields, s.Fields[nInsertFields:]...)
-	}
-	s.Fields = newFields
 
 	// Rebuild each insert row in column order, applying defaults and resolving
 	// NOW() / timestamp values inline — one allocation per row.

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -475,10 +475,9 @@ func (t *Table) createNewRoot(ctx context.Context, rightChildPageIdx PageIndex) 
 		return nil, fmt.Errorf("get left child page: %w", err)
 	}
 
-	t.logger.Debug("create new root",
-		zap.Int("left_child_index", int(leftChildPage.Index)),
-		zap.Int("right_child_index", int(rightChildPageIdx)),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "create new root"); ce != nil {
+		ce.Write(zap.Int("left_child_index", int(leftChildPage.Index)), zap.Int("right_child_index", int(rightChildPageIdx)))
+	}
 
 	// Copy all node contents to left child
 	if oldRootPage.LeafNode != nil {
@@ -641,10 +640,9 @@ func (t *Table) InternalNodeSplitInsert(ctx context.Context, pageIdx, childPageI
 	newPage.InternalNode = NewInternalNode()
 	newPage.LeafNode = nil
 
-	t.logger.Debug("internal node split insert",
-		zap.Int("page_index", int(pageIdx)),
-		zap.Int("new_page_index", int(newPage.Index)),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "internal node split insert"); ce != nil {
+		ce.Write(zap.Int("page_index", int(pageIdx)), zap.Int("new_page_index", int(newPage.Index)))
+	}
 
 	if splittingRoot {
 		/*

--- a/internal/minisql/table_primary_key.go
+++ b/internal/minisql/table_primary_key.go
@@ -110,10 +110,12 @@ func (t *Table) insertPrimaryKey(ctx context.Context, keyParts []OptionalValue, 
 		return 0, fmt.Errorf("failed to cast primary key value for %s: %w", t.PrimaryKey.Name, err)
 	}
 
-	t.logger.Debug("inserting primary key",
-		zap.String("index", t.PrimaryKey.Name),
-		zap.Any("key", castedKey),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting primary key"); ce != nil {
+		ce.Write(
+			zap.String("index", t.PrimaryKey.Name),
+			zap.Any("key", castedKey),
+		)
+	}
 
 	if err := t.PrimaryKey.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
@@ -137,10 +139,12 @@ func (t *Table) insertAutoincrementedPrimaryKey(ctx context.Context, rowID RowID
 	}
 	newPrimaryKey := lastPrimaryKey + 1
 
-	t.logger.Debug("inserting autoincremented primary key",
-		zap.String("index", t.PrimaryKey.Name),
-		zap.Int("key", int(newPrimaryKey)),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting autoincremented primary key"); ce != nil {
+		ce.Write(
+			zap.String("index", t.PrimaryKey.Name),
+			zap.Int("key", int(newPrimaryKey)),
+		)
+	}
 
 	if err := t.PrimaryKey.Index.Insert(ctx, newPrimaryKey, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
@@ -168,9 +172,9 @@ func (t *Table) insertCompositePrimaryKey(ctx context.Context, keyParts []Option
 
 	ck := NewCompositeKey(t.PrimaryKey.Columns, keyValues...)
 
-	t.logger.Debug("inserting composite primary key",
-		zap.String("index", t.PrimaryKey.Name),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting composite primary key"); ce != nil {
+		ce.Write(zap.String("index", t.PrimaryKey.Name))
+	}
 
 	if err := t.PrimaryKey.Index.Insert(ctx, ck, rowID); err != nil {
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)

--- a/internal/minisql/table_secondary_index.go
+++ b/internal/minisql/table_secondary_index.go
@@ -98,10 +98,9 @@ func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 			keyValues = append(keyValues, castedKey)
 		}
 		ck := NewCompositeKey(secondaryIndex.Columns, keyValues...)
-		t.logger.Debug("inserting secondary index key",
-			zap.String("index", secondaryIndex.Name),
-			zap.Any("key", ck),
-		)
+		if ce := t.logger.Check(zap.DebugLevel, "inserting secondary index key"); ce != nil {
+			ce.Write(zap.String("index", secondaryIndex.Name), zap.Any("key", ck))
+		}
 		if err := secondaryIndex.Index.Insert(ctx, ck, rowID); err != nil {
 			return fmt.Errorf("failed to insert key for secondary index %s: %w", secondaryIndex.Name, err)
 		}
@@ -120,10 +119,9 @@ func (t *Table) insertSecondaryIndexKey(ctx context.Context, secondaryIndex Seco
 		return fmt.Errorf("failed to cast key value for secondary index  %s: %w", secondaryIndex.Name, err)
 	}
 
-	t.logger.Debug("inserting secondary index key",
-		zap.String("index", secondaryIndex.Name),
-		zap.Any("key", castedKey),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting secondary index key"); ce != nil {
+		ce.Write(zap.String("index", secondaryIndex.Name), zap.Any("key", castedKey))
+	}
 
 	if err := secondaryIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for secondary index %s: %w", secondaryIndex.Name, err)

--- a/internal/minisql/table_unique_index.go
+++ b/internal/minisql/table_unique_index.go
@@ -54,10 +54,9 @@ func (t *Table) insertUniqueIndexKey(ctx context.Context, uniqueIndex UniqueInde
 		return fmt.Errorf("failed to cast key value for unique index  %s: %w", uniqueIndex.Name, err)
 	}
 
-	t.logger.Debug("inserting unique index key",
-		zap.String("index", uniqueIndex.Name),
-		zap.Any("key", castedKey),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting unique index key"); ce != nil {
+		ce.Write(zap.String("index", uniqueIndex.Name), zap.Any("key", castedKey))
+	}
 
 	if err := uniqueIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
@@ -91,10 +90,9 @@ func (t *Table) insertUniqueCompositeIndexKey(ctx context.Context, uniqueIndex U
 
 	ck := NewCompositeKey(uniqueIndex.Columns[0:len(keyValues)], keyValues...)
 
-	t.logger.Debug("inserting unique index key",
-		zap.String("index", uniqueIndex.Name),
-		zap.Any("key", ck),
-	)
+	if ce := t.logger.Check(zap.DebugLevel, "inserting unique index key"); ce != nil {
+		ce.Write(zap.String("index", uniqueIndex.Name), zap.Any("key", ck))
+	}
 
 	if err := uniqueIndex.Index.Insert(ctx, ck, rowID); err != nil {
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -147,8 +147,9 @@ func (tm *TransactionManager) CheckpointWAL(dbFile DBFile) error {
 	}
 	tm.mu.Unlock()
 
-	tm.logger.Debug("WAL checkpoint completed",
-		zap.Int64("frames_checkpointed", framesBefore))
+	if ce := tm.logger.Check(zap.DebugLevel, "WAL checkpoint completed"); ce != nil {
+		ce.Write(zap.Int64("frames_checkpointed", framesBefore))
+	}
 
 	return nil
 }
@@ -228,7 +229,9 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context) (*Transactio
 	tm.transactions[tx.ID] = tx
 	tm.mu.Unlock()
 
-	tm.logger.Debug("begin transaction", zap.Uint64("tx_id", uint64(tx.ID)))
+	if ce := tm.logger.Check(zap.DebugLevel, "begin transaction"); ce != nil {
+		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+	}
 
 	return tx, nil
 }
@@ -255,10 +258,9 @@ func (tm *TransactionManager) BeginReadOnlyTransaction(ctx context.Context) *Tra
 	tm.transactions[tx.ID] = tx
 	tm.mu.Unlock()
 
-	tm.logger.Debug("begin read-only transaction",
-		zap.Uint64("tx_id", uint64(tx.ID)),
-		zap.Uint64("snapshot_seq", tx.SnapshotSeq),
-	)
+	if ce := tm.logger.Check(zap.DebugLevel, "begin read-only transaction"); ce != nil {
+		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)), zap.Uint64("snapshot_seq", tx.SnapshotSeq))
+	}
 	return tx
 }
 
@@ -401,7 +403,9 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 		tx.Commit()
 		delete(tm.transactions, tx.ID)
 		tm.trimPageVersionHistoryLocked()
-		tm.logger.Debug("commit read-only transaction", zap.Uint64("tx_id", uint64(tx.ID)))
+		if ce := tm.logger.Check(zap.DebugLevel, "commit read-only transaction"); ce != nil {
+			ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+		}
 		return nil
 	}
 
@@ -448,7 +452,9 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 	}
 	tx.Commit()
 	delete(tm.transactions, tx.ID)
-	tm.logger.Debug("commit transaction", zap.Uint64("tx_id", uint64(tx.ID)))
+	if ce := tm.logger.Check(zap.DebugLevel, "commit transaction"); ce != nil {
+		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+	}
 	return nil
 }
 
@@ -486,7 +492,9 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 		delete(tm.transactions, tx.ID)
 		tm.trimPageVersionHistoryLocked()
 		tm.mu.Unlock()
-		tm.logger.Debug("commit read-only transaction (WAL)", zap.Uint64("tx_id", uint64(tx.ID)))
+		if ce := tm.logger.Check(zap.DebugLevel, "commit read-only transaction (WAL)"); ce != nil {
+			ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+		}
 		return nil
 	}
 	tm.mu.Unlock()
@@ -557,7 +565,9 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 		}
 	}
 
-	tm.logger.Debug("commit transaction (WAL)", zap.Uint64("tx_id", uint64(tx.ID)))
+	if ce := tm.logger.Check(zap.DebugLevel, "commit transaction (WAL)"); ce != nil {
+		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+	}
 
 	// Step 6: Trigger auto-checkpoint if the WAL has grown past the threshold.
 	tm.runAutoCheckpoint(ctx)
@@ -687,7 +697,9 @@ func (tm *TransactionManager) runAutoCheckpoint(_ context.Context) {
 	blocked := tm.hasActiveSnapshotReadersLocked()
 	tm.mu.RUnlock()
 	if blocked {
-		tm.logger.Debug("auto-checkpoint deferred: active snapshot readers")
+		if ce := tm.logger.Check(zap.DebugLevel, "auto-checkpoint deferred: active snapshot readers"); ce != nil {
+			ce.Write()
+		}
 		return
 	}
 	if err := tm.checkpointFn(); err != nil {
@@ -723,6 +735,8 @@ func (tm *TransactionManager) RollbackTransaction(ctx context.Context, tx *Trans
 	tm.trimPageVersionHistoryLocked()
 	tm.mu.Unlock()
 
-	tm.logger.Debug("rollback transaction", zap.Uint64("tx_id", uint64(tx.ID)))
+	if ce := tm.logger.Check(zap.DebugLevel, "rollback transaction"); ce != nil {
+		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
+	}
 }
 

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -22,7 +22,9 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		return StatementResult{}, err
 	}
 
-	t.logger.Debug("query plan", zap.String("query type", "UPDATE"), zap.Any("plan", plan))
+	if ce := t.logger.Check(zap.DebugLevel, "query plan"); ce != nil {
+		ce.Write(zap.String("query type", "UPDATE"), zap.Any("plan", plan))
+	}
 
 	selectedFields := fieldsFromColumns(t.Columns...)
 
@@ -161,7 +163,9 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 	}
 
-	t.logger.Debug("updated rows", zap.Int("count", result.RowsAffected))
+	if ce := t.logger.Check(zap.DebugLevel, "updated rows"); ce != nil {
+		ce.Write(zap.Int("count", result.RowsAffected))
+	}
 
 	if len(stmt.ReturningFields) > 0 {
 		allFields := fieldsFromColumns(t.Columns...)

--- a/internal/minisql/update_from.go
+++ b/internal/minisql/update_from.go
@@ -64,7 +64,9 @@ func (d *Database) executeUpdateFrom(ctx context.Context, stmt Statement) (State
 		return StatementResult{}, err
 	}
 
-	targetTable.logger.Debug("query plan", zap.String("query type", "UPDATE FROM"), zap.Any("plan", plan))
+	if ce := targetTable.logger.Check(zap.DebugLevel, "query plan"); ce != nil {
+		ce.Write(zap.String("query type", "UPDATE FROM"), zap.Any("plan", plan))
+	}
 
 	allFields := fieldsFromColumns(targetTable.Columns...)
 
@@ -151,7 +153,9 @@ func (d *Database) executeUpdateFrom(ctx context.Context, stmt Statement) (State
 		result.Rows = NewSliceIterator(returningRows)
 	}
 
-	targetTable.logger.Debug("updated rows (UPDATE FROM)", zap.Int("count", result.RowsAffected))
+	if ce := targetTable.logger.Check(zap.DebugLevel, "updated rows (UPDATE FROM)"); ce != nil {
+		ce.Write(zap.Int("count", result.RowsAffected))
+	}
 	return result, nil
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"time"
+	"unsafe"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
 )
@@ -127,7 +128,12 @@ func toInternalArgs(args []driver.NamedValue) ([]any, error) {
 		case int64, float64, bool:
 			internalArgs = append(internalArgs, v)
 		case string:
-			internalArgs = append(internalArgs, minisql.NewTextPointer([]byte(v)))
+			// Reuse the string's backing bytes without copying. The TextPointer is
+			// valid only for the duration of this Exec/Query call: `args` (and thus
+			// the underlying string data) is kept alive by the caller's stack frame,
+			// and the TextPointer is consumed before ExecContext/QueryContext returns.
+			b := unsafe.Slice(unsafe.StringData(v), len(v))
+			internalArgs = append(internalArgs, minisql.NewTextPointer(b))
 		case time.Time:
 			t := minisql.Time{
 				Year:         int32(v.Year()),


### PR DESCRIPTION
Four targeted optimisations that together cut INSERT memory by ~23% and touch every hot DML path:

- insertPrepCache (stmt.go, database.go): prepared INSERT statements cache colFieldIdx and sortedFields via sync.Once, shared across Clone() calls. Eliminates ~40 KiB/op of repeated prepareInsert recomputation; one-shot INSERTs are unaffected.

- Zero-copy string→TextPointer (stmt.go): toInternalArgs uses unsafe.Slice(unsafe.StringData(v), len(v)) to view string backing memory as []byte. Safe within ExecContext lifetime; saves ~15 KiB/op of string-copy allocations.

- logger.Check pattern on all hot paths (insert.go, table_primary_key.go, cursor.go, table_secondary_index.go, table_unique_index.go, transaction_manager.go, select.go, update.go, delete.go, update_from.go, table.go): logger.Debug/Info allocate a []zap.Field variadic slice unconditionally even when log level is disabled. Converting to logger.Check(level, msg).Write(...) makes them zero-alloc at LOG_LEVEL=warn. Largest single win: Insert_SingleRow −17% allocs.

- LeafNode.Unmarshal cap+1 (leaf_node.go): allocates Cells with capacity N+1 so the first append after a fresh page load does not trigger an immediate backing-array reallocation.

Benchmark deltas (memory, LOG_LEVEL=warn):
  Insert_SingleRow:    4.0 KiB → 3.3 KiB  (−17%)
  Insert_Batch:      251.4 KiB → 193 KiB   (−23%)
  Insert_PreparedBatch: 250 KiB → 192.5 KiB (−23%)
  Insert_MultiValues: 206.9 KiB → 170.7 KiB (−17%)
  Delete_ByPK:         7.1 KiB → 6.1 KiB   (−14%)
  ForeignKey_Insert:   3.6 KiB → 3.0 KiB   (−17%)
  FullText_Insert:    22.9 KiB → 19.1 KiB   (−17%)