### PR TITLE
docs: fill in godoc stubs in root package public API

### DIFF
--- a/minisql.go
+++ b/minisql.go
@@ -162,7 +162,8 @@ type Conn struct {
 	slowQueryThreshold time.Duration
 }
 
-// Ping ...
+// Ping verifies the connection is still alive. MiniSQL is an embedded engine
+// with no network layer, so this always succeeds.
 func (c *Conn) Ping(ctx context.Context) error {
 	// TODO - implement a real ping?
 	return nil
@@ -340,21 +341,24 @@ func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 	}, nil
 }
 
-// SetTransaction ...
+// SetTransaction associates an active write transaction with this connection.
+// Passing nil clears the current transaction after commit or rollback.
 func (c *Conn) SetTransaction(tx *minisql.Transaction) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.transaction = tx
 }
 
-// HasActiveTransaction ...
+// HasActiveTransaction reports whether an explicit BEGIN transaction is
+// currently open on this connection.
 func (c *Conn) HasActiveTransaction() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.transaction != nil
 }
 
-// TransactionContext ...
+// TransactionContext returns a context that carries the connection's active
+// transaction, or the original context if no transaction is open.
 func (c *Conn) TransactionContext(ctx context.Context) context.Context {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/result.go
+++ b/result.go
@@ -1,6 +1,7 @@
 package minisql
 
-// Result ...
+// Result is a database/sql/driver.Result implementation returned by INSERT,
+// UPDATE, and DELETE statements.
 type Result struct {
 	rowsAffected int64
 	lastInsertID int64

--- a/rows.go
+++ b/rows.go
@@ -9,7 +9,9 @@ import (
 	"github.com/RichardKnop/minisql/internal/minisql"
 )
 
-// Rows ...
+// Rows is a database/sql/driver.Rows implementation that iterates over the
+// results of a SELECT query. It supports both the materialised row iterator
+// path and the zero-copy RowView path used by covering-index scans.
 type Rows struct {
 	columns             []minisql.Column
 	rowViewFieldIndexes []int

--- a/stmt.go
+++ b/stmt.go
@@ -10,7 +10,9 @@ import (
 	"github.com/RichardKnop/minisql/internal/minisql"
 )
 
-// Stmt ...
+// Stmt is a database/sql/driver.Stmt implementation for a prepared SQL
+// statement. It holds a pre-parsed statement and binds arguments at execution
+// time via ExecContext or QueryContext.
 type Stmt struct {
 	conn      *Conn
 	query     string
@@ -49,7 +51,9 @@ func (s Stmt) Exec(args []driver.Value) (driver.Result, error) {
 	return nil, fmt.Errorf("Exec without context is not supported; use ExecContext instead")
 }
 
-// ExecContext ...
+// ExecContext executes the prepared statement with the given arguments.
+// It binds placeholder values, runs the statement, and returns the affected
+// row count and last-insert-id wrapped in a Result.
 func (s Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (result driver.Result, err error) {
 	start := time.Now()
 	defer func() {
@@ -82,7 +86,9 @@ func (s Stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return nil, fmt.Errorf("Query without context is not supported; use QueryContext instead")
 }
 
-// QueryContext ...
+// QueryContext executes the prepared query with the given arguments and returns
+// the result rows. A read-only snapshot transaction is opened automatically for
+// SELECT statements and committed when the returned Rows is closed.
 func (s Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	start := time.Now()
 	defer func() {

--- a/tx.go
+++ b/tx.go
@@ -6,14 +6,18 @@ import (
 	"github.com/RichardKnop/minisql/internal/minisql"
 )
 
-// Tx ...
+// Tx is a database/sql/driver.Tx implementation representing an explicit
+// BEGIN/COMMIT/ROLLBACK transaction. Write transactions use Optimistic
+// Concurrency Control (OCC); conflicts return pkg/errors.ErrTxConflict.
 type Tx struct {
 	conn *Conn
 	tx   *minisql.Transaction
 	ctx  context.Context
 }
 
-// Commit ...
+// Commit flushes the transaction's write set to the WAL and clears the active
+// transaction on the connection. Returns pkg/errors.ErrTxConflict if a
+// concurrent write transaction modified a page read by this transaction.
 func (tx Tx) Commit() error {
 	if err := tx.conn.db.GetTransactionManager().CommitTransaction(tx.ctx, tx.tx); err != nil {
 		return err
@@ -22,7 +26,8 @@ func (tx Tx) Commit() error {
 	return nil
 }
 
-// Rollback ...
+// Rollback discards all writes made in this transaction and clears the active
+// transaction on the connection. It never returns an error.
 func (tx Tx) Rollback() error {
 	tx.conn.db.GetTransactionManager().RollbackTransaction(tx.ctx, tx.tx)
 	tx.conn.SetTransaction(nil)


### PR DESCRIPTION
Replace all // Foo ... placeholder comments with accurate one-line or multi-line godoc on Conn, Rows, Stmt, Tx, and Result. Covers Ping, SetTransaction, HasActiveTransaction, TransactionContext, ExecContext, QueryContext, Commit, Rollback, and the type-level docs for each type. pkg/ packages (bloom, lrucache, bitwise) were already fully documented.