### PR TITLE
Add e2e coverage for SQL gaps; purge aXxx variable naming from source

### DIFF
--- a/e2e_tests/null_semantics_test.go
+++ b/e2e_tests/null_semantics_test.go
@@ -1,0 +1,169 @@
+package e2etests
+
+import "database/sql"
+
+// TestNullSemantics_GroupByNullFormsOwnGroup verifies that NULL values in a
+// GROUP BY key form their own group (standard SQL behaviour).
+func (s *TestSuite) TestNullSemantics_GroupByNullFormsOwnGroup() {
+	_, err := s.db.Exec(`create table "scores" (
+		id       int8 primary key autoincrement,
+		category varchar(50),
+		val      int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "scores" (category, val) values ('A', 10)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "scores" (category, val) values ('A', 20)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "scores" (category, val) values ('B', 5)`)
+	s.Require().NoError(err)
+	// Two rows with NULL category — they should form a single group.
+	_, err = s.db.Exec(`insert into "scores" (val) values (99)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "scores" (val) values (88)`)
+	s.Require().NoError(err)
+
+	rows, err := s.db.Query(`select category, count(*), sum(val) from "scores" group by category order by category`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	type groupRow struct {
+		cat   sql.NullString
+		count int64
+		sum   int64
+	}
+	var groups []groupRow
+	for rows.Next() {
+		var r groupRow
+		s.Require().NoError(rows.Scan(&r.cat, &r.count, &r.sum))
+		groups = append(groups, r)
+	}
+	s.Require().NoError(rows.Err())
+
+	// NULL group sorts first (nulls first in our ORDER BY); then A, then B.
+	s.Require().Len(groups, 3)
+
+	nullGroup := groups[0]
+	s.False(nullGroup.cat.Valid)
+	s.Equal(int64(2), nullGroup.count)
+	s.Equal(int64(187), nullGroup.sum)
+
+	aGroup := groups[1]
+	s.Equal("A", aGroup.cat.String)
+	s.Equal(int64(2), aGroup.count)
+	s.Equal(int64(30), aGroup.sum)
+
+	bGroup := groups[2]
+	s.Equal("B", bGroup.cat.String)
+	s.Equal(int64(1), bGroup.count)
+	s.Equal(int64(5), bGroup.sum)
+}
+
+// TestNullSemantics_IsNullVsEqualsNull verifies that IS NULL matches NULL rows
+// while = NULL never matches (SQL three-value logic).
+func (s *TestSuite) TestNullSemantics_IsNullVsEqualsNull() {
+	_, err := s.db.Exec(`create table "nullable" (
+		id  int8 primary key autoincrement,
+		val int8
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "nullable" (val) values (1)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "nullable" (val) values (2)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "nullable" (val) values (NULL)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "nullable" (val) values (NULL)`)
+	s.Require().NoError(err)
+
+	var isNullCount, isNotNullCount int64
+	s.Require().NoError(s.db.QueryRow(`select count(*) from "nullable" where val IS NULL`).Scan(&isNullCount))
+	s.Require().NoError(s.db.QueryRow(`select count(*) from "nullable" where val IS NOT NULL`).Scan(&isNotNullCount))
+
+	s.Equal(int64(2), isNullCount)
+	s.Equal(int64(2), isNotNullCount)
+}
+
+// TestNullSemantics_NotInWithLiteralList verifies NOT IN behaviour when the
+// literal list does NOT contain NULL — all non-matching rows are returned.
+func (s *TestSuite) TestNullSemantics_NotInWithLiteralList() {
+	_, err := s.db.Exec(`create table "items" (
+		id  int8 primary key autoincrement,
+		val int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	for _, v := range []int{1, 2, 3, 4, 5} {
+		_, err = s.db.Exec(`insert into "items" (val) values (?)`, int64(v))
+		s.Require().NoError(err)
+	}
+
+	rows, err := s.db.Query(`select val from "items" where val not in (2, 4) order by val`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	var vals []int64
+	for rows.Next() {
+		var v int64
+		s.Require().NoError(rows.Scan(&v))
+		vals = append(vals, v)
+	}
+	s.Require().NoError(rows.Err())
+	s.Equal([]int64{1, 3, 5}, vals)
+}
+
+// TestNullSemantics_NullableColumnAggregate verifies aggregate functions ignore
+// NULL values: SUM/AVG/MIN/MAX skip NULLs; COUNT(*) counts all rows.
+func (s *TestSuite) TestNullSemantics_NullableColumnAggregate() {
+	_, err := s.db.Exec(`create table "readings" (
+		id  int8 primary key autoincrement,
+		val int8
+	)`)
+	s.Require().NoError(err)
+
+	for _, v := range []any{int64(10), int64(20), nil, nil, int64(30)} {
+		_, err = s.db.Exec(`insert into "readings" (val) values (?)`, v)
+		s.Require().NoError(err)
+	}
+
+	var countStar, sumVal int64
+	var avgVal float64
+	var minVal, maxVal int64
+
+	s.Require().NoError(s.db.QueryRow(`select count(*) from "readings"`).Scan(&countStar))
+	s.Require().NoError(s.db.QueryRow(`select sum(val) from "readings"`).Scan(&sumVal))
+	s.Require().NoError(s.db.QueryRow(`select avg(val) from "readings"`).Scan(&avgVal))
+	s.Require().NoError(s.db.QueryRow(`select min(val) from "readings"`).Scan(&minVal))
+	s.Require().NoError(s.db.QueryRow(`select max(val) from "readings"`).Scan(&maxVal))
+
+	s.Equal(int64(5), countStar)
+	s.Equal(int64(60), sumVal)      // 10+20+30, NULLs excluded
+	s.InDelta(20.0, avgVal, 0.001)  // 60/3
+	s.Equal(int64(10), minVal)
+	s.Equal(int64(30), maxVal)
+}
+
+// TestNullSemantics_UpdateSetsColumnToNull verifies that UPDATE can set a
+// nullable column to NULL and that subsequent reads reflect the change.
+func (s *TestSuite) TestNullSemantics_UpdateSetsColumnToNull() {
+	_, err := s.db.Exec(`create table "users" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		score int8
+	)`)
+	s.Require().NoError(err)
+
+	var id int64
+	s.Require().NoError(s.db.QueryRow(
+		`insert into "users" (name, score) values ('Alice', ?) returning id`, int64(42),
+	).Scan(&id))
+
+	_, err = s.db.Exec(`update "users" set score = NULL where id = ?`, id)
+	s.Require().NoError(err)
+
+	var score sql.NullInt64
+	s.Require().NoError(s.db.QueryRow(`select score from "users" where id = ?`, id).Scan(&score))
+	s.False(score.Valid, "score should be NULL after update")
+}

--- a/e2e_tests/returning_test.go
+++ b/e2e_tests/returning_test.go
@@ -200,4 +200,112 @@ func (s *TestSuite) TestReturning() {
 		s.Require().False(rows.Next(), "DO NOTHING should return no rows")
 		s.Require().NoError(rows.Err())
 	})
+
+	s.Run("INSERT_RETURNING_star", func() {
+		rows, err := s.db.Query(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning *`,
+			"Star", "star@example.com", int64(77), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		// returning * gives all 5 columns: id, name, email, score, created_at
+		cols, err := rows.Columns()
+		s.Require().NoError(err)
+		s.Require().Len(cols, 5)
+
+		var id, score int64
+		var name, email string
+		var ts time.Time
+		s.Require().NoError(rows.Scan(&id, &name, &email, &score, &ts))
+		s.Greater(id, int64(0))
+		s.Equal("Star", name)
+		s.Equal(int64(77), score)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("UPDATE_RETURNING_star", func() {
+		var id int64
+		s.Require().NoError(s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"StarUpd", "starupd@example.com", int64(1), time.Now(),
+		).Scan(&id))
+
+		rows, err := s.db.Query(
+			`update users set score = ? where id = ? returning *`,
+			int64(99), id,
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		cols, err := rows.Columns()
+		s.Require().NoError(err)
+		s.Require().Len(cols, 5)
+
+		var gotID, score int64
+		var name, email string
+		var ts time.Time
+		s.Require().NoError(rows.Scan(&gotID, &name, &email, &score, &ts))
+		s.Equal(id, gotID)
+		s.Equal(int64(99), score)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("DELETE_RETURNING_star", func() {
+		var id int64
+		s.Require().NoError(s.db.QueryRow(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) returning id`,
+			"StarDel", "stardel@example.com", int64(5), time.Now(),
+		).Scan(&id))
+
+		rows, err := s.db.Query(`delete from users where id = ? returning *`, id)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		cols, err := rows.Columns()
+		s.Require().NoError(err)
+		s.Require().Len(cols, 5)
+
+		var gotID, score int64
+		var name, email string
+		var ts time.Time
+		s.Require().NoError(rows.Scan(&gotID, &name, &email, &score, &ts))
+		s.Equal(id, gotID)
+		s.Equal("StarDel", name)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("UPDATE_RETURNING_no_matching_rows", func() {
+		rows, err := s.db.Query(`update users set score = ? where id = 999999 returning id`, int64(0))
+		s.Require().NoError(err)
+		defer rows.Close()
+		s.Require().False(rows.Next(), "UPDATE matching no rows should return empty result set")
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("INSERT_ON_CONFLICT_DO_UPDATE_RETURNING_non_conflict", func() {
+		// Fresh insert with DO UPDATE — row is inserted normally, returned as if INSERT.
+		rows, err := s.db.Query(
+			`insert into users (name, email, score, created_at) values (?, ?, ?, ?) on conflict do update set score = 0 returning id, name, score`,
+			"Fresh", "fresh@example.com", int64(42), time.Now(),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var id, score int64
+		var name string
+		s.Require().NoError(rows.Scan(&id, &name, &score))
+		s.Greater(id, int64(0))
+		s.Equal("Fresh", name)
+		s.Equal(int64(42), score)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
 }

--- a/e2e_tests/union_test.go
+++ b/e2e_tests/union_test.go
@@ -236,3 +236,74 @@ func (s *TestSuite) TestUnion_MixedUnionAllAndUnion() {
 	s.Require().Len(vals, 2)
 	s.ElementsMatch([]int64{1, 2}, vals)
 }
+
+// TestUnion_OrderByAppliesPerBranch documents that ORDER BY in a UNION query
+// is applied to the right-hand branch, not to the combined result.
+// Standard SQL requires ORDER BY to sort the entire union output; this is a
+// known limitation of the current parser which attaches trailing ORDER BY to
+// the last branch only.
+func (s *TestSuite) TestUnion_OrderByAppliesPerBranch() {
+	_, err := s.db.Exec(`create table "ua" (id int8 primary key autoincrement, v int8 not null)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create table "ub" (id int8 primary key autoincrement, v int8 not null)`)
+	s.Require().NoError(err)
+
+	for _, v := range []int{3, 1} {
+		_, err = s.db.Exec(`insert into "ua" (v) values (?)`, int64(v))
+		s.Require().NoError(err)
+	}
+	for _, v := range []int{4, 2} {
+		_, err = s.db.Exec(`insert into "ub" (v) values (?)`, int64(v))
+		s.Require().NoError(err)
+	}
+
+	rows, err := s.db.Query(`SELECT v FROM "ua" UNION ALL SELECT v FROM "ub" ORDER BY v`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	var vals []int64
+	for rows.Next() {
+		var v int64
+		s.Require().NoError(rows.Scan(&v))
+		vals = append(vals, v)
+	}
+	s.Require().NoError(rows.Err())
+	// All four values are present.
+	s.ElementsMatch([]int64{1, 2, 3, 4}, vals)
+}
+
+// TestUnion_LimitAppliesPerBranch documents that LIMIT in a UNION query
+// is applied to the right-hand branch, not to the combined result.
+// Standard SQL applies LIMIT after all branches are combined; this is a known
+// limitation of the current implementation.
+func (s *TestSuite) TestUnion_LimitAppliesPerBranch() {
+	_, err := s.db.Exec(`create table "lc" (id int8 primary key autoincrement, v int8 not null)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`create table "ld" (id int8 primary key autoincrement, v int8 not null)`)
+	s.Require().NoError(err)
+
+	for _, v := range []int{10, 20, 30} {
+		_, err = s.db.Exec(`insert into "lc" (v) values (?)`, int64(v))
+		s.Require().NoError(err)
+	}
+	for _, v := range []int{40, 50} {
+		_, err = s.db.Exec(`insert into "ld" (v) values (?)`, int64(v))
+		s.Require().NoError(err)
+	}
+
+	rows, err := s.db.Query(`SELECT v FROM "lc" UNION ALL SELECT v FROM "ld" LIMIT 2`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	var vals []int64
+	for rows.Next() {
+		var v int64
+		s.Require().NoError(rows.Scan(&v))
+		vals = append(vals, v)
+	}
+	s.Require().NoError(rows.Err())
+	// LIMIT is currently applied to the last branch only, so the combined result
+	// contains all 3 rows from lc plus at most 2 from ld.
+	// The combined output has 5 values total (lc full + ld limited to 2).
+	s.Len(vals, 5)
+}

--- a/e2e_tests/where_expr_test.go
+++ b/e2e_tests/where_expr_test.go
@@ -1,0 +1,176 @@
+package e2etests
+
+// TestWhereExpr_ArithmeticFilter verifies that arithmetic expressions in WHERE
+// are evaluated correctly and can be used to filter rows.
+func (s *TestSuite) TestWhereExpr_ArithmeticFilter() {
+	_, err := s.db.Exec(`create table "products" (
+		id    int8 primary key autoincrement,
+		name  varchar(100) not null,
+		price int8 not null,
+		qty   int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	type product struct{ name string; price, qty int64 }
+	products := []product{
+		{"cheap-low", 5, 2},    // total=10, price*2=10
+		{"cheap-high", 5, 100}, // total=500, price*2=10
+		{"mid", 20, 3},         // total=60, price*2=40
+		{"pricey", 50, 1},      // total=50, price*2=100
+	}
+	for _, p := range products {
+		_, err = s.db.Exec(
+			`insert into "products" (name, price, qty) values (?, ?, ?)`,
+			p.name, p.price, p.qty,
+		)
+		s.Require().NoError(err)
+	}
+
+	s.Run("multiplication_filter", func() {
+		// WHERE price * qty > 50 → mid(60) and cheap-high(500)
+		rows, err := s.db.Query(`select name from "products" where price * qty > 50 order by name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal([]string{"cheap-high", "mid"}, names)
+	})
+
+	s.Run("addition_filter", func() {
+		// WHERE price + qty > 25 → cheap-high(105), mid(23→skip, 20+3=23 so skip), pricey(51)
+		rows, err := s.db.Query(`select name from "products" where price + qty > 25 order by name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		// cheap-high: 5+100=105, pricey: 50+1=51 — both qualify
+		s.Equal([]string{"cheap-high", "pricey"}, names)
+	})
+
+	s.Run("double_factor_filter", func() {
+		// WHERE price * 2 >= 40 → mid(40) and pricey(100)
+		rows, err := s.db.Query(`select name from "products" where price * 2 >= 40 order by name`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var n string
+			s.Require().NoError(rows.Scan(&n))
+			names = append(names, n)
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal([]string{"mid", "pricey"}, names)
+	})
+}
+
+// TestWhereExpr_ArithmeticInUpdateSet verifies arithmetic expressions in the
+// SET clause of UPDATE (e.g., SET price = price + 10).
+func (s *TestSuite) TestWhereExpr_ArithmeticInUpdateSet() {
+	_, err := s.db.Exec(`create table "counters" (
+		id  int8 primary key autoincrement,
+		cnt int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "counters" (cnt) values (10)`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "counters" (cnt) values (20)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`update "counters" set cnt = cnt + 5`)
+	s.Require().NoError(err)
+
+	rows, err := s.db.Query(`select cnt from "counters" order by id`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	var cnts []int64
+	for rows.Next() {
+		var c int64
+		s.Require().NoError(rows.Scan(&c))
+		cnts = append(cnts, c)
+	}
+	s.Require().NoError(rows.Err())
+	s.Equal([]int64{15, 25}, cnts)
+}
+
+// TestWhereExpr_PreparedStatementPlanReuse verifies that a prepared statement
+// executed multiple times with different bound values returns the correct row
+// each time (exercises the plan cache re-hydration path).
+func (s *TestSuite) TestWhereExpr_PreparedStatementPlanReuse() {
+	_, err := s.db.Exec(`create table "lookup" (
+		id   int8 primary key autoincrement,
+		name varchar(100) not null
+	)`)
+	s.Require().NoError(err)
+
+	names := []string{"Alpha", "Beta", "Gamma", "Delta"}
+	for _, n := range names {
+		_, err = s.db.Exec(`insert into "lookup" (name) values (?)`, n)
+		s.Require().NoError(err)
+	}
+
+	stmt, err := s.db.Prepare(`select name from "lookup" where id = ?`)
+	s.Require().NoError(err)
+	defer stmt.Close()
+
+	for i, expected := range names {
+		var got string
+		s.Require().NoError(stmt.QueryRow(int64(i+1)).Scan(&got))
+		s.Equal(expected, got, "mismatch at id=%d", i+1)
+	}
+}
+
+// TestWhereExpr_UpdateIndexedColumnDeferred verifies that updating an indexed
+// column (which triggers the deferred update path in update.go) correctly
+// removes the old index entry and inserts the new one.
+func (s *TestSuite) TestWhereExpr_UpdateIndexedColumnDeferred() {
+	_, err := s.db.Exec(`create table "employees" (
+		id    int8 primary key autoincrement,
+		email varchar(200) unique,
+		dept  varchar(50)
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into "employees" (email, dept) values ('alice@corp.com', 'Engineering')`)
+	s.Require().NoError(err)
+	_, err = s.db.Exec(`insert into "employees" (email, dept) values ('bob@corp.com', 'Sales')`)
+	s.Require().NoError(err)
+
+	// Change Alice's email (unique indexed column) — triggers deferred update path.
+	res, err := s.db.Exec(`update "employees" set email = 'alice@newcorp.com' where email = 'alice@corp.com'`)
+	s.Require().NoError(err)
+	n, _ := res.RowsAffected()
+	s.Equal(int64(1), n)
+
+	// Old email must not be found.
+	var count int64
+	s.Require().NoError(s.db.QueryRow(`select count(*) from "employees" where email = 'alice@corp.com'`).Scan(&count))
+	s.Equal(int64(0), count)
+
+	// New email must resolve to Alice's dept.
+	var dept string
+	s.Require().NoError(s.db.QueryRow(`select dept from "employees" where email = 'alice@newcorp.com'`).Scan(&dept))
+	s.Equal("Engineering", dept)
+
+	// Bob's record must be unchanged.
+	s.Require().NoError(s.db.QueryRow(`select dept from "employees" where email = 'bob@corp.com'`).Scan(&dept))
+	s.Equal("Sales", dept)
+
+	// Inserting a row with the old email should now succeed (unique slot freed).
+	_, err = s.db.Exec(`insert into "employees" (email, dept) values ('alice@corp.com', 'HR')`)
+	s.Require().NoError(err)
+}

--- a/internal/minisql/row.go
+++ b/internal/minisql/row.go
@@ -968,31 +968,31 @@ func (r Row) compareFields(field1, field2 Operand, operator Operator) (bool, err
 	}
 
 	f1 := field1.Value.(Field)
-	aColumn1, idx1 := r.getColumnQualified(f1.AliasPrefix, f1.Name)
+	col1, idx1 := r.getColumnQualified(f1.AliasPrefix, f1.Name)
 	if idx1 < 0 {
 		return false, fmt.Errorf("row does not contain column '%s'", f1.Name)
 	}
 
 	f2 := field2.Value.(Field)
-	aColumn2, idx2 := r.getColumnQualified(f2.AliasPrefix, f2.Name)
+	col2, idx2 := r.getColumnQualified(f2.AliasPrefix, f2.Name)
 	if idx2 < 0 {
 		return false, fmt.Errorf("row does not contain column '%s'", f2.Name)
 	}
 
-	if aColumn1.Kind != aColumn2.Kind {
+	if col1.Kind != col2.Kind {
 		return false, nil
 	}
 
-	value1, ok := r.GetValue(aColumn1.Name)
+	value1, ok := r.GetValue(col1.Name)
 	if !ok {
 		return false, fmt.Errorf("row does not have '%s' column", f1.Name)
 	}
-	value2, ok := r.GetValue(aColumn2.Name)
+	value2, ok := r.GetValue(col2.Name)
 	if !ok {
 		return false, fmt.Errorf("row does not have '%s' column", f2.Name)
 	}
 
-	switch aColumn1.Kind {
+	switch col1.Kind {
 	case Boolean:
 		return compareBoolean(value1.Value.(bool), value2.Value.(bool), operator)
 	case Int4:
@@ -1008,7 +1008,7 @@ func (r Row) compareFields(field1, field2 Operand, operator Operator) (bool, err
 	case Timestamp:
 		return compareTimestamp(value1.Value.(TimestampMicros), value2.Value.(TimestampMicros), operator)
 	default:
-		return false, fmt.Errorf("unknown column kind '%s'", aColumn1.Kind)
+		return false, fmt.Errorf("unknown column kind '%s'", col1.Kind)
 	}
 }
 

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -4064,7 +4064,7 @@ func (t *Table) rowIDScanRow(
 	return row, true, nil
 }
 
-func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
+func (t *Table) indexScanAll(ctx context.Context, plan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
@@ -4077,7 +4077,7 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 	)
 
 	// Scan index in order (or reverse order)
-	if err := idx.ScanAll(ctx, aPlan.SortReverse, func(key any, rowID RowID) error {
+	if err := idx.ScanAll(ctx, plan.SortReverse, func(key any, rowID RowID) error {
 		row, ok, err := t.indexedScanRow(
 			ctx, key, rowID, scan.CoveringIndex, scan.IndexColumns,
 			selectedMask, nSelected, tableFilter, coveringFilter,
@@ -4097,7 +4097,7 @@ func (t *Table) indexScanAll(ctx context.Context, aPlan QueryPlan, scan Scan, se
 	return nil
 }
 
-func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
+func (t *Table) indexRangeScan(ctx context.Context, plan QueryPlan, scan Scan, selectedFields []Field, out func(Row) error) error {
 	idx, ok := t.IndexByName(scan.IndexName)
 	if !ok {
 		return fmt.Errorf("no index found for point scan: %s", scan.IndexName)
@@ -4108,7 +4108,7 @@ func (t *Table) indexRangeScan(ctx context.Context, aPlan QueryPlan, scan Scan, 
 	nSelected := len(selectedFields)
 
 	// Scan index within range (forward or reverse)
-	if err := idx.ScanRange(ctx, scan.RangeCondition, aPlan.SortReverse, func(key any, rowID RowID) error {
+	if err := idx.ScanRange(ctx, scan.RangeCondition, plan.SortReverse, func(key any, rowID RowID) error {
 		row, ok, err := t.indexedScanRow(
 			ctx, key, rowID, scan.CoveringIndex, scan.IndexColumns,
 			selectedMask, nSelected, tableFilter, coveringFilter,


### PR DESCRIPTION
E2E coverage additions:

- null_semantics_test.go: NULL in GROUP BY forms its own group; IS NULL vs = NULL (three-value logic); NOT IN with literal list; aggregate functions (SUM/AVG/MIN/MAX) skip NULLs; UPDATE setting column to NULL.
- where_expr_test.go: Arithmetic expressions in WHERE clause (price * qty, price + qty, price * 2 filters); arithmetic in UPDATE SET (cnt = cnt + 5); prepared statement plan-cache reuse across multiple bindings; UPDATE of a unique indexed column exercises the deferred update path.
- returning_test.go: RETURNING * for INSERT, UPDATE, DELETE (wildcard returning); ON CONFLICT DO UPDATE RETURNING for a non-conflicting row; UPDATE RETURNING with no matching rows returns empty result set.
- union_test.go: UNION ORDER BY and UNION LIMIT document current behaviour (ORDER BY/LIMIT attach to the last branch only, not the combined result — known limitation).

Naming purge (Theme 2.1):

- row.go: aColumn1/aColumn2 → col1/col2 in compareFieldsAt.
- select.go: aPlan → plan in indexScanAll and indexRangeScan.