### PR TITLE
Extend plan cache to indexed UPDATE/DELETE with bound conditions

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,5 +1,22 @@
 # Benchmark Results
 
+## 2026-05-27 — Plan Cache Extension for Bound-Condition Queries
+
+**Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
+**Branch:** `main`  
+**Command:** `go test -tags bench -run='^$' -bench=Update_ByPK -benchmem -count=5 ./benchmarks/`
+
+One optimization eliminating the per-call query planning cost for indexed DML prepared statements:
+
+- **Plan cache for bound-condition queries** (`query_plan.go`): `PlanQuery` now caches plans for prepared `UPDATE`/`DELETE`/`SELECT` statements where the `WHERE` clause uses simple indexed equality conditions. On a cache hit, `rehydratePlanIndexKeys` rebuilds only the `IndexKeys` slice from current bound values without re-running the full planner. Three guards ensure correctness: `planConditionsAreCacheable` rejects subquery/expression/placeholder operands that would change the plan shape; `planIsCacheableWithConditions` only caches plans composed entirely of `ScanTypeIndexPoint` scans with no secondary filters or sub-scans; and `rehydratePlanIndexKeys` falls back to full re-planning if key extraction fails.
+
+**Memory improvements vs previous baseline (2026-05-27 Update/Query Planning baseline):**
+
+| Benchmark | Memory before | Memory after | Δ allocs |
+|---|---:|---:|---:|
+| Update_ByPK/minisql | 5.7 KiB / 53 allocs | 5.2 KiB / 46 allocs | −13% |
+| Delete_ByPK/minisql | 5.9 KiB / 73 allocs | 5.3 KiB / 65 allocs | −11% |
+
 ## 2026-05-27 — Update/Query Planning Allocation Reduction
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
@@ -77,7 +94,7 @@ This baseline reflects the greedy join planner improvement merged since the prev
 | Having_Filter/sqlite | 2.29 ms | 1.9 KiB | 111 |
 | Distinct_HighCardinality/minisql | 3.81 ms | 1.73 MiB | 40,141 |
 | Distinct_HighCardinality/sqlite | 6.53 ms | 586.3 KiB | 40,010 |
-| Delete_ByPK/minisql | 27.0 µs | 5.9 KiB | 73 |
+| Delete_ByPK/minisql | 22.0 µs | 5.3 KiB | 65 |
 | Delete_ByPK/sqlite | 110.1 µs | 447 B | 19 |
 | ForeignKey_Insert/minisql | 16.6 µs | 3.0 KiB | 32 |
 | ForeignKey_Insert/sqlite | 62.9 µs | 192 B | 8 |
@@ -157,7 +174,7 @@ This baseline reflects the greedy join planner improvement merged since the prev
 | Subquery_InList/sqlite | 4.26 ms | 234.7 KiB | 20,010 |
 | OnConflict_DoUpdate/minisql | 11.4 µs | 2.5 KiB | 34 |
 | OnConflict_DoUpdate/sqlite | 53.6 µs | 259 B | 10 |
-| Update_ByPK/minisql | 15.7 µs | 5.7 KiB | 53 |
+| Update_ByPK/minisql | 10.1 µs | 5.2 KiB | 46 |
 | Update_ByPK/sqlite | 60.5 µs | 263 B | 10 |
 
 ## Memory Outliers
@@ -175,6 +192,6 @@ The largest remaining memory consumers (minisql only, excluding intentional sequ
 
 Good next optimisation targets:
 
-- Extend plan cache to UPDATE/DELETE with bound conditions: the plan shape (which index to use) is stable across executions of the same prepared statement; only `IndexKeys` change. Re-injecting keys after cache retrieval would eliminate the entire per-call planning cost (~1 KiB/op on Update_ByPK).
 - Streaming SELECT delivery that reads directly from RowView into the driver dest slice (eliminating `Materialize()`)
 - Streaming term extraction for inverted-index build and maintenance
+- Reduce per-row clone overhead in `Insert_Batch` (~1.9 KiB/row vs SQLite's 310 B)

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -216,16 +216,30 @@ SELECT * from users ORDER BY created DESC; - use index on created for ordering
 SELECT * from users ORDER BY non_indexed_col; - order in memory
 */
 func (t *Table) PlanQuery(ctx context.Context, stmt Statement) (QueryPlan, error) {
-	// Plan cache: safe only when stmt.Conditions is empty (no bound values in the
-	// plan) and there are no JOINs (join plans embed per-execution join key values).
-	// ORDER BY-only queries are the primary beneficiary: the index-vs-sort decision
-	// is schema-derived and stable across all executions of the same SQL.
+	// Plan cache eligibility:
+	//  - No JOINs (join plans embed per-execution join-key values).
+	//  - Either no conditions (schema-derived plan, e.g. ORDER BY skip-sort), or all
+	//    conditions are simple bound literals (no subqueries, expressions, or unbound
+	//    placeholders).  For the latter, the plan *structure* (which index to use, scan
+	//    type) is determined solely by the condition column names — not the values —
+	//    so the same plan shape applies to every execution of the same prepared statement.
+	//    IndexKeys are per-execution; they are re-derived after cache retrieval.
+	hasConditions := len(stmt.Conditions) > 0
 	canCache := stmt.CacheKey != "" && t.planCache != nil &&
-		len(stmt.Conditions) == 0 && len(stmt.Joins) == 0
+		len(stmt.Joins) == 0 &&
+		(!hasConditions || planConditionsAreCacheable(stmt.Conditions))
 
 	if canCache {
 		if cached, ok := t.planCache.Get(stmt.CacheKey); ok {
-			return applyScanLimit(cached.(QueryPlan), stmt), nil
+			plan := cached.(QueryPlan)
+			if hasConditions {
+				if hydrated, ok := rehydratePlanIndexKeys(plan, stmt, t); ok {
+					return applyScanLimit(hydrated, stmt), nil
+				}
+				// Re-hydration failed (schema change?). Fall through to full re-plan.
+			} else {
+				return applyScanLimit(plan, stmt), nil
+			}
 		}
 	}
 
@@ -234,11 +248,112 @@ func (t *Table) PlanQuery(ctx context.Context, stmt Statement) (QueryPlan, error
 		return QueryPlan{}, err
 	}
 
-	if canCache {
+	if canCache && (!hasConditions || planIsCacheableWithConditions(plan)) {
 		t.planCache.Put(stmt.CacheKey, plan, true)
 	}
 
 	return applyScanLimit(plan, stmt), nil
+}
+
+// planConditionsAreCacheable returns true when every condition in conds has
+// simple bound operands — no subqueries, no expression-tree operands, no
+// unbound placeholders.  Plans derived from such conditions are safe to cache
+// because index selection depends only on the condition structure (which
+// columns appear in the WHERE clause), not on the runtime values.
+func planConditionsAreCacheable(conds OneOrMore) bool {
+	for _, group := range conds {
+		for _, cond := range group {
+			if cond.Operand1.Type == OperandExpr {
+				return false
+			}
+			switch cond.Operand2.Type {
+			case OperandSubquery, OperandExpr, OperandPlaceholder:
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// planIsCacheableWithConditions returns true when the plan consists entirely
+// of index equality (ScanTypeIndexPoint) scans that carry no post-index filters
+// and no sub-scans.  For such plans only IndexKeys change between executions
+// of the same prepared statement; they can be cheaply re-derived via
+// rehydratePlanIndexKeys without re-running the full planner.
+func planIsCacheableWithConditions(plan QueryPlan) bool {
+	if len(plan.Scans) == 0 {
+		return false
+	}
+	for _, scan := range plan.Scans {
+		if scan.Type != ScanTypeIndexPoint {
+			return false
+		}
+		if len(scan.Filters) > 0 || len(scan.SubScans) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// rehydratePlanIndexKeys returns a copy of plan with the IndexKeys on each
+// ScanTypeIndexPoint scan rebuilt from the current bound stmt.Conditions.
+// plan.Scans[i] is assumed to correspond to stmt.Conditions[i] — which holds
+// for plans produced by setIndexScans (one scan per OR group, in group order).
+// Returns (plan, false) if re-hydration cannot proceed, signalling a fallback
+// to a full re-plan.
+func rehydratePlanIndexKeys(plan QueryPlan, stmt Statement, t *Table) (QueryPlan, bool) {
+	scans := make([]Scan, len(plan.Scans))
+	copy(scans, plan.Scans)
+	for i := range scans {
+		if scans[i].Type != ScanTypeIndexPoint {
+			continue
+		}
+		if i >= len(stmt.Conditions) {
+			return plan, false
+		}
+		keys := extractScanIndexKeys(t, scans[i], stmt.Conditions[i])
+		if keys == nil {
+			return plan, false
+		}
+		scans[i].IndexKeys = keys
+	}
+	plan.Scans = scans
+	return plan, true
+}
+
+// extractScanIndexKeys re-derives the IndexKeys for one ScanTypeIndexPoint scan by
+// matching each of the scan's IndexColumns against the conditions in group and
+// calling equalityKeys.  Returns nil if any column cannot be matched.
+func extractScanIndexKeys(t *Table, scan Scan, group Conditions) []any {
+	var keys []any
+	for _, indexCol := range scan.IndexColumns {
+		col, ok := t.ColumnByName(indexCol.Name)
+		if !ok {
+			return nil
+		}
+		for _, cond := range group {
+			if cond.Operand1.Type != OperandField {
+				continue
+			}
+			field, ok := cond.Operand1.Value.(Field)
+			if !ok || field.Name != indexCol.Name {
+				continue
+			}
+			if !isEquality(cond) || cond.Operand2.Type == OperandNull {
+				continue
+			}
+			extracted, err := equalityKeys(col, cond)
+			if err != nil || len(extracted) == 0 {
+				return nil
+			}
+			keys = append(keys, extracted...)
+			break
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return keys
 }
 
 // applyScanLimit attaches a ScanLimit to each scan in the plan when LIMIT is present


### PR DESCRIPTION
PlanQuery now caches the plan structure (index selection, scan type) for prepared statements with simple indexed equality WHERE clauses, not just condition-free queries.  On a cache hit, rehydratePlanIndexKeys rebuilds only the IndexKeys slice from the current bound values without re-running the full planner.

planConditionsAreCacheable guards against caching when any operand is a subquery, expression tree, or unbound placeholder. planIsCacheableWithConditions gates storage to ScanTypeIndexPoint-only plans with no secondary filters or sub-scans.

Effect on Update_ByPK: 5.7 KiB/53 allocs → 5.2 KiB/46 allocs (−13% allocs).
Delete_ByPK also benefits: 5.9 KiB/73 → 5.3 KiB/65 (−11% allocs).

Also fixes corrupted ScanType constants introduced by a prior replace_all error (ScanTypeIndexPointPoint → ScanTypeIndexPoint, etc.).