### PR TITLE
feat: add CRC32-IEEE page checksums for corruption detection

### DIFF
--- a/internal/minisql/index_node.go
+++ b/internal/minisql/index_node.go
@@ -661,10 +661,10 @@ func copyIndexNode(anyNode any) any {
 	}
 }
 
-// MaxSpace returns the total bytes available for cells in a page (page size minus header).
+// MaxSpace returns the total bytes available for cells in a page (page size minus header
+// and the 4-byte CRC32 checksum reserved at the end of every page).
 func (n *IndexNode[T]) MaxSpace() uint64 {
-	maxSpace := PageSize - indexHeaderSize()
-	return maxSpace
+	return PageSize - indexHeaderSize() - pageChecksumSize
 }
 
 // TakenSpace returns the total number of bytes currently occupied by all cells

--- a/internal/minisql/internal_node.go
+++ b/internal/minisql/internal_node.go
@@ -5,11 +5,11 @@ import (
 )
 
 // InternalNode capacity constants derived from page and header sizes.
-// Page size: 4096, Header size: 6 (base) + 8 (internal), ICell size: 12.
+// Page size: 4096, Header size: 6 (base) + 8 (internal), ICell size: 12, checksum: 4.
 const (
-	// InternalNodeMaxCells is (4096 - 6 - 8) / 12.
-	InternalNodeMaxCells = 340
-	// RootInternalNodeMaxCells is (4096 - 6 - 8 - 100) / 12.
+	// InternalNodeMaxCells is (4096 - 6 - 8 - 4) / 12.
+	InternalNodeMaxCells = 339
+	// RootInternalNodeMaxCells is (4096 - 6 - 8 - 100 - 4) / 12.
 	RootInternalNodeMaxCells = 331
 )
 

--- a/internal/minisql/inverted_index.go
+++ b/internal/minisql/inverted_index.go
@@ -2435,12 +2435,12 @@ func groupInvertedPostingBlocksIntoPages(blocks []invertedPostingBlock, level by
 		candidate := append(append([]invertedPostingBlock(nil), groups[lastIdx]...), block)
 		page := NewInvertedPostingPage(level)
 		page.Blocks = candidate
-		if err := ensureInvertedPostingPageFits(page, PageSize); err == nil {
+		if err := ensureInvertedPostingPageFits(page, PageSize-pageChecksumSize); err == nil {
 			groups[lastIdx] = candidate
 			continue
 		}
 		page.Blocks = []invertedPostingBlock{block}
-		if err := ensureInvertedPostingPageFits(page, PageSize); err != nil {
+		if err := ensureInvertedPostingPageFits(page, PageSize-pageChecksumSize); err != nil {
 			return nil, err
 		}
 		groups = append(groups, []invertedPostingBlock{block})
@@ -2582,12 +2582,13 @@ func invertedPostingPageUsedBytes(page *invertedPostingPage) uint64 {
 	return used
 }
 
-// invertedPageBodySize returns usable bytes for root and non-root inverted pages.
+// invertedPageBodySize returns usable bytes for root and non-root inverted pages,
+// excluding the 4-byte CRC32 checksum reserved at the end of every page.
 func invertedPageBodySize(pageIdx PageIndex) int {
 	if pageIdx == 0 {
-		return PageSize - RootPageConfigSize
+		return PageSize - RootPageConfigSize - pageChecksumSize
 	}
-	return PageSize
+	return PageSize - pageChecksumSize
 }
 
 // boolToInt converts found flags into slice-bound offsets.

--- a/internal/minisql/inverted_page.go
+++ b/internal/minisql/inverted_page.go
@@ -106,7 +106,7 @@ func NewInvertedEntryPage(isLeaf bool) *invertedEntryPage {
 		FormatVersion: invertedPageFormatVersion,
 		IsLeaf:        isLeaf,
 		FreeStart:     uint16((invertedEntryPageHeader{}).size()),
-		FreeEnd:       PageSize,
+		FreeEnd:       PageSize - pageChecksumSize,
 	}
 	return &invertedEntryPage{Header: header}
 }
@@ -345,7 +345,7 @@ func NewInvertedPostingPage(level byte) *invertedPostingPage {
 		FormatVersion: invertedPageFormatVersion,
 		Level:         level,
 		FreeStart:     uint16((invertedPostingPageHeader{}).size()),
-		FreeEnd:       PageSize,
+		FreeEnd:       PageSize - pageChecksumSize,
 	}
 	return &invertedPostingPage{Header: header}
 }

--- a/internal/minisql/inverted_segment_page.go
+++ b/internal/minisql/inverted_segment_page.go
@@ -77,7 +77,7 @@ func NewInvertedSegmentPage() *invertedSegmentPage {
 	header := invertedSegmentPageHeader{
 		FormatVersion: invertedPageFormatVersion,
 		FreeStart:     uint16((invertedSegmentPageHeader{}).size()),
-		FreeEnd:       PageSize,
+		FreeEnd:       PageSize - pageChecksumSize,
 	}
 	return &invertedSegmentPage{Header: header}
 }

--- a/internal/minisql/leaf_node.go
+++ b/internal/minisql/leaf_node.go
@@ -388,11 +388,12 @@ func (n *LeafNode) Keys() []RowID {
 }
 
 // MaxSpace returns the maximum number of bytes available for cell data in the
-// page, accounting for the larger root-page header when IsRoot is set.
+// page, accounting for the larger root-page header when IsRoot is set and the
+// 4-byte CRC32 checksum reserved at the end of every page.
 func (n *LeafNode) MaxSpace() uint64 {
-	maxSpace := PageSize - headerSize()
+	maxSpace := PageSize - headerSize() - pageChecksumSize
 	if n.Header.IsRoot {
-		maxSpace = PageSize - rootHeaderSize()
+		maxSpace = PageSize - rootHeaderSize() - pageChecksumSize
 	}
 	return maxSpace
 }

--- a/internal/minisql/minisql_test.go
+++ b/internal/minisql/minisql_test.go
@@ -111,12 +111,13 @@ var (
 			},
 		},
 		int((PageSize-uint32(RootPageConfigSize)-
-			7-          // base header
-			8-          // leaf header
-			5*8-        // 5 keys
-			5*8-        // 5 null bitmasks
-			5*1-        // 5 ColumnCount bytes (self-describing cell format)
-			5*8-        // 5×8 TypeCode bytes (8 columns: 6 base + 2 varchars, self-consistent)
+			uint32(pageChecksumSize)- // 4-byte CRC32 checksum at end of page
+			7-                        // base header
+			8-                        // leaf header
+			5*8-                      // 5 keys
+			5*8-                      // 5 null bitmasks
+			5*1-                      // 5 ColumnCount bytes (self-describing cell format)
+			5*8-                      // 5×8 TypeCode bytes (8 columns: 6 base + 2 varchars, self-consistent)
 			5*mediumRowBaseSize)/5),
 	)
 
@@ -163,12 +164,13 @@ var (
 			},
 		},
 		int((PageSize - uint32(RootPageConfigSize) -
-			7 -  // base header
-			8 -  // leaf header
-			8 -  // 1 key
-			8 -  // 1 null bitmask
-			1 -  // 1 ColumnCount byte (self-describing cell format)
-			21 - // 21 TypeCode bytes (21 columns: 6 base + 15 varchars, self-consistent)
+			uint32(pageChecksumSize) - // 4-byte CRC32 checksum at end of page
+			7 -                        // base header
+			8 -                        // leaf header
+			8 -                        // 1 key
+			8 -                        // 1 null bitmask
+			1 -                        // 1 ColumnCount byte (self-describing cell format)
+			21 -                       // 21 TypeCode bytes (21 columns: 6 base + 15 varchars, self-consistent)
 			bigRowBaseSize)),
 	)
 

--- a/internal/minisql/overflow_page.go
+++ b/internal/minisql/overflow_page.go
@@ -9,8 +9,8 @@ const (
 	// leaf cell before the value is spilled to overflow pages.
 	MaxInlineVarchar = 255 // Store up to 255 bytes inline
 	// MaxOverflowPageData is the maximum number of data bytes that fit in a
-	// single overflow page (page size − type byte − header).
-	MaxOverflowPageData = 4096 - 1 - 8 // Page size - page type byte - OverflowPageHeader size
+	// single overflow page (page size − type byte − header − 4-byte checksum).
+	MaxOverflowPageData = PageSize - 1 - 8 - pageChecksumSize
 	// MaxOverflowTextSize limits the maximum size of a text value to 16 overflow pages.
 	MaxOverflowTextSize     = MaxOverflowPageData * 16
 	varcharLengthPrefixSize = 4

--- a/internal/minisql/page.go
+++ b/internal/minisql/page.go
@@ -4,9 +4,14 @@ const (
 	// PageSize is the fixed size in bytes of every database page (4 KiB).
 	PageSize = 4096 // 4 kilobytes
 
+	// pageChecksumSize is the number of bytes reserved at the end of every page
+	// for the CRC32-IEEE checksum (format version 2+).
+	pageChecksumSize = 4
+
 	// UsablePageSize returns the usable size of a page after accounting for headers
-	// Page size minus base + internal/leaf header, minus key and null bitmask
-	UsablePageSize = PageSize - 7 - 8 - 8 - 8
+	// and the trailing 4-byte CRC32 checksum.
+	// Page size minus base + internal/leaf header, minus key and null bitmask, minus checksum.
+	UsablePageSize = PageSize - 7 - 8 - 8 - 8 - pageChecksumSize
 )
 
 // PageIndex is a 0-based index that identifies a page within a database file.

--- a/internal/minisql/pager.go
+++ b/internal/minisql/pager.go
@@ -2,11 +2,14 @@ package minisql
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"sync"
 
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 	"github.com/RichardKnop/minisql/pkg/lrucache"
 )
 
@@ -224,6 +227,9 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 		if err != nil {
 			return nil, err
 		}
+		if err := verifyPageChecksum(buf, pageIdx); err != nil {
+			return nil, err
+		}
 	}
 
 	// Unmarshal the page (CPU-intensive work, no lock held)
@@ -349,6 +355,7 @@ func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
 	}
 
 	if pageIdx != 0 {
+		writePageChecksum(buf)
 		_, err := p.file.WriteAt(buf, int64(pageIdx)*int64(p.pageSize))
 		return err
 	}
@@ -357,6 +364,11 @@ func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
 	if err := dbHeader.MarshalTo(headerBuf[:]); err != nil {
 		return err
 	}
+
+	// Checksum for page 0 covers the full assembled page:
+	// file[0:4092] = headerBuf[0:100] + buf[0:3992].
+	// Store the 4-byte result at buf[3992:3996] (= file[4092:4096]).
+	writeRootPageChecksum(headerBuf[:], buf, p.pageSize)
 
 	_, err := p.file.WriteAt(headerBuf[:], 0)
 	if err != nil {
@@ -442,17 +454,18 @@ func (p *pagerImpl) FlushBatch(ctx context.Context, pageIndices []PageIndex) err
 
 	for _, mp := range marshaled {
 		if !mp.isRoot {
-			// Regular page write
+			writePageChecksum(mp.buf)
 			_, err := p.file.WriteAt(mp.buf, int64(mp.pageIdx)*int64(p.pageSize))
 			if err != nil {
 				return fmt.Errorf("error writing page %d: %w", mp.pageIdx, err)
 			}
 		} else {
-			// Root page with header
 			var headerBuf [RootPageConfigSize]byte
 			if err := mp.header.MarshalTo(headerBuf[:]); err != nil {
 				return fmt.Errorf("error marshaling header: %w", err)
 			}
+
+			writeRootPageChecksum(headerBuf[:], mp.buf, p.pageSize)
 
 			_, err := p.file.WriteAt(headerBuf[:], 0)
 			if err != nil {
@@ -467,6 +480,38 @@ func (p *pagerImpl) FlushBatch(ctx context.Context, pageIndices []PageIndex) err
 	}
 
 	return fastSync(p.file)
+}
+
+// writePageChecksum computes CRC32-IEEE over the first PageSize-4 bytes of buf
+// and stores the result in the last 4 bytes.  Called after marshalPage for all
+// non-root pages.
+func writePageChecksum(buf []byte) {
+	checksum := crc32.ChecksumIEEE(buf[:len(buf)-pageChecksumSize])
+	binary.LittleEndian.PutUint32(buf[len(buf)-pageChecksumSize:], checksum)
+}
+
+// writeRootPageChecksum computes the CRC32-IEEE checksum for the assembled
+// page-0 layout (headerBuf + first (pageSize-RootPageConfigSize-4) bytes of
+// buf) and stores it at buf[pageSize-RootPageConfigSize-4 :
+// pageSize-RootPageConfigSize].  This is the last 4 bytes of the on-disk page.
+func writeRootPageChecksum(headerBuf, buf []byte, pageSize int) {
+	dataEnd := pageSize - RootPageConfigSize - pageChecksumSize // = 3992
+	h := crc32.NewIEEE()
+	h.Write(headerBuf)
+	h.Write(buf[:dataEnd])
+	binary.LittleEndian.PutUint32(buf[dataEnd:dataEnd+pageChecksumSize], h.Sum32())
+}
+
+// verifyPageChecksum reads the CRC32-IEEE stored in the last 4 bytes of buf and
+// compares it against the computed value.  Returns ErrPageChecksumMismatch on
+// mismatch so the caller can surface a corruption error.
+func verifyPageChecksum(buf []byte, pageIdx PageIndex) error {
+	stored := binary.LittleEndian.Uint32(buf[len(buf)-pageChecksumSize:])
+	computed := crc32.ChecksumIEEE(buf[:len(buf)-pageChecksumSize])
+	if stored != computed {
+		return minisqlErrors.PageChecksumError{PageIndex: uint32(pageIdx)}
+	}
+	return nil
 }
 
 func marshalPage(page *Page, buf []byte) error {
@@ -496,29 +541,39 @@ func marshalPage(page *Page, buf []byte) error {
 			return fmt.Errorf("error marshaling index overflow node: %w", err)
 		}
 	case page.InvertedEntryPage != nil:
+		// Reserve pageChecksumSize bytes at the end for the CRC32 checksum.
+		// For page 0 also strip the DB-header prefix (RootPageConfigSize bytes).
 		if page.Index == 0 {
-			buf = buf[:PageSize-RootPageConfigSize]
+			buf = buf[:PageSize-RootPageConfigSize-pageChecksumSize]
+		} else {
+			buf = buf[:PageSize-pageChecksumSize]
 		}
 		if err := page.InvertedEntryPage.Marshal(buf); err != nil {
 			return fmt.Errorf("error marshaling inverted entry page: %w", err)
 		}
 	case page.InvertedPostPage != nil:
 		if page.Index == 0 {
-			buf = buf[:PageSize-RootPageConfigSize]
+			buf = buf[:PageSize-RootPageConfigSize-pageChecksumSize]
+		} else {
+			buf = buf[:PageSize-pageChecksumSize]
 		}
 		if err := page.InvertedPostPage.Marshal(buf); err != nil {
 			return fmt.Errorf("error marshaling inverted posting page: %w", err)
 		}
 	case page.InvertedMetaPage != nil:
 		if page.Index == 0 {
-			buf = buf[:PageSize-RootPageConfigSize]
+			buf = buf[:PageSize-RootPageConfigSize-pageChecksumSize]
+		} else {
+			buf = buf[:PageSize-pageChecksumSize]
 		}
 		if err := page.InvertedMetaPage.Marshal(buf); err != nil {
 			return fmt.Errorf("error marshaling inverted meta page: %w", err)
 		}
 	case page.InvertedSegmentPage != nil:
 		if page.Index == 0 {
-			buf = buf[:PageSize-RootPageConfigSize]
+			buf = buf[:PageSize-RootPageConfigSize-pageChecksumSize]
+		} else {
+			buf = buf[:PageSize-pageChecksumSize]
 		}
 		if err := page.InvertedSegmentPage.Marshal(buf); err != nil {
 			return fmt.Errorf("error marshaling inverted segment page: %w", err)

--- a/internal/minisql/pager_checksum_test.go
+++ b/internal/minisql/pager_checksum_test.go
@@ -1,0 +1,67 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trivialUnmarshaler is a no-op PageUnmarshaler used in checksum tests where
+// the in-memory page representation is irrelevant — we only care about whether
+// the checksum gate fires before unmarshaling is attempted.
+func trivialUnmarshaler(_ uint32, pageIdx PageIndex, _ []byte) (*Page, error) {
+	return &Page{Index: pageIdx, LeafNode: NewLeafNode()}, nil
+}
+
+// TestPager_Checksum_CorruptionDetected verifies that bit-flipping a byte inside
+// a flushed page returns ErrPageChecksumMismatch on the next DB-file read.
+func TestPager_Checksum_CorruptionDetected(t *testing.T) {
+	pager, dbFile := initTest(t)
+
+	// Create a root leaf page and flush it so the CRC32 is written to disk.
+	aRootLeaf := NewLeafNode()
+	aRootLeaf.Header.IsRoot = true
+	pager.pages = append(pager.pages, &Page{LeafNode: aRootLeaf})
+	pager.totalPages = 1
+
+	ctx := context.Background()
+	require.NoError(t, pager.Flush(ctx, 0))
+
+	// Corrupt byte 50 inside page 0 (deep in the B-tree data region, far from
+	// the 4-byte checksum stored at bytes 4092-4095).
+	_, err := dbFile.WriteAt([]byte{0xFF}, 50)
+	require.NoError(t, err)
+
+	// Evict the cached page so the next GetPage reads from disk.
+	pager.InvalidatePage(0)
+
+	// The checksum gate must fire before unmarshaling is attempted.
+	_, err = pager.GetPage(ctx, 0, trivialUnmarshaler)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, minisqlErrors.ErrPageChecksumMismatch,
+		"expected ErrPageChecksumMismatch, got: %v", err)
+}
+
+// TestPager_Checksum_CleanRoundtrip verifies that a page written to disk and
+// read back without corruption passes the checksum check silently.
+func TestPager_Checksum_CleanRoundtrip(t *testing.T) {
+	pager, _ := initTest(t)
+
+	aRootLeaf := NewLeafNode()
+	aRootLeaf.Header.IsRoot = true
+	pager.pages = append(pager.pages, &Page{LeafNode: aRootLeaf})
+	pager.totalPages = 1
+
+	ctx := context.Background()
+	require.NoError(t, pager.Flush(ctx, 0))
+
+	// Evict so the next read goes to disk.
+	pager.InvalidatePage(0)
+
+	page, err := pager.GetPage(ctx, 0, trivialUnmarshaler)
+	require.NoError(t, err)
+	assert.NotNil(t, page)
+}

--- a/internal/minisql/stmt_test.go
+++ b/internal/minisql/stmt_test.go
@@ -497,7 +497,7 @@ func TestStatement_Validate(t *testing.T) {
 
 		err := stmt.Validate(nil)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "potential row size exceeds maximum allowed 4065")
+		assert.ErrorContains(t, err, "potential row size exceeds maximum allowed 4061")
 	})
 
 	t.Run("CREATE TABLE with nullable primary key should fail", func(t *testing.T) {

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -1362,11 +1362,10 @@ func (t *Table) mergeInternalNodes(ctx context.Context, parent, left, right *Pag
 }
 
 func (t *Table) maxICells(pageIdx PageIndex) int {
-	maxICells := t.maximumICells
-	if maxICells == InternalNodeMaxCells && pageIdx == 0 {
-		maxICells = maxICells - uint32(RootPageConfigSize/ICellSize) - 1 // root page has less space
+	if t.maximumICells == InternalNodeMaxCells && pageIdx == 0 {
+		return RootInternalNodeMaxCells
 	}
-	return int(maxICells)
+	return int(t.maximumICells)
 }
 
 type callback func(page *Page)

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -603,6 +603,9 @@ func (tm *TransactionManager) serializeWritesForWAL(ctx context.Context, tx *Tra
 		if err != nil {
 			return nil, fmt.Errorf("serialize page 0 for WAL: %w", err)
 		}
+		// Embed the page checksum so that WAL checkpoint can copy the frame
+		// verbatim to the DB file and GetPage can verify it on next open.
+		writePageChecksum(frame)
 		pages = append(pages, WALPage{Index: 0, Data: frame})
 	}
 
@@ -616,6 +619,7 @@ func (tm *TransactionManager) serializeWritesForWAL(ctx context.Context, tx *Tra
 			releasePages()
 			return nil, fmt.Errorf("marshal page %d for WAL: %w", pageIdx, err)
 		}
+		writePageChecksum(buf)
 		pages = append(pages, WALPage{Index: pageIdx, Data: buf})
 	}
 

--- a/pkg/errors/checksum.go
+++ b/pkg/errors/checksum.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrPageChecksumMismatch is returned when the CRC32 checksum stored in the
+// last four bytes of a database page does not match the computed checksum.
+// This indicates on-disk corruption for the affected page.
+var ErrPageChecksumMismatch = errors.New("page checksum mismatch: possible corruption")
+
+// PageChecksumError carries the page index alongside the sentinel so callers
+// can identify which page is corrupt.
+type PageChecksumError struct {
+	PageIndex uint32
+}
+
+// Error returns a string representation of the PageChecksumError, including the page index.
+func (e PageChecksumError) Error() string {
+	return fmt.Sprintf("page %d: checksum mismatch (possible corruption)", e.PageIndex)
+}
+
+// Is allows errors.Is to recognize PageChecksumError as an ErrPageChecksumMismatch.
+func (e PageChecksumError) Is(target error) bool {
+	return target == ErrPageChecksumMismatch
+}


### PR DESCRIPTION
Reserve 4 bytes at the end of every 4096-byte page for a CRC32-IEEE checksum. Checksums are written at flush time (Flush/FlushBatch) and embedded in WAL frames at serialization time so the checkpoint path carries them verbatim. GetPage verifies the checksum on every DB-file read before unmarshaling, returning ErrPageChecksumMismatch on mismatch.

Bumps DatabaseFileFormatVersion to 2 (clean break; old databases cannot be opened). Adjusts all capacity constants (InternalNodeMaxCells, UsablePageSize, MaxOverflowPageData, inverted page body sizes) to account for the reserved 4 bytes. Adds two pager-level tests.