### PR TITLE
perf: reduce UPDATE/indexed-query allocation overhead

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,32 @@
 # Benchmark Results
 
+## 2026-05-27 — Update/Query Planning Allocation Reduction
+
+**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
+**Branch:** `main`  
+**Command:** `LOG_LEVEL=warn go test -tags bench -bench=. -benchmem -count=1 -run '^$' ./benchmarks/`  
+**Runtime:** `210.164s`
+
+Four targeted optimizations benefiting all write paths and all indexed queries:
+
+- **`matchedConditions []bool` in `tryMatchIndex`** (`query_plan.go`): Replaced `map[int]bool` with `[]bool` indexed by condition position. Condition indices are contiguous 0..len(group)-1, so a slice is correct and avoids map bucket allocations entirely. For a single-condition WHERE clause (the common case), the slice is 1 byte and stack-allocatable. Added `numMatched int` to `indexMatch` to preserve the count of matched conditions without relying on `len()`. Affects every query that uses index-equality planning — UPDATE, DELETE, SELECT with indexed WHERE, ON CONFLICT.
+
+- **`Table.allFields []Field` and `Table.textOverflowCols []Column` cached fields** (`table.go`, `update.go`, `cursor.go`): Both `fieldsFromColumns(t.Columns...)` and the text-overflow column list are pure functions of `t.Columns`, which is immutable after table construction. Pre-compute them once in `NewTable` and reuse. Removed the now-dead `textOverflowColumns()` helper from `stmt.go`. Eliminates two per-`Update()` call allocations.
+
+- **Pre-size `WriteSet` map in `BeginTransaction`** (`transaction_manager.go`): Changed `make(map[PageIndex]WriteInfo)` to `make(map[PageIndex]WriteInfo, 8)`. A single-row write touches ~3–5 pages (data leaf + PK index leaf + secondary index leaf(s)). Pre-allocating 8 slots avoids all bucket-growth allocations for the common case. Halved `TrackWrite` allocation from 104 MB → 50 MB per 100K-iteration run.
+
+- **Share `Fields` slice for UPDATE in `Statement.Clone`** (`stmt.go`): `BindArguments` for UPDATE only reads `stmt.Fields` (to find which `Updates` map keys hold placeholders) and never mutates it. Share the reference rather than copying, same as the existing INSERT optimisation.
+
+**Memory improvements vs previous baseline (2026-05-27 Insert optimisation baseline):**
+
+| Benchmark | Memory before | Memory after | Δ |
+|---|---:|---:|---:|
+| Update_ByPK/minisql | 6.5 KiB | 5.7 KiB | −12% |
+| OnConflict_DoUpdate/minisql | 2.8 KiB | 2.5 KiB | −8% |
+| Select_PointScan/minisql | 4.7 KiB | 4.5 KiB | −4% |
+| Delete_ByPK/minisql | 6.1 KiB | 5.9 KiB | −3% |
+| Explain/minisql | 6.0 KiB | 5.8 KiB | −4% |
+
 ## 2026-05-27 — Insert Allocation Reduction: Prep Cache, Unsafe String Reuse, logger.Check
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
@@ -44,110 +71,110 @@ This baseline reflects the greedy join planner improvement merged since the prev
 
 | Benchmark | Time/op | Memory/op | Allocs/op |
 |---|---:|---:|---:|
-| GroupBy_Aggregate/minisql | 951.1 µs | 37.4 KiB | 459 |
-| GroupBy_Aggregate/sqlite | 2.35 ms | 3.5 KiB | 309 |
-| Having_Filter/minisql | 783.7 µs | 28.7 KiB | 264 |
-| Having_Filter/sqlite | 2.05 ms | 1.9 KiB | 111 |
-| Distinct_HighCardinality/minisql | 3.68 ms | 1.73 MiB | 40,141 |
-| Distinct_HighCardinality/sqlite | 6.17 ms | 586.3 KiB | 40,010 |
-| Delete_ByPK/minisql | 25.0 µs | 6.1 KiB | 74 |
-| Delete_ByPK/sqlite | 94.9 µs | 447 B | 19 |
-| ForeignKey_Insert/minisql | 15.3 µs | 3.0 KiB | 32 |
-| ForeignKey_Insert/sqlite | 51.8 µs | 192 B | 8 |
-| ForeignKey_DeleteCascade/minisql | 84.0 µs | 10.9 KiB | 136 |
-| ForeignKey_DeleteCascade/sqlite | 86.8 µs | 128 B | 5 |
-| Insert_SingleRow/minisql | 15.5 µs | 3.3 KiB | 35 |
-| Insert_SingleRow/sqlite | 51.6 µs | 311 B | 12 |
-| Insert_Batch/minisql | 425.6 µs | 193.0 KiB | 2,746 |
-| Insert_Batch/sqlite | 268.1 µs | 31.0 KiB | 1,301 |
-| Insert_PreparedBatch/minisql | 400.3 µs | 192.5 KiB | 2,754 |
-| Insert_PreparedBatch/sqlite | 243.4 µs | 31.0 KiB | 1,300 |
-| Insert_MultiValues/minisql | 240.0 µs | 170.7 KiB | 1,870 |
-| Insert_MultiValues/sqlite | 197.5 µs | 25.2 KiB | 615 |
-| FullText_BuildIndex/minisql | 5.07 ms | 1.73 MiB | 16,382 |
+| GroupBy_Aggregate/minisql | 1.00 ms | 37.2 KiB | 459 |
+| GroupBy_Aggregate/sqlite | 2.89 ms | 3.5 KiB | 309 |
+| Having_Filter/minisql | 820.1 µs | 28.8 KiB | 264 |
+| Having_Filter/sqlite | 2.29 ms | 1.9 KiB | 111 |
+| Distinct_HighCardinality/minisql | 3.81 ms | 1.73 MiB | 40,141 |
+| Distinct_HighCardinality/sqlite | 6.53 ms | 586.3 KiB | 40,010 |
+| Delete_ByPK/minisql | 27.0 µs | 5.9 KiB | 73 |
+| Delete_ByPK/sqlite | 110.1 µs | 447 B | 19 |
+| ForeignKey_Insert/minisql | 16.6 µs | 3.0 KiB | 32 |
+| ForeignKey_Insert/sqlite | 62.9 µs | 192 B | 8 |
+| ForeignKey_DeleteCascade/minisql | 67.5 µs | 10.7 KiB | 135 |
+| ForeignKey_DeleteCascade/sqlite | 86.9 µs | 128 B | 5 |
+| Insert_SingleRow/minisql | 15.3 µs | 3.3 KiB | 35 |
+| Insert_SingleRow/sqlite | 58.9 µs | 311 B | 12 |
+| Insert_Batch/minisql | 392.4 µs | 193.2 KiB | 2,748 |
+| Insert_Batch/sqlite | 266.6 µs | 31.0 KiB | 1,301 |
+| Insert_PreparedBatch/minisql | 400.3 µs | 192.3 KiB | 2,753 |
+| Insert_PreparedBatch/sqlite | 269.2 µs | 31.0 KiB | 1,297 |
+| Insert_MultiValues/minisql | 222.0 µs | 171.2 KiB | 1,874 |
+| Insert_MultiValues/sqlite | 242.2 µs | 25.2 KiB | 613 |
+| FullText_BuildIndex/minisql | 4.40 ms | 1.71 MiB | 16,280 |
 | FullText_BuildIndex/sqlite | 2.51 ms | 392 B | 20 |
-| FullText_Insert_WithIndex/minisql | 52.6 µs | 19.1 KiB | 158 |
-| FullText_Insert_WithIndex/sqlite | 99.4 µs | 439 B | 18 |
-| FullText_Search_SingleTerm/rare/minisql | 19.3 µs | 4.3 KiB | 67 |
-| FullText_Search_SingleTerm/rare/sqlite | 11.8 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/medium/minisql | 19.9 µs | 4.3 KiB | 67 |
-| FullText_Search_SingleTerm/medium/sqlite | 12.5 µs | 392 B | 12 |
-| FullText_Search_SingleTerm/common/minisql | 20.9 µs | 4.3 KiB | 69 |
-| FullText_Search_SingleTerm/common/sqlite | 69.4 µs | 408 B | 14 |
-| FullText_Search_MultiTermAND/minisql | 37.7 µs | 13.4 KiB | 88 |
-| FullText_Search_MultiTermAND/sqlite | 42.7 µs | 392 B | 12 |
-| FullText_Search_Phrase/minisql | 51.4 µs | 28.4 KiB | 304 |
-| FullText_Search_Phrase/sqlite | 31.6 µs | 400 B | 13 |
-| FullText_Search_AfterDeletes/minisql | 144.8 µs | 77.3 KiB | 90 |
-| FullText_Update_WithIndex/minisql | 55.5 µs | 25.3 KiB | 212 |
-| FullText_Update_WithIndex/sqlite | 106.2 µs | 290 B | 12 |
-| FullText_Delete_WithIndex/minisql | 66.6 µs | 26.1 KiB | 202 |
-| FullText_Delete_WithIndex/sqlite | 146.1 µs | 135 B | 6 |
-| JSONInverted_BuildIndex/minisql_indexed | 7.24 ms | 4.08 MiB | 63,043 |
-| JSONInverted_Insert_WithIndex/minisql_indexed | 72.7 µs | 48.4 KiB | 213 |
-| JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 32.1 µs | 9.8 KiB | 101 |
-| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 3.15 ms | 2.00 MiB | 38,096 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 734.1 µs | 408 B | 14 |
-| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 32.5 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 46.4 µs | 11.0 KiB | 141 |
-| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 3.18 ms | 2.00 MiB | 38,118 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 784.9 µs | 408 B | 14 |
-| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 141.3 µs | 408 B | 14 |
-| JSONInverted_Contains_AfterDeletes/minisql_indexed | 183.6 µs | 74.3 KiB | 118 |
-| JSONInverted_Update_WithIndex/minisql_indexed | 12.8 µs | 6.6 KiB | 76 |
-| JSONInverted_Delete_WithIndex/minisql_indexed | 530.2 µs | 1011.9 KiB | 390 |
-| Join_Inner_SmallLarge/minisql | 7.04 ms | 1.27 MiB | 89,855 |
-| Join_Inner_SmallLarge/sqlite | 6.19 ms | 1.09 MiB | 99,757 |
-| Join_Inner_LowSelectivity/minisql | 137.9 µs | 23.4 KiB | 1,298 |
-| Join_Inner_LowSelectivity/sqlite | 780.5 µs | 11.3 KiB | 1,009 |
-| Join_Left_UnmatchedRows/minisql | 4.26 ms | 878.3 KiB | 79,743 |
-| Join_Left_UnmatchedRows/sqlite | 4.89 ms | 708.2 KiB | 70,157 |
-| Vacuum_Small/minisql | 22.1 ms | 1.49 MiB | 13,002 |
-| Vacuum_Small/sqlite | 612.2 µs | 91 B | 4 |
-| WAL_Checkpoint/minisql | 332.0 µs | 71.6 KiB | 42 |
-| WAL_Checkpoint/sqlite | 163.8 µs | 441 B | 12 |
-| Explain/minisql | 7.2 µs | 6.0 KiB | 56 |
-| Explain/sqlite | 1.8 µs | 680 B | 18 |
-| Select_PointScan/minisql | 7.3 µs | 4.7 KiB | 58 |
-| Select_PointScan/sqlite | 4.3 µs | 679 B | 26 |
-| Select_Limit/minisql | 8.5 µs | 3.7 KiB | 97 |
+| FullText_Insert_WithIndex/minisql | 55.1 µs | 19.0 KiB | 158 |
+| FullText_Insert_WithIndex/sqlite | 105.7 µs | 438 B | 18 |
+| FullText_Search_SingleTerm/rare/minisql | 19.5 µs | 4.3 KiB | 67 |
+| FullText_Search_SingleTerm/rare/sqlite | 12.3 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/medium/minisql | 21.3 µs | 4.3 KiB | 67 |
+| FullText_Search_SingleTerm/medium/sqlite | 17.8 µs | 392 B | 12 |
+| FullText_Search_SingleTerm/common/minisql | 20.5 µs | 4.3 KiB | 69 |
+| FullText_Search_SingleTerm/common/sqlite | 74.3 µs | 408 B | 14 |
+| FullText_Search_MultiTermAND/minisql | 36.4 µs | 13.4 KiB | 88 |
+| FullText_Search_MultiTermAND/sqlite | 43.3 µs | 392 B | 12 |
+| FullText_Search_Phrase/minisql | 37.6 µs | 28.5 KiB | 304 |
+| FullText_Search_Phrase/sqlite | 33.9 µs | 400 B | 13 |
+| FullText_Search_AfterDeletes/minisql | 112.5 µs | 77.4 KiB | 90 |
+| FullText_Update_WithIndex/minisql | 53.8 µs | 24.6 KiB | 208 |
+| FullText_Update_WithIndex/sqlite | 166.8 µs | 290 B | 12 |
+| FullText_Delete_WithIndex/minisql | 79.8 µs | 26.2 KiB | 202 |
+| FullText_Delete_WithIndex/sqlite | 175.0 µs | 135 B | 6 |
+| JSONInverted_BuildIndex/minisql_indexed | 6.23 ms | 4.08 MiB | 63,045 |
+| JSONInverted_Insert_WithIndex/minisql_indexed | 81.3 µs | 41.9 KiB | 212 |
+| JSONInverted_Contains_KeyValue/key_value/minisql_indexed | 32.0 µs | 9.9 KiB | 101 |
+| JSONInverted_Contains_KeyValue/key_value/minisql_sequential | 2.38 ms | 2.00 MiB | 38,096 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_scan | 967.0 µs | 409 B | 14 |
+| JSONInverted_Contains_KeyValue/key_value/sqlite_json_expr_index | 35.3 µs | 408 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_indexed | 45.9 µs | 11.0 KiB | 141 |
+| JSONInverted_Contains_ObjectSubset/object_subset/minisql_sequential | 2.87 ms | 2.00 MiB | 38,118 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_scan | 943.7 µs | 409 B | 14 |
+| JSONInverted_Contains_ObjectSubset/object_subset/sqlite_json_expr_index | 149.5 µs | 408 B | 14 |
+| JSONInverted_Contains_AfterDeletes/minisql_indexed | 180.4 µs | 74.3 KiB | 118 |
+| JSONInverted_Update_WithIndex/minisql_indexed | 11.6 µs | 6.2 KiB | 73 |
+| JSONInverted_Delete_WithIndex/minisql_indexed | 455.9 µs | 1011.7 KiB | 389 |
+| Join_Inner_SmallLarge/minisql | 7.59 ms | 1.27 MiB | 89,855 |
+| Join_Inner_SmallLarge/sqlite | 5.78 ms | 1.09 MiB | 99,757 |
+| Join_Inner_LowSelectivity/minisql | 126.8 µs | 23.4 KiB | 1,298 |
+| Join_Inner_LowSelectivity/sqlite | 810.9 µs | 11.3 KiB | 1,009 |
+| Join_Left_UnmatchedRows/minisql | 4.02 ms | 878.0 KiB | 79,743 |
+| Join_Left_UnmatchedRows/sqlite | 4.85 ms | 708.2 KiB | 70,157 |
+| Vacuum_Small/minisql | 22.9 ms | 1.53 MiB | 13,014 |
+| Vacuum_Small/sqlite | 567.3 µs | 91 B | 4 |
+| WAL_Checkpoint/minisql | 323.8 µs | 71.6 KiB | 42 |
+| WAL_Checkpoint/sqlite | 154.3 µs | 441 B | 12 |
+| Explain/minisql | 6.2 µs | 5.8 KiB | 55 |
+| Explain/sqlite | 1.7 µs | 680 B | 18 |
+| Select_PointScan/minisql | 6.7 µs | 4.5 KiB | 57 |
+| Select_PointScan/sqlite | 4.2 µs | 679 B | 26 |
+| Select_Limit/minisql | 8.6 µs | 3.7 KiB | 97 |
 | Select_Limit/sqlite | 10.0 µs | 1.7 KiB | 104 |
-| Select_FullScan/minisql | 4.46 ms | 1.27 MiB | 79,823 |
-| Select_FullScan/sqlite | 6.30 ms | 1.33 MiB | 99,758 |
-| Select_CountStar/minisql | 6.2 µs | 2.5 KiB | 27 |
-| Select_CountStar/sqlite | 10.6 µs | 400 B | 13 |
-| Select_IndexRangeScan/minisql | 1.43 ms | 113.5 KiB | 6,641 |
-| Select_IndexRangeScan/sqlite | 824.5 µs | 85.9 KiB | 6,581 |
-| Select_SecondaryIndex_LowSelectivity/minisql | 2.27 ms | 437.1 KiB | 29,932 |
-| Select_SecondaryIndex_LowSelectivity/sqlite | 3.03 ms | 313.0 KiB | 29,886 |
-| Select_SecondaryIndex_LowSelectivityLimit/minisql | 11.7 µs | 5.3 KiB | 112 |
-| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 9.8 µs | 1.1 KiB | 64 |
-| Select_RangeScan/minisql | 1.60 ms | 83.6 KiB | 5,507 |
-| Select_RangeScan/sqlite | 943.7 µs | 85.9 KiB | 6,581 |
-| CTE_Materialise/minisql | 803.7 µs | 7.9 KiB | 85 |
-| CTE_Materialise/sqlite | 460.1 µs | 400 B | 13 |
-| Subquery_InList/minisql | 4.92 ms | 872.4 KiB | 35,098 |
-| Subquery_InList/sqlite | 3.94 ms | 234.7 KiB | 20,010 |
-| OnConflict_DoUpdate/minisql | 10.4 µs | 2.8 KiB | 35 |
-| OnConflict_DoUpdate/sqlite | 41.9 µs | 260 B | 10 |
-| Update_ByPK/minisql | 12.3 µs | 6.5 KiB | 57 |
-| Update_ByPK/sqlite | 43.5 µs | 263 B | 10 |
+| Select_FullScan/minisql | 4.23 ms | 1.27 MiB | 79,823 |
+| Select_FullScan/sqlite | 6.93 ms | 1.33 MiB | 99,758 |
+| Select_CountStar/minisql | 7.2 µs | 2.5 KiB | 27 |
+| Select_CountStar/sqlite | 12.8 µs | 400 B | 13 |
+| Select_IndexRangeScan/minisql | 1.27 ms | 112.6 KiB | 6,641 |
+| Select_IndexRangeScan/sqlite | 894.8 µs | 85.9 KiB | 6,581 |
+| Select_SecondaryIndex_LowSelectivity/minisql | 2.66 ms | 437.5 KiB | 29,931 |
+| Select_SecondaryIndex_LowSelectivity/sqlite | 3.29 ms | 313.0 KiB | 29,886 |
+| Select_SecondaryIndex_LowSelectivityLimit/minisql | 11.4 µs | 5.1 KiB | 111 |
+| Select_SecondaryIndex_LowSelectivityLimit/sqlite | 10.4 µs | 1.1 KiB | 64 |
+| Select_RangeScan/minisql | 1.73 ms | 84.1 KiB | 5,507 |
+| Select_RangeScan/sqlite | 1.00 ms | 85.9 KiB | 6,581 |
+| CTE_Materialise/minisql | 947.8 µs | 8.0 KiB | 85 |
+| CTE_Materialise/sqlite | 515.3 µs | 400 B | 13 |
+| Subquery_InList/minisql | 5.55 ms | 875.0 KiB | 35,098 |
+| Subquery_InList/sqlite | 4.26 ms | 234.7 KiB | 20,010 |
+| OnConflict_DoUpdate/minisql | 11.4 µs | 2.5 KiB | 34 |
+| OnConflict_DoUpdate/sqlite | 53.6 µs | 259 B | 10 |
+| Update_ByPK/minisql | 15.7 µs | 5.7 KiB | 53 |
+| Update_ByPK/sqlite | 60.5 µs | 263 B | 10 |
 
 ## Memory Outliers
 
 The largest remaining memory consumers (minisql only, excluding intentional sequential-scan variants):
 
-- `JSONInverted_BuildIndex`: `4.08 MiB/op`, `63,043 allocs/op` — in-memory term→postings map during build
+- `JSONInverted_BuildIndex`: `4.08 MiB/op`, `63,045 allocs/op` — in-memory term→postings map during build
 - `Distinct_HighCardinality`: `1.73 MiB/op`, `40,141 allocs/op` — in-memory dedup set for 10K distinct rows
-- `FullText_BuildIndex`: `1.73 MiB/op`, `16,382 allocs/op` — per-doc postings map
-- `Vacuum_Small`: `1.49 MiB/op` — full copy-compact-swap; structural cost
-- `Join_Inner_SmallLarge`: `1.27 MiB/op`, `89,855 allocs/op` — INLJ result materialization for 10K matched rows (was 3.46 MiB with wrong hash-build side)
+- `FullText_BuildIndex`: `1.71 MiB/op`, `16,280 allocs/op` — per-doc postings map
+- `Vacuum_Small`: `1.53 MiB/op` — full copy-compact-swap; structural cost
+- `Join_Inner_SmallLarge`: `1.27 MiB/op`, `89,855 allocs/op` — INLJ result materialization for 10K matched rows
 - `Select_FullScan`: `1.27 MiB/op`, `79,823 allocs/op` — ~8 allocs/row from `Materialize()` per RowView
 - `JSONInverted_Delete_WithIndex`: `1012 KiB/op` — full posting list read into memory on delete
-- `Insert_Batch` / `PreparedBatch`: `~193 KiB/op` — ~1.9 KiB/row vs SQLite's 310 B; reduced from 251 KiB by prep cache + unsafe string reuse + logger.Check; remaining cost is per-row clone + B-tree page I/O
+- `Insert_Batch` / `PreparedBatch`: `~193 KiB/op` — ~1.9 KiB/row vs SQLite's 310 B; remaining cost is per-row clone + B-tree page I/O
 
 Good next optimisation targets:
 
+- Extend plan cache to UPDATE/DELETE with bound conditions: the plan shape (which index to use) is stable across executions of the same prepared statement; only `IndexKeys` change. Re-injecting keys after cache retrieval would eliminate the entire per-call planning cost (~1 KiB/op on Update_ByPK).
 - Streaming SELECT delivery that reads directly from RowView into the driver dest slice (eliminating `Materialize()`)
 - Streaming term extraction for inverted-index build and maintenance
-- Reduce per-row INSERT clone overhead (Statement.Clone allocates inner maps/slices even for identical prepared execs)

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -431,7 +431,7 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 	}
 
 	// Remove any overflow pages
-	if overflowColumns := textOverflowColumns(c.Table.Columns...); len(overflowColumns) > 0 {
+	if overflowColumns := c.Table.textOverflowCols; len(overflowColumns) > 0 {
 		// TODO - a more efficient implementation would be to try to reuse existing overflow pages
 		// if possible. For example if text size didn't change much and fits into existing overflow pages.
 		changedColumns := make([]Column, 0, len(changedValues))

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -335,7 +335,8 @@ func (t *Table) planQueryUncached(ctx context.Context, stmt Statement) (QueryPla
 
 // indexMatch represents a potential index match for equality conditions
 type indexMatch struct {
-	matchedConditions   map[int]bool
+	matchedConditions   []bool // indexed by condition position within the group
+	numMatched          int    // count of true entries in matchedConditions
 	rangeCondition      *RangeCondition
 	stats               *IndexStats
 	info                IndexInfo
@@ -376,10 +377,8 @@ func (t *Table) findBestEqualityIndexMatch(group Conditions) *indexMatch {
 			}
 
 			// Same selectivity - prefer more matched columns
-			newMatchedCols := len(newMatch.matchedConditions)
-			bestMatchedCols := len(bestMatch.matchedConditions)
-			if newMatchedCols != bestMatchedCols {
-				return newMatchedCols > bestMatchedCols
+			if newMatch.numMatched != bestMatch.numMatched {
+				return newMatch.numMatched > bestMatch.numMatched
 			}
 
 			// Same matched columns - prefer primary key, then unique
@@ -402,10 +401,8 @@ func (t *Table) findBestEqualityIndexMatch(group Conditions) *indexMatch {
 		}
 
 		// Both are PK or both are not PK - compare number of matched columns (more is better)
-		newMatchedCols := len(newMatch.matchedConditions)
-		bestMatchedCols := len(bestMatch.matchedConditions)
-		if newMatchedCols != bestMatchedCols {
-			return newMatchedCols > bestMatchedCols
+		if newMatch.numMatched != bestMatch.numMatched {
+			return newMatch.numMatched > bestMatch.numMatched
 		}
 
 		// Same number of columns - prefer by index type (unique over secondary)
@@ -489,9 +486,12 @@ func (t *Table) findBestEqualityIndexMatch(group Conditions) *indexMatch {
 				continue
 			}
 		}
+		mc := make([]bool, len(group))
+		mc[condIdx] = true
 		exprMatch := &indexMatch{
 			info:              si.IndexInfo,
-			matchedConditions: map[int]bool{condIdx: true},
+			matchedConditions: mc,
+			numMatched:        1,
 			keys:              keys,
 		}
 		if isBetterMatch(exprMatch) {
@@ -678,8 +678,14 @@ func literalText(expr *Expr) (string, bool) {
 // tryMatchIndex attempts to match an index against the conditions in a group.
 // It returns a match if it can find equality conditions for a prefix of the index columns.
 func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch {
-	matchedConditions := make(map[int]bool)
-	var compositeKey []any
+	// Use a bool slice keyed by condition index — cheaper than map[int]bool since
+	// condition indices are contiguous 0..len(group)-1 and the slice is tiny enough
+	// to be stack-allocated by the compiler for common single-condition WHERE clauses.
+	matchedConditions := make([]bool, len(group))
+	var (
+		compositeKey []any
+		numMatched   int
+	)
 
 	// For composite indexes, we need to match columns in order from left to right
 	for colIdx, indexCol := range indexInfo.Columns {
@@ -731,6 +737,7 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 			}
 
 			matchedConditions[condIdx] = true
+			numMatched++
 			compositeKey = append(compositeKey, keys...)
 			foundMatch = true
 			break
@@ -744,7 +751,7 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 	}
 
 	// No conditions matched this index
-	if len(matchedConditions) == 0 {
+	if numMatched == 0 {
 		return nil
 	}
 
@@ -753,7 +760,7 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 	_, isUnique := t.UniqueIndexes[indexInfo.Name]
 
 	// Determine if this is a partial match (prefix of composite index)
-	numMatchedColumns := len(matchedConditions)
+	numMatchedColumns := numMatched
 	isPartialMatch := numMatchedColumns > 0 && numMatchedColumns < len(indexInfo.Columns)
 
 	var indexKeys []any
@@ -814,6 +821,7 @@ func (t *Table) tryMatchIndex(indexInfo IndexInfo, group Conditions) *indexMatch
 	match := &indexMatch{
 		info:                indexInfo,
 		matchedConditions:   matchedConditions,
+		numMatched:          numMatched,
 		keys:                indexKeys,
 		estKeyStr:           estKeyStr,
 		rangeCondition:      rangeCondition,
@@ -987,7 +995,7 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 		}
 
 		// Also collect indexes that could be used for range scans
-		for _, cond := range group {
+		for condIdx, cond := range group {
 			if cond.Operand1.Type != OperandField {
 				continue
 			}
@@ -1005,17 +1013,8 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 			}
 
 			// Skip if this condition was already matched for equality
-			if match != nil {
-				alreadyMatched := false
-				for condIdx := range match.matchedConditions {
-					if &group[condIdx] == &cond {
-						alreadyMatched = true
-						break
-					}
-				}
-				if alreadyMatched {
-					continue
-				}
+			if match != nil && match.matchedConditions[condIdx] {
+				continue
 			}
 
 			// Check if this could be used for range scan
@@ -1056,8 +1055,10 @@ func (p *QueryPlan) setIndexScans(t *Table, conditions OneOrMore) error {
 
 					// Collect the complete set of covered condition indices.
 					allCovered := make(map[int]bool)
-					for k := range match.matchedConditions {
-						allCovered[k] = true
+					for k, ok := range match.matchedConditions {
+						if ok {
+							allCovered[k] = true
+						}
 					}
 					for k := range additionalCovered {
 						allCovered[k] = true

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -245,16 +245,6 @@ func fieldsFromColumns(columns ...Column) []Field {
 	return fields
 }
 
-func textOverflowColumns(columns ...Column) []Column {
-	overflowColumns := make([]Column, 0, len(columns))
-	for _, col := range columns {
-		if !col.MayUseOverflowText() {
-			continue
-		}
-		overflowColumns = append(overflowColumns, col)
-	}
-	return overflowColumns
-}
 
 func textOverflowFields(columns ...Column) []Field {
 	overflowFields := make([]Field, 0, len(columns))
@@ -533,10 +523,12 @@ func (s Statement) NumPlaceholders() int {
 func (s Statement) Clone() Statement {
 	// For INSERT, Fields are always fully rebuilt by prepareInsert — share the
 	// reference to avoid an allocation that immediately becomes dead.
-	// For all other kinds, deep-copy so that downstream mutations (e.g. BindArguments
-	// filling Placeholder values) don't corrupt the prepared statement.
+	// For UPDATE, BindArguments only reads Fields (to find which Updates keys hold
+	// placeholders) and never writes to it — share the reference too.
+	// For all other kinds, deep-copy so that downstream mutations don't corrupt
+	// the prepared statement.
 	var fields []Field
-	if s.Kind == Insert {
+	if s.Kind == Insert || s.Kind == Update {
 		fields = s.Fields
 	} else {
 		fields = make([]Field, len(s.Fields))

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -53,6 +53,10 @@ type Table struct {
 	// checks here first and stores results after planning. Nil for system tables
 	// and virtual tables created for derived-table subqueries.
 	planCache LRUCache[string]
+	// allFields and textOverflowCols are derived from Columns at construction time
+	// and reused across calls to avoid per-call allocations.
+	allFields        []Field
+	textOverflowCols []Column
 	// rightmostTablePage caches the last leaf page index for SeekNextRowID so that
 	// sequential (autoincrement) inserts skip the O(log N) root→leaf traversal.
 	// lastTxIDTablePage guards against stale hints from rolled-back transactions.
@@ -91,9 +95,15 @@ func NewTable(logger *zap.Logger, pager TxPager, txManager *TransactionManager, 
 		table.provider = &singleTableProvider{table: table}
 	}
 
-	// Build column name -> column index cache
+	// Build column name -> column index cache; also pre-compute derived column slices.
 	for i, col := range columns {
 		table.columnCache[col.Name] = i
+	}
+	table.allFields = fieldsFromColumns(columns...)
+	for _, col := range columns {
+		if col.MayUseOverflowText() {
+			table.textOverflowCols = append(table.textOverflowCols, col)
+		}
 	}
 
 	// Apply options

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -222,7 +222,7 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context) (*Transactio
 	tx := &Transaction{
 		ID:        tm.nextTxID,
 		StartTime: time.Now(),
-		WriteSet:  make(map[PageIndex]WriteInfo),
+		WriteSet:  make(map[PageIndex]WriteInfo, 8),
 		Status:    TxActive,
 	}
 	tm.nextTxID += 1

--- a/internal/minisql/update.go
+++ b/internal/minisql/update.go
@@ -26,7 +26,7 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 		ce.Write(zap.String("query type", "UPDATE"), zap.Any("plan", plan))
 	}
 
-	selectedFields := fieldsFromColumns(t.Columns...)
+	selectedFields := t.allFields
 
 	result := StatementResult{
 		Columns: t.Columns,
@@ -168,14 +168,13 @@ func (t *Table) Update(ctx context.Context, stmt Statement) (StatementResult, er
 	}
 
 	if len(stmt.ReturningFields) > 0 {
-		allFields := fieldsFromColumns(t.Columns...)
 		returningRows := make([]Row, 0, len(updatedKeys))
 		for _, key := range updatedKeys {
 			cursor, err := t.Seek(ctx, key)
 			if err != nil {
 				return result, err
 			}
-			row, err := cursor.fetchRow(ctx, false, allFields...)
+			row, err := cursor.fetchRow(ctx, false, t.allFields...)
 			if err != nil {
 				return result, err
 			}


### PR DESCRIPTION
Four targeted optimisations that benefit all write paths and all indexed-WHERE queries:

- matchedConditions []bool in tryMatchIndex (query_plan.go): replace map[int]bool with []bool indexed by condition position. Condition indices are contiguous 0..len(group)-1, so a slice is correct and avoids map bucket allocations entirely. For single-condition WHERE clauses the slice is 1 byte and stack-allocatable. Added numMatched int to indexMatch to preserve the matched-column count without relying on len(). Benefits UPDATE, DELETE, SELECT, ON CONFLICT.

- Table.allFields and Table.textOverflowCols cached fields (table.go, update.go, cursor.go): both are pure functions of t.Columns which is immutable after construction. Pre-compute in NewTable and reuse. Removes two per-Update() call allocations. Removed now-dead textOverflowColumns() helper from stmt.go.

- Pre-size WriteSet in BeginTransaction (transaction_manager.go): make(map[PageIndex]WriteInfo, 8) instead of an empty map. A single-row write touches ~3-5 pages; 8 slots avoids all bucket-growth allocations for the common case. Halved TrackWrite allocation per run.

- Share Fields slice for UPDATE in Statement.Clone (stmt.go): BindArguments for UPDATE only reads stmt.Fields (to find which Updates keys hold placeholders) and never mutates it. Share the reference rather than copying, same as the existing INSERT optimisation.

Benchmark deltas (memory, LOG_LEVEL=warn):
  Update_ByPK:           6.5 KiB → 5.7 KiB  (−12%)
  OnConflict_DoUpdate:   2.8 KiB → 2.5 KiB  (−8%)
  Select_PointScan:      4.7 KiB → 4.5 KiB  (−4%)
  Delete_ByPK:           6.1 KiB → 5.9 KiB  (−3%)
  Explain:               6.0 KiB → 5.8 KiB  (−4%)