### PR TITLE
feat: add VECTOR(n) column type with VEC_L2 and VEC_COSINE distance f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 4. JSON + UUID as native types
 5. Built-in full-text search
 6. Built-in JSON inverted index
+7. Built-in vector similarity search (`VECTOR(n)` column type + `VEC_L2` / `VEC_COSINE` distance functions)
 
 To use minisql in your Go code, import the driver:
 
@@ -366,6 +367,7 @@ if err := rows.Err(); err != nil {
 | `TIMESTAMP`  | 8-byte signed integer representing number of microseconds from `2000-01-01 00:00:00 UTC` (`Postgres epoch`). Supported range is from `4713 BC` to `294276 AD` inclusive. |
 | `JSON`       | Variable-length JSON document. Stored as compact text (whitespace stripped on write). Validated on insert/update — invalid JSON is rejected. Supports path extraction via `->` / `->>` operators and `JSON_*` functions. See [JSON Type](#json-type). |
 | `UUID`       | Fixed 16-byte binary UUID stored inline in B-tree pages. Accepts the standard hyphenated form `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Upper-case input is normalised to lowercase on write. Invalid values are rejected at insert/update time. Returned as a lowercase hyphenated string. See [UUID Type](#uuid-type). |
+| `VECTOR(n)`  | n-dimensional float32 embedding vector. `n` is the dimension count declared in the column definition. The 8-byte inline leaf cell stores the dimension count and a pointer to overflow pages where the raw float32 data lives. Values are passed as bracket-delimited float lists: `'[0.1, 0.2, 0.3]'`. Returned as a string in the same format (trailing zeros stripped: `0.0` → `0`, `1.0` → `1`). Supports distance queries via `VEC_L2` and `VEC_COSINE`. See [Vector Type](#vector-type). |
 
 ## TIMESTAMP Spec
 
@@ -506,6 +508,84 @@ SELECT CAST('{"a": 1}' AS JSON);  -- Returns: {"a":1}  (compacted)
 - Extracting a key that does not exist returns SQL `NULL`.
 - Applying `->` or `->>` to a SQL `NULL` returns `NULL`.
 
+## Vector Type
+
+The `vector(n)` column type stores an `n`-dimensional float32 embedding vector. The dimension count is fixed at table-creation time and enforced on every insert and update.
+
+- Values are passed as bracket-delimited comma-separated float lists: `'[0.1, 0.2, 0.3]'`.
+- Values are returned as strings in the same bracket format (trailing zeros stripped: `1.0` → `1`, `0.0` → `0`).
+- The inline B-tree cell is 8 bytes (4-byte dimension count + 4-byte first overflow page index). Actual float data always lives on overflow pages.
+- Nullable vector columns are supported — pass `nil` to store SQL `NULL`.
+- Dimension mismatch on insert/update is rejected with an error.
+
+```sql
+CREATE TABLE documents (
+    id        int8 primary key autoincrement,
+    body      text not null,
+    embedding vector(3) not null
+);
+```
+
+### Inserting Vectors
+
+Pass vector values as strings via prepared statements:
+
+```go
+_, err := db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", "[0.1, 0.2, 0.3]",
+)
+```
+
+### Querying Vectors
+
+```go
+rows, err := db.QueryContext(ctx,
+    `SELECT id, body, embedding FROM documents WHERE id = 1`)
+// ...
+var id int64
+var body, embedding string
+rows.Scan(&id, &body, &embedding)
+// embedding == "[0.1, 0.2, 0.3]"
+```
+
+### Vector Distance Functions
+
+Use `VEC_L2` (Euclidean distance) or `VEC_COSINE` (cosine distance) to measure similarity. The literal vector argument must be a bracket-delimited float string:
+
+```sql
+-- Find the 5 nearest documents to a query vector (smallest L2 distance first)
+SELECT id, body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+
+-- Top-3 most similar by cosine distance (identical direction = 0, orthogonal = 1)
+SELECT id, body, VEC_COSINE(embedding, '[1.0, 0.0, 0.0]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 3;
+
+-- Filtered vector search: only search within a category
+SELECT id, VEC_L2(embedding, '[1.0, 0.0]') AS dist
+FROM tagged_docs
+WHERE category = 'tech'
+ORDER BY dist
+LIMIT 10;
+```
+
+**`VEC_L2(col, literal)`** — Euclidean (L2) distance: `sqrt(Σ(aᵢ − bᵢ)²)`. Returns `0.0` for identical vectors.
+
+**`VEC_COSINE(col, literal)`** — Cosine distance: `1 − (a · b) / (|a| × |b|)`. Returns `0.0` for identical direction, `1.0` for orthogonal vectors. Both vectors must be non-zero; zero-vector input returns an error.
+
+### Nullable Vector Columns
+
+```go
+var emb *string
+rows.Scan(&emb)
+// emb == nil when the column value is NULL
+```
+
 ## UUID Type
 
 The `uuid` column type stores a standard UUID in fixed 16-byte binary form, inline in the B-tree page. No overflow pages are used.
@@ -614,6 +694,7 @@ rows.Scan(&owner)
 | Numeric functions | `ABS(n)` — absolute value (preserves input type); `FLOOR(n)`, `CEIL(n)` — floor/ceiling; `ROUND(n[, d])` — round to `d` decimal places (default 0); `MOD(a, b)` — modulo (integer or float). All usable in `SELECT`, `UPDATE SET`, composable with each other and arithmetic |
 | Date/time functions | `NOW()` — current UTC timestamp; `DATE_TRUNC('unit', ts)` — truncate to `year`/`month`/`week`/`day`/`hour`/`minute`/`second`; `EXTRACT('field', ts)` / `DATE_PART('field', ts)` — extract numeric field (`year`, `month`, `day`, `hour`, `minute`, `second`, `dow`); `TO_TIMESTAMP('str')` — parse timestamp string into a TIMESTAMP value. All usable in `SELECT`, `UPDATE SET`, composable with other expressions |
 | Full-text search functions | `MATCH(doc, query)` and `TS_RANK(doc, query)` provide initial full-text semantics. `CREATE FULLTEXT INDEX` can accelerate literal `MATCH` predicates on one `TEXT`/`VARCHAR` column. |
+| Vector distance functions | `VEC_L2(col, literal)` — Euclidean distance between a `VECTOR(n)` column and a literal vector string. `VEC_COSINE(col, literal)` — cosine distance (0 = identical direction, 1 = orthogonal). Both return `DOUBLE`. Use with `ORDER BY dist LIMIT k` for nearest-neighbour search. See [Vector Type](#vector-type). |
 | `CASE WHEN` | Searched form: `CASE WHEN cond THEN result … ELSE default END`; simple form: `CASE expr WHEN val THEN result … ELSE default END`. Multiple WHEN clauses, optional ELSE (omitting returns NULL). Usable in `SELECT` (including nested in arithmetic), `UPDATE SET`, supports `IS NULL` / `IS NOT NULL` / all comparison operators in conditions |
 | `UNION` / `UNION ALL` | Combine results of two or more `SELECT` statements. `UNION ALL` concatenates all rows (duplicates kept); `UNION` deduplicates the combined result. Chains of three or more branches supported (e.g. `SELECT … UNION ALL SELECT … UNION SELECT …`). Each branch may have its own `WHERE` clause. |
 | `CAST(expr AS type)` | Standard SQL type coercion. Supported target types: `BOOLEAN`, `INT4`, `INT8`, `REAL`, `DOUBLE`, `TEXT`, `VARCHAR(n)`, `TIMESTAMP`, `JSON`, `UUID`. Follows SQLite semantics: float→int truncates toward zero; text→int/float parses leading digits (non-numeric input → 0). `CAST(x AS JSON)` validates and compacts the value. `CAST(x AS UUID)` parses a UUID string and stores it in binary form. `CAST(uuid_col AS TEXT)` formats the 16-byte value back to a hyphenated lowercase string. NULL propagates. Usable anywhere an expression is valid (e.g. `SELECT CAST(price AS INT8)`, `SELECT CAST(n AS TEXT) AS label`, `SELECT CAST(id AS TEXT) FROM widgets`). |
@@ -682,6 +763,22 @@ rows.Scan(&owner)
 | `JSON_TYPE(doc[, path])` | JSON type name of the value (`object`, `array`, `text`, `integer`, `real`, `true`, `false`, `null`). |
 | `JSON_ARRAY_LENGTH(doc)` | Number of elements in a JSON array. |
 | `JSON_CONTAINS(doc, query)` | Boolean JSON subset containment, indexable with `CREATE INVERTED INDEX` when the query JSON is a literal. |
+
+#### Vector Distance Functions
+
+| Function | Description |
+|----------|-------------|
+| `VEC_L2(col, literal)` | Euclidean (L2) distance between a `VECTOR(n)` column and a bracket-delimited float literal. Returns `DOUBLE`. `0.0` for identical vectors. |
+| `VEC_COSINE(col, literal)` | Cosine distance: `1 − cosine_similarity`. Returns `DOUBLE`. `0.0` = identical direction, `1.0` = orthogonal. Both vectors must be non-zero. |
+
+Both functions are usable in `SELECT`, composable with `AS` aliases, and support `ORDER BY alias LIMIT k` for nearest-neighbour queries.
+
+```sql
+SELECT body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
 
 #### Full-Text Search Functions
 

--- a/e2e_tests/vector_test.go
+++ b/e2e_tests/vector_test.go
@@ -1,0 +1,405 @@
+package e2etests
+
+import (
+	"context"
+	"math"
+)
+
+var createDocumentsVectorTableSQL = `create table "documents" (
+	id int8 primary key autoincrement,
+	body text not null,
+	embedding vector(3) not null
+);`
+
+func (s *TestSuite) TestVectorColumn() {
+	_, err := s.db.Exec(createDocumentsVectorTableSQL)
+	s.Require().NoError(err)
+
+	s.Run("INSERT_and_SELECT", func() {
+		_, err := s.db.Exec(
+			`insert into documents (body, embedding) values (?, ?)`,
+			"hello world", "[0.1, 0.2, 0.3]",
+		)
+		s.Require().NoError(err)
+
+		rows, err := s.db.QueryContext(context.Background(),
+			`select id, body, embedding from documents where id = 1;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var id int64
+		var body, embedding string
+		s.Require().NoError(rows.Scan(&id, &body, &embedding))
+		s.Equal(int64(1), id)
+		s.Equal("hello world", body)
+		s.Equal("[0.1, 0.2, 0.3]", embedding)
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("INSERT_multiple_rows", func() {
+		vecs := [][2]string{
+			{"doc A", "[1.0, 0.0, 0.0]"},
+			{"doc B", "[0.0, 1.0, 0.0]"},
+			{"doc C", "[0.0, 0.0, 1.0]"},
+		}
+		for _, v := range vecs {
+			_, err := s.db.Exec(
+				`insert into documents (body, embedding) values (?, ?)`,
+				v[0], v[1],
+			)
+			s.Require().NoError(err)
+		}
+
+		rows, err := s.db.QueryContext(context.Background(),
+			`select count(*) from documents;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var count int64
+		s.Require().NoError(rows.Scan(&count))
+		s.Equal(int64(4), count) // 1 from previous sub-test + 3
+	})
+}
+
+func (s *TestSuite) TestVecL2Distance() {
+	_, err := s.db.Exec(createDocumentsVectorTableSQL)
+	s.Require().NoError(err)
+
+	// Insert docs with known embeddings.
+	docs := []struct {
+		body      string
+		embedding string
+	}{
+		{"origin", "[0.0, 0.0, 0.0]"},
+		{"point a", "[1.0, 0.0, 0.0]"},
+		{"point b", "[3.0, 4.0, 0.0]"}, // L2 distance from origin = 5
+		{"point c", "[0.0, 0.0, 1.0]"},
+	}
+	for _, d := range docs {
+		_, err := s.db.Exec(
+			`insert into documents (body, embedding) values (?, ?)`,
+			d.body, d.embedding,
+		)
+		s.Require().NoError(err)
+	}
+
+	s.Run("VEC_L2_distance_computed_correctly", func() {
+		rows, err := s.db.QueryContext(context.Background(),
+			`select body, VEC_L2(embedding, '[0.0, 0.0, 0.0]') AS dist FROM documents ORDER BY id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		expected := []struct {
+			body string
+			dist float64
+		}{
+			{"origin", 0.0},
+			{"point a", 1.0},
+			{"point b", 5.0},
+			{"point c", 1.0},
+		}
+		for _, exp := range expected {
+			s.Require().True(rows.Next())
+			var body string
+			var dist float64
+			s.Require().NoError(rows.Scan(&body, &dist))
+			s.Equal(exp.body, body)
+			s.InDelta(exp.dist, dist, 0.0001)
+		}
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("VEC_L2_nearest_neighbor", func() {
+		// Find the nearest neighbor to [1.0, 0.0, 0.0].
+		rows, err := s.db.QueryContext(context.Background(),
+			`select body, VEC_L2(embedding, '[1.0, 0.0, 0.0]') AS dist FROM documents ORDER BY dist LIMIT 1;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var body string
+		var dist float64
+		s.Require().NoError(rows.Scan(&body, &dist))
+		s.Equal("point a", body)
+		s.InDelta(0.0, dist, 0.0001)
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+}
+
+func (s *TestSuite) TestVecCosineDistance() {
+	_, err := s.db.Exec(createDocumentsVectorTableSQL)
+	s.Require().NoError(err)
+
+	docs := []struct {
+		body      string
+		embedding string
+	}{
+		{"x-axis", "[1.0, 0.0, 0.0]"},
+		{"y-axis", "[0.0, 1.0, 0.0]"},
+		{"diagonal", "[1.0, 1.0, 0.0]"},
+	}
+	for _, d := range docs {
+		_, err := s.db.Exec(
+			`insert into documents (body, embedding) values (?, ?)`,
+			d.body, d.embedding,
+		)
+		s.Require().NoError(err)
+	}
+
+	s.Run("VEC_COSINE_identical_direction", func() {
+		// x-axis vs x-axis → cosine distance 0
+		rows, err := s.db.QueryContext(context.Background(),
+			`select body, VEC_COSINE(embedding, '[1.0, 0.0, 0.0]') AS dist FROM documents WHERE id = 1;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var body string
+		var dist float64
+		s.Require().NoError(rows.Scan(&body, &dist))
+		s.Equal("x-axis", body)
+		s.InDelta(0.0, dist, 0.0001)
+	})
+
+	s.Run("VEC_COSINE_orthogonal", func() {
+		// x-axis vs y-axis → cosine distance 1
+		rows, err := s.db.QueryContext(context.Background(),
+			`select body, VEC_COSINE(embedding, '[0.0, 1.0, 0.0]') AS dist FROM documents WHERE id = 1;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var body string
+		var dist float64
+		s.Require().NoError(rows.Scan(&body, &dist))
+		s.Equal("x-axis", body)
+		s.InDelta(1.0, dist, 0.0001)
+	})
+
+	s.Run("VEC_COSINE_top_k_search", func() {
+		// Find top-2 most similar to [1.0, 0.0, 0.0].
+		rows, err := s.db.QueryContext(context.Background(),
+			`select body, VEC_COSINE(embedding, '[1.0, 0.0, 0.0]') AS dist FROM documents ORDER BY dist LIMIT 2;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var body string
+		var dist float64
+		s.Require().NoError(rows.Scan(&body, &dist))
+		// x-axis is identical → distance 0
+		s.Equal("x-axis", body)
+		s.InDelta(0.0, dist, 0.0001)
+
+		s.Require().True(rows.Next())
+		s.Require().NoError(rows.Scan(&body, &dist))
+		// diagonal is 45° off → cosine distance = 1 - 1/sqrt(2)
+		s.Equal("diagonal", body)
+		s.InDelta(1.0-1.0/math.Sqrt2, dist, 0.001)
+
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+}
+
+func (s *TestSuite) TestVectorColumnNullable() {
+	_, err := s.db.Exec(`create table "items" (
+		id int8 primary key autoincrement,
+		name varchar(100) not null,
+		embedding vector(2)
+	);`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into items (name, embedding) values (?, ?)`, "no-vec", nil)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(`insert into items (name, embedding) values (?, ?)`, "with-vec", "[1.0, 0.0]")
+	s.Require().NoError(err)
+
+	rows, err := s.db.QueryContext(context.Background(),
+		`select name, embedding from items order by id;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	s.Require().True(rows.Next())
+	var name string
+	var emb *string
+	s.Require().NoError(rows.Scan(&name, &emb))
+	s.Equal("no-vec", name)
+	s.Nil(emb)
+
+	s.Require().True(rows.Next())
+	s.Require().NoError(rows.Scan(&name, &emb))
+	s.Equal("with-vec", name)
+	s.Require().NotNil(emb)
+	s.Equal("[1, 0]", *emb)
+
+	s.False(rows.Next())
+	s.Require().NoError(rows.Err())
+}
+
+func (s *TestSuite) TestVectorDDLRoundTrip() {
+	_, err := s.db.Exec(`create table "vecs" (
+		id int8 primary key autoincrement,
+		embedding vector(1536) not null
+	);`)
+	s.Require().NoError(err)
+
+	// Build a 1536-dim vector literal.
+	data := make([]float32, 1536)
+	for i := range data {
+		data[i] = float32(i) * 0.001
+	}
+
+	// Insert a 1536-dim vector.
+	vec := make([]byte, 0, 1536*6)
+	vec = append(vec, '[')
+	for i, f := range data {
+		if i > 0 {
+			vec = append(vec, ',')
+		}
+		vec = append(vec, []byte(floatStr(float64(f)))...)
+	}
+	vec = append(vec, ']')
+
+	_, err = s.db.Exec(`insert into vecs (embedding) values (?)`, string(vec))
+	s.Require().NoError(err)
+
+	rows, err := s.db.QueryContext(context.Background(),
+		`select embedding from vecs where id = 1;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	s.Require().True(rows.Next())
+	var got string
+	s.Require().NoError(rows.Scan(&got))
+	s.NotEmpty(got)
+	s.False(rows.Next())
+	s.Require().NoError(rows.Err())
+}
+
+func (s *TestSuite) TestVectorUpdate() {
+	_, err := s.db.Exec(createDocumentsVectorTableSQL)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(
+		`insert into documents (body, embedding) values (?, ?)`,
+		"doc1", "[1.0, 0.0, 0.0]",
+	)
+	s.Require().NoError(err)
+
+	// Update the vector.
+	_, err = s.db.Exec(
+		`update documents set embedding = ? where id = 1`,
+		"[0.0, 1.0, 0.0]",
+	)
+	s.Require().NoError(err)
+
+	rows, err := s.db.QueryContext(context.Background(),
+		`select embedding from documents where id = 1;`)
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	s.Require().True(rows.Next())
+	var emb string
+	s.Require().NoError(rows.Scan(&emb))
+	s.Equal("[0, 1, 0]", emb)
+	s.False(rows.Next())
+	s.Require().NoError(rows.Err())
+}
+
+func (s *TestSuite) TestVectorWithWhereFilter() {
+	_, err := s.db.Exec(`create table "tagged_docs" (
+		id int8 primary key autoincrement,
+		category varchar(50) not null,
+		embedding vector(2) not null
+	);`)
+	s.Require().NoError(err)
+
+	inserts := []struct {
+		cat string
+		vec string
+	}{
+		{"tech", "[1.0, 0.0]"},
+		{"food", "[0.0, 1.0]"},
+		{"tech", "[0.9, 0.1]"},
+		{"food", "[0.1, 0.9]"},
+	}
+	for _, ins := range inserts {
+		_, err := s.db.Exec(
+			`insert into tagged_docs (category, embedding) values (?, ?)`,
+			ins.cat, ins.vec,
+		)
+		s.Require().NoError(err)
+	}
+
+	// Nearest tech docs to [1.0, 0.0].
+	rows, err := s.db.QueryContext(context.Background(),
+		`select id, VEC_L2(embedding, '[1.0, 0.0]') AS dist
+		FROM tagged_docs WHERE category = ?
+		ORDER BY dist LIMIT 1;`, "tech")
+	s.Require().NoError(err)
+	defer rows.Close()
+
+	s.Require().True(rows.Next())
+	var id int64
+	var dist float64
+	s.Require().NoError(rows.Scan(&id, &dist))
+	s.Equal(int64(1), id)    // "[1.0, 0.0]" is exact match
+	s.InDelta(0.0, dist, 0.001)
+	s.False(rows.Next())
+	s.Require().NoError(rows.Err())
+}
+
+// floatStr converts a float64 to a compact string for vector literal construction.
+func floatStr(f float64) string {
+	if f == 0 {
+		return "0"
+	}
+	// Use strconv-compatible format
+	s := ""
+	if f < 0 {
+		s = "-"
+		f = -f
+	}
+	// Simple integer part + decimal
+	intPart := int64(f)
+	fracPart := f - float64(intPart)
+	s += itoa(intPart)
+	if fracPart > 0 {
+		s += "." + fracStr(fracPart, 3)
+	}
+	return s
+}
+
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+func fracStr(f float64, places int) string {
+	s := ""
+	for range places {
+		f *= 10
+		d := int(f)
+		s += string(rune('0' + d))
+		f -= float64(d)
+	}
+	// Trim trailing zeros
+	for len(s) > 1 && s[len(s)-1] == '0' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -243,6 +243,10 @@ func (c *Cursor) saveToCell(ctx context.Context, node *LeafNode, cellIdx uint32,
 	if err != nil {
 		return fmt.Errorf("store overflow texts: %w", err)
 	}
+	row, err = row.storeOverflowVectors(ctx, c.Table.pager)
+	if err != nil {
+		return fmt.Errorf("store overflow vectors: %w", err)
+	}
 
 	rowBuf, err := row.Marshal()
 	if err != nil {
@@ -430,7 +434,7 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		return true, nil
 	}
 
-	// Remove any overflow pages
+	// Remove any overflow pages for changed text columns.
 	if overflowColumns := c.Table.textOverflowCols; len(overflowColumns) > 0 {
 		// TODO - a more efficient implementation would be to try to reuse existing overflow pages
 		// if possible. For example if text size didn't change much and fits into existing overflow pages.
@@ -447,9 +451,28 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		}
 	}
 
+	// Remove any overflow pages for changed vector columns.
+	if overflowColumns := c.Table.vectorOverflowCols; len(overflowColumns) > 0 {
+		changedColumns := make([]Column, 0, len(changedValues))
+		for _, col := range overflowColumns {
+			_, ok := changedValues[col.Name]
+			if !ok {
+				continue
+			}
+			changedColumns = append(changedColumns, col)
+		}
+		if err := c.Table.freeOverflowPages(ctx, oldRow, changedColumns...); err != nil {
+			return false, err
+		}
+	}
+
 	row, err = row.storeOverflowTexts(ctx, c.Table.pager)
 	if err != nil {
 		return false, fmt.Errorf("store overflow texts: %w", err)
+	}
+	row, err = row.storeOverflowVectors(ctx, c.Table.pager)
+	if err != nil {
+		return false, fmt.Errorf("store overflow vectors: %w", err)
 	}
 
 	if c.Table.HasPrimaryKey() {

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -1486,6 +1486,66 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		}
 		return jsonContains(docStr, queryStr)
 
+	// ── Vector distance functions ──────────────────────────────────────────────
+
+	case "VEC_L2":
+		if len(e.Args) != 2 {
+			return nil, fmt.Errorf("VEC_L2 requires exactly 2 arguments")
+		}
+		arg0, err := e.Args[0].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		arg1, err := e.Args[1].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		if arg0 == nil || arg1 == nil {
+			return nil, nil
+		}
+		a, err := toVectorPointer(arg0)
+		if err != nil {
+			return nil, fmt.Errorf("VEC_L2: first argument: %w", err)
+		}
+		b, err := toVectorPointer(arg1)
+		if err != nil {
+			return nil, fmt.Errorf("VEC_L2: second argument: %w", err)
+		}
+		dist, err := L2Distance(a, b)
+		if err != nil {
+			return nil, err
+		}
+		return dist, nil
+
+	case "VEC_COSINE":
+		if len(e.Args) != 2 {
+			return nil, fmt.Errorf("VEC_COSINE requires exactly 2 arguments")
+		}
+		arg0, err := e.Args[0].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		arg1, err := e.Args[1].Eval(row)
+		if err != nil {
+			return nil, err
+		}
+		if arg0 == nil || arg1 == nil {
+			return nil, nil
+		}
+		a, err := toVectorPointer(arg0)
+		if err != nil {
+			return nil, fmt.Errorf("VEC_COSINE: first argument: %w", err)
+		}
+		b, err := toVectorPointer(arg1)
+		if err != nil {
+			return nil, fmt.Errorf("VEC_COSINE: second argument: %w", err)
+		}
+		dist, err := CosineDistance(a, b)
+		if err != nil {
+			return nil, err
+		}
+		return dist, nil
+
 	default:
 		return nil, fmt.Errorf("unknown function %q", e.FuncName)
 	}

--- a/internal/minisql/parallel_scan.go
+++ b/internal/minisql/parallel_scan.go
@@ -322,6 +322,11 @@ func (t *Table) parallelScanWorker(
 					send(parallelScanResult{err: err})
 					return
 				}
+				row, err = row.readOverflowVectors(ctx, t.pager)
+				if err != nil {
+					send(parallelScanResult{err: err})
+					return
+				}
 				if !send(parallelScanResult{row: row}) {
 					return
 				}

--- a/internal/minisql/row.go
+++ b/internal/minisql/row.go
@@ -53,6 +53,10 @@ func (r Row) Size() uint64 {
 			continue
 		}
 
+		if col.Kind.IsVector() {
+			size += 8 // 4-byte dims + 4-byte first overflow page index
+			continue
+		}
 		if !col.Kind.IsText() {
 			size += uint64(col.Size)
 			continue
@@ -272,6 +276,11 @@ func compareValue(kind ColumnKind, v1, v2 OptionalValue) bool {
 		u2, ok2 := v2.Value.(UUIDValue)
 		return ok1 && ok2 && u1 == u2
 	}
+	if kind.IsVector() {
+		// VectorPointer contains a slice and is not directly comparable; vectors
+		// on indexes are not supported, so just report "changed" to be safe.
+		return false
+	}
 	if !kind.IsText() {
 		return v1.Value == v2.Value
 	}
@@ -397,6 +406,13 @@ func (r Row) Marshal() ([]byte, error) {
 			}
 			copy(buf[offset:offset+16], value[:])
 			offset += 16
+		case Vector:
+			vp, ok := r.Values[i].Value.(VectorPointer)
+			if !ok {
+				return nil, fmt.Errorf("could not cast value for column %s to VectorPointer", col.Name)
+			}
+			vp.Marshal(buf, offset)
+			offset += 8
 		}
 	}
 

--- a/internal/minisql/row_view.go
+++ b/internal/minisql/row_view.go
@@ -181,6 +181,10 @@ func (rv RowView) ValueAt(idx int) (OptionalValue, error) {
 		var value UUIDValue
 		copy(value[:], rv.value[offset:offset+16])
 		return OptionalValue{Value: value, Valid: true}, nil
+	case Vector:
+		var vp VectorPointer
+		vp.Unmarshal(rv.value, uint64(offset))
+		return OptionalValue{Value: vp, Valid: true}, nil
 	default:
 		return OptionalValue{}, fmt.Errorf("unsupported column kind %s", col.Kind)
 	}
@@ -203,21 +207,35 @@ func (rv RowView) ValueAtWithOverflow(ctx context.Context, pager TxPager, idx in
 		return value, err
 	}
 	col := rv.columns[idx]
-	if !col.MayUseOverflowText() {
-		return value, nil
+	if col.MayUseOverflowText() {
+		textPointer, ok := value.Value.(TextPointer)
+		if !ok {
+			return OptionalValue{}, fmt.Errorf("expected TextPointer value for text column %s", col.Name)
+		}
+		if !textPointer.IsInline() && pager == nil {
+			return OptionalValue{}, fmt.Errorf("overflow text column %d requires a pager", idx)
+		}
+		textPointer, err = textPointer.readOverflowText(ctx, pager)
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		return OptionalValue{Valid: true, Value: textPointer}, nil
 	}
-	textPointer, ok := value.Value.(TextPointer)
-	if !ok {
-		return OptionalValue{}, fmt.Errorf("expected TextPointer value for text column %s", col.Name)
+	if col.MayUseOverflowVector() {
+		vp, ok := value.Value.(VectorPointer)
+		if !ok {
+			return OptionalValue{}, fmt.Errorf("expected VectorPointer value for vector column %s", col.Name)
+		}
+		if pager == nil {
+			return OptionalValue{}, fmt.Errorf("vector overflow column %d requires a pager", idx)
+		}
+		vp, err = vp.readOverflow(ctx, pager)
+		if err != nil {
+			return OptionalValue{}, err
+		}
+		return OptionalValue{Valid: true, Value: vp}, nil
 	}
-	if !textPointer.IsInline() && pager == nil {
-		return OptionalValue{}, fmt.Errorf("overflow text column %d requires a pager", idx)
-	}
-	textPointer, err = textPointer.readOverflowText(ctx, pager)
-	if err != nil {
-		return OptionalValue{}, err
-	}
-	return OptionalValue{Valid: true, Value: textPointer}, nil
+	return value, nil
 }
 
 // BoolAt lazily decodes a BOOLEAN column.
@@ -439,13 +457,17 @@ func (rv RowView) Materialize(selectedMask []bool) (Row, error) {
 	return row, nil
 }
 
-// MaterializeWithOverflow decodes selected columns and loads overflow text.
+// MaterializeWithOverflow decodes selected columns and loads overflow text and vector data.
 func (rv RowView) MaterializeWithOverflow(ctx context.Context, pager TxPager, selectedMask []bool) (Row, error) {
 	row, err := rv.Materialize(selectedMask)
 	if err != nil {
 		return Row{}, err
 	}
-	return row.readOverflowTexts(ctx, pager)
+	row, err = row.readOverflowTexts(ctx, pager)
+	if err != nil {
+		return Row{}, err
+	}
+	return row.readOverflowVectors(ctx, pager)
 }
 
 func (rv RowView) requireKind(idx int, kind ColumnKind) error {

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -169,6 +169,9 @@ const (
 	Timestamp
 	JSON
 	UUID
+	// Vector is the VECTOR(n) column type storing n-dimensional float32 embeddings.
+	// The dimension count is stored in Column.Size; data lives in overflow pages.
+	Vector
 )
 
 // IsInt reports whether the column kind is an integer type (INT4 or INT8).
@@ -198,6 +201,8 @@ func (k ColumnKind) String() string {
 		return "json"
 	case UUID:
 		return "uuid"
+	case Vector:
+		return "vector"
 	default:
 		return "unknown"
 	}
@@ -211,6 +216,11 @@ func (k ColumnKind) IsText() bool {
 // IsUUID reports whether the column kind is UUID.
 func (k ColumnKind) IsUUID() bool {
 	return k == UUID
+}
+
+// IsVector reports whether the column kind is a vector embedding type.
+func (k ColumnKind) IsVector() bool {
+	return k == Vector
 }
 
 // Column describes a single column in a table's schema, including its data type,
@@ -235,6 +245,12 @@ type Column struct {
 // MayUseOverflowText reports whether values in this column may live on overflow pages.
 func (c Column) MayUseOverflowText() bool {
 	return c.Kind == Text || c.Kind == JSON || (c.Kind == Varchar && c.Size > MaxInlineVarchar)
+}
+
+// MayUseOverflowVector reports whether values in this column live on vector overflow pages.
+// All VECTOR(n) columns always use overflow pages regardless of dimension count.
+func (c Column) MayUseOverflowVector() bool {
+	return c.Kind == Vector
 }
 
 func fieldsFromColumns(columns ...Column) []Field {
@@ -1065,6 +1081,15 @@ func coerceColumnValue(col Column, val OptionalValue, now Time, ctx string) (Opt
 			return val, fmt.Errorf("column %q: %w", col.Name, err)
 		}
 		val.Value = uv
+	case Vector:
+		vp, err := toVectorPointer(val.Value)
+		if err != nil {
+			return val, fmt.Errorf("column %q: %w", col.Name, err)
+		}
+		if col.Size > 0 && vp.Dims != col.Size {
+			return val, fmt.Errorf("column %q: vector has %d dimensions, expected %d", col.Name, vp.Dims, col.Size)
+		}
+		val.Value = vp
 	}
 	return val, nil
 }
@@ -1859,6 +1884,11 @@ func isValueValidForColumn(col Column, val OptionalValue) error {
 		default:
 			return fmt.Errorf("expects a UUID string for column %q", col.Name)
 		}
+	case Vector:
+		_, ok := val.Value.(VectorPointer)
+		if !ok {
+			return fmt.Errorf("expects a VectorPointer value for vector column %q", col.Name)
+		}
 	}
 	return nil
 }
@@ -1963,7 +1993,7 @@ func (s Statement) createTableDDL() string {
 
 	for i, col := range s.Columns {
 		fmt.Fprintf(&sb, "	%s %s", col.Name, col.Kind)
-		if col.Kind == Varchar {
+		if col.Kind == Varchar || col.Kind == Vector {
 			fmt.Fprintf(&sb, "(%d)", col.Size)
 		}
 		switch {

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -53,10 +53,11 @@ type Table struct {
 	// checks here first and stores results after planning. Nil for system tables
 	// and virtual tables created for derived-table subqueries.
 	planCache LRUCache[string]
-	// allFields and textOverflowCols are derived from Columns at construction time
-	// and reused across calls to avoid per-call allocations.
-	allFields        []Field
-	textOverflowCols []Column
+	// allFields, textOverflowCols, and vectorOverflowCols are derived from Columns at
+	// construction time and reused across calls to avoid per-call allocations.
+	allFields         []Field
+	textOverflowCols  []Column
+	vectorOverflowCols []Column
 	// rightmostTablePage caches the last leaf page index for SeekNextRowID so that
 	// sequential (autoincrement) inserts skip the O(log N) root→leaf traversal.
 	// lastTxIDTablePage guards against stale hints from rolled-back transactions.
@@ -103,6 +104,9 @@ func NewTable(logger *zap.Logger, pager TxPager, txManager *TransactionManager, 
 	for _, col := range columns {
 		if col.MayUseOverflowText() {
 			table.textOverflowCols = append(table.textOverflowCols, col)
+		}
+		if col.MayUseOverflowVector() {
+			table.vectorOverflowCols = append(table.vectorOverflowCols, col)
 		}
 	}
 
@@ -867,36 +871,67 @@ func (t *Table) freeOverflowPages(ctx context.Context, row Row, onlyForColumns .
 		columns = onlyForColumns
 	}
 	for _, col := range columns {
-		if !col.Kind.IsText() {
-			continue
-		}
-		value, ok := row.GetValue(col.Name)
-		if !ok || !value.Valid {
-			continue
-		}
-		textPointer, ok := value.Value.(TextPointer)
-		if !ok {
-			return fmt.Errorf("expected TextPointer value for text column %s", col.Name)
-		}
-		if textPointer.IsInline() {
-			continue
-		}
-		pagesToFree := make([]PageIndex, 0, 1)
-		overflowPage, err := t.pager.GetOverflowPage(ctx, textPointer.FirstPage)
-		if err != nil {
-			return err
-		}
-		pagesToFree = append(pagesToFree, overflowPage.Index)
-		for overflowPage.OverflowPage.Header.NextPage > 0 {
-			overflowPage, err = t.pager.GetOverflowPage(ctx, overflowPage.OverflowPage.Header.NextPage)
+		switch {
+		case col.Kind.IsText():
+			value, ok := row.GetValue(col.Name)
+			if !ok || !value.Valid {
+				continue
+			}
+			textPointer, ok := value.Value.(TextPointer)
+			if !ok {
+				return fmt.Errorf("expected TextPointer value for text column %s", col.Name)
+			}
+			if textPointer.IsInline() {
+				continue
+			}
+			pagesToFree := make([]PageIndex, 0, 1)
+			overflowPage, err := t.pager.GetOverflowPage(ctx, textPointer.FirstPage)
 			if err != nil {
 				return err
 			}
 			pagesToFree = append(pagesToFree, overflowPage.Index)
-		}
-		for _, pageIdx := range pagesToFree {
-			if err := t.pager.AddFreePage(ctx, pageIdx); err != nil {
+			for overflowPage.OverflowPage.Header.NextPage > 0 {
+				overflowPage, err = t.pager.GetOverflowPage(ctx, overflowPage.OverflowPage.Header.NextPage)
+				if err != nil {
+					return err
+				}
+				pagesToFree = append(pagesToFree, overflowPage.Index)
+			}
+			for _, pageIdx := range pagesToFree {
+				if err := t.pager.AddFreePage(ctx, pageIdx); err != nil {
+					return err
+				}
+			}
+
+		case col.Kind.IsVector():
+			value, ok := row.GetValue(col.Name)
+			if !ok || !value.Valid {
+				continue
+			}
+			vp, ok := value.Value.(VectorPointer)
+			if !ok {
+				return fmt.Errorf("expected VectorPointer value for vector column %s", col.Name)
+			}
+			if vp.Dims == 0 || vp.FirstPage == 0 {
+				continue
+			}
+			pagesToFree := make([]PageIndex, 0, 1)
+			overflowPage, err := t.pager.GetOverflowPage(ctx, vp.FirstPage)
+			if err != nil {
 				return err
+			}
+			pagesToFree = append(pagesToFree, overflowPage.Index)
+			for overflowPage.OverflowPage.Header.NextPage > 0 {
+				overflowPage, err = t.pager.GetOverflowPage(ctx, overflowPage.OverflowPage.Header.NextPage)
+				if err != nil {
+					return err
+				}
+				pagesToFree = append(pagesToFree, overflowPage.Index)
+			}
+			for _, pageIdx := range pagesToFree {
+				if err := t.pager.AddFreePage(ctx, pageIdx); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/minisql/type_code.go
+++ b/internal/minisql/type_code.go
@@ -26,6 +26,7 @@ const (
 	TypeCodeTimestamp TypeCode = 6
 	TypeCodeUUID      TypeCode = 7
 	TypeCodeText      TypeCode = 8
+	TypeCodeVector    TypeCode = 9
 )
 
 // kindToTypeCode maps a ColumnKind to its TypeCode.
@@ -47,6 +48,8 @@ func kindToTypeCode(k ColumnKind) TypeCode {
 		return TypeCodeUUID
 	case Varchar, Text, JSON:
 		return TypeCodeText
+	case Vector:
+		return TypeCodeVector
 	default:
 		return TypeCodeNull
 	}
@@ -83,6 +86,8 @@ func typeCodeFixedSize(tc TypeCode) int {
 		return 16
 	case TypeCodeText:
 		return -1
+	case TypeCodeVector:
+		return 8 // 4-byte dims + 4-byte first overflow page index
 	default:
 		return 0
 	}

--- a/internal/minisql/vector.go
+++ b/internal/minisql/vector.go
@@ -1,0 +1,250 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// VectorPointer is stored in the leaf cell for a VECTOR(n) column.
+// The 8-byte inline representation holds the dimension count and the first
+// overflow page index; actual float32 data lives on overflow pages.
+type VectorPointer struct {
+	Data      []float32
+	Dims      uint32
+	FirstPage PageIndex
+}
+
+// Size returns the fixed 8-byte inline serialised size of the pointer.
+// (4 bytes for Dims + 4 bytes for FirstPage)
+func (vp VectorPointer) Size() uint64 {
+	return 8
+}
+
+// Marshal writes the VectorPointer (8 bytes) into buf at byte offset i.
+func (vp *VectorPointer) Marshal(buf []byte, i uint64) {
+	marshalUint32(buf, vp.Dims, i)
+	marshalUint32(buf, uint32(vp.FirstPage), i+4)
+}
+
+// Unmarshal reads the VectorPointer from buf at byte offset i.
+// Data is not populated; call readOverflow to load the float32 values.
+func (vp *VectorPointer) Unmarshal(buf []byte, i uint64) {
+	vp.Dims = unmarshalUint32(buf, i)
+	vp.FirstPage = PageIndex(unmarshalUint32(buf, i+4))
+}
+
+// ParseVectorLiteral parses a bracket-delimited float list like "[0.1, 0.2, 0.3]"
+// into a VectorPointer with Data populated and FirstPage = 0.
+func ParseVectorLiteral(s string) (VectorPointer, error) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
+		return VectorPointer{}, fmt.Errorf("vector literal must be enclosed in brackets, got: %q", s)
+	}
+	s = s[1 : len(s)-1]
+	parts := strings.Split(s, ",")
+	data := make([]float32, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		f, err := strconv.ParseFloat(p, 32)
+		if err != nil {
+			return VectorPointer{}, fmt.Errorf("invalid vector component %q: %w", p, err)
+		}
+		data = append(data, float32(f))
+	}
+	return VectorPointer{
+		Dims: uint32(len(data)),
+		Data: data,
+	}, nil
+}
+
+// FormatVector returns the string representation "[v0, v1, ...]" of a VectorPointer.
+func FormatVector(vp VectorPointer) string {
+	if len(vp.Data) == 0 {
+		return "[]"
+	}
+	var sb strings.Builder
+	sb.WriteByte('[')
+	for i, f := range vp.Data {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(strconv.FormatFloat(float64(f), 'f', -1, 32))
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// toVectorPointer converts v to a VectorPointer.
+// Accepts VectorPointer (pass-through), TextPointer, or string (parsed as a vector literal).
+func toVectorPointer(v any) (VectorPointer, error) {
+	switch vp := v.(type) {
+	case VectorPointer:
+		return vp, nil
+	case TextPointer:
+		return ParseVectorLiteral(vp.String())
+	case string:
+		return ParseVectorLiteral(vp)
+	default:
+		return VectorPointer{}, fmt.Errorf("cannot convert %T to vector", v)
+	}
+}
+
+// L2Distance computes the Euclidean distance between two vectors.
+func L2Distance(a, b VectorPointer) (float64, error) {
+	if a.Dims != b.Dims {
+		return 0, fmt.Errorf("VEC_L2: dimension mismatch: %d vs %d", a.Dims, b.Dims)
+	}
+	var sum float64
+	for i := range a.Data {
+		d := float64(a.Data[i]) - float64(b.Data[i])
+		sum += d * d
+	}
+	return math.Sqrt(sum), nil
+}
+
+// CosineDistance computes the cosine distance (1 − cosine_similarity) between two vectors.
+func CosineDistance(a, b VectorPointer) (float64, error) {
+	if a.Dims != b.Dims {
+		return 0, fmt.Errorf("VEC_COSINE: dimension mismatch: %d vs %d", a.Dims, b.Dims)
+	}
+	var dot, normA, normB float64
+	for i := range a.Data {
+		ai := float64(a.Data[i])
+		bi := float64(b.Data[i])
+		dot += ai * bi
+		normA += ai * ai
+		normB += bi * bi
+	}
+	if normA == 0 || normB == 0 {
+		return 0, fmt.Errorf("VEC_COSINE: zero-length vector")
+	}
+	return 1 - dot/(math.Sqrt(normA)*math.Sqrt(normB)), nil
+}
+
+// storeOverflowVectors writes float32 data to overflow pages for all Vector columns in r.
+func (r Row) storeOverflowVectors(ctx context.Context, pager TxPager) (Row, error) {
+	for i, col := range r.Columns {
+		if !col.Kind.IsVector() {
+			continue
+		}
+		value := r.Values[i]
+		if !value.Valid {
+			continue
+		}
+		vp, ok := value.Value.(VectorPointer)
+		if !ok {
+			return r, fmt.Errorf("expected VectorPointer value for vector column %s", col.Name)
+		}
+		if err := vp.storeOverflow(ctx, pager); err != nil {
+			return r, err
+		}
+		r.Values[i] = OptionalValue{Valid: true, Value: vp}
+	}
+	return r, nil
+}
+
+func (vp *VectorPointer) storeOverflow(ctx context.Context, pager TxPager) error {
+	if vp.Dims == 0 {
+		return nil
+	}
+
+	rawBytes := make([]byte, vp.Dims*4)
+	for i, f := range vp.Data {
+		marshalFloat32(rawBytes, f, uint64(i)*4)
+	}
+
+	totalBytes := uint32(len(rawBytes))
+	numPages := (totalBytes + MaxOverflowPageData - 1) / MaxOverflowPageData
+	remaining := totalBytes
+	offset := uint32(0)
+
+	var previousPage *Page
+	for i := uint32(0); i < numPages; i++ {
+		freePage, err := pager.GetFreePage(ctx)
+		if err != nil {
+			return fmt.Errorf("allocate vector overflow page: %w", err)
+		}
+		if i == 0 {
+			vp.FirstPage = freePage.Index
+		}
+		dataSize := min(remaining, MaxOverflowPageData)
+		remaining -= dataSize
+		freePage.OverflowPage = &OverflowPage{
+			Header: OverflowPageHeader{
+				DataSize: dataSize,
+			},
+			Data: rawBytes[offset : offset+dataSize],
+		}
+		offset += dataSize
+		if previousPage != nil {
+			previousPage.OverflowPage.Header.NextPage = freePage.Index
+		}
+		previousPage = freePage
+	}
+	return nil
+}
+
+// readOverflowVectors reads float32 data from overflow pages for all Vector columns in r.
+func (r Row) readOverflowVectors(ctx context.Context, pager TxPager) (Row, error) {
+	for i, col := range r.Columns {
+		if !col.Kind.IsVector() {
+			continue
+		}
+		if i >= len(r.Values) || !r.Values[i].Valid {
+			continue
+		}
+		vp, ok := r.Values[i].Value.(VectorPointer)
+		if !ok {
+			return Row{}, fmt.Errorf("expected VectorPointer value for vector column %s", col.Name)
+		}
+		if vp.Dims == 0 {
+			continue
+		}
+		if pager == nil {
+			return Row{}, fmt.Errorf("vector overflow column %d requires a pager", i)
+		}
+		vp, err := vp.readOverflow(ctx, pager)
+		if err != nil {
+			return Row{}, err
+		}
+		r.Values[i] = OptionalValue{Value: vp, Valid: true}
+	}
+	return r, nil
+}
+
+func (vp VectorPointer) readOverflow(ctx context.Context, pager TxPager) (VectorPointer, error) {
+	if vp.Dims == 0 {
+		return vp, nil
+	}
+
+	totalBytes := vp.Dims * 4
+	rawBytes := make([]byte, 0, totalBytes)
+	currentPageIdx := vp.FirstPage
+	remaining := totalBytes
+
+	for remaining > 0 {
+		overflowPage, err := pager.ReadPage(ctx, currentPageIdx)
+		if err != nil {
+			return VectorPointer{}, fmt.Errorf("read vector overflow page %d: %w", currentPageIdx, err)
+		}
+		if overflowPage.OverflowPage == nil {
+			return VectorPointer{}, fmt.Errorf("page %d is not an overflow page", currentPageIdx)
+		}
+		dataSize := min(remaining, overflowPage.OverflowPage.Header.DataSize)
+		rawBytes = append(rawBytes, overflowPage.OverflowPage.Data[:dataSize]...)
+		remaining -= dataSize
+		currentPageIdx = overflowPage.OverflowPage.Header.NextPage
+	}
+
+	vp.Data = make([]float32, vp.Dims)
+	for i := uint32(0); i < vp.Dims; i++ {
+		vp.Data[i] = unmarshalFloat32(rawBytes, uint64(i)*4)
+	}
+	return vp, nil
+}

--- a/internal/minisql/vector_test.go
+++ b/internal/minisql/vector_test.go
@@ -1,0 +1,389 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTxPager is a minimal in-memory TxPager implementation for unit tests.
+type mockTxPager struct {
+	pages   map[PageIndex]*Page
+	nextIdx PageIndex
+}
+
+func newMockTxPager() *mockTxPager {
+	return &mockTxPager{pages: make(map[PageIndex]*Page), nextIdx: 1}
+}
+
+func (m *mockTxPager) ReadPage(_ context.Context, idx PageIndex) (*Page, error) {
+	p, ok := m.pages[idx]
+	if !ok {
+		return nil, fmt.Errorf("page %d not found", idx)
+	}
+	return p, nil
+}
+func (m *mockTxPager) ModifyPage(ctx context.Context, idx PageIndex) (*Page, error) {
+	return m.ReadPage(ctx, idx)
+}
+func (m *mockTxPager) GetFreePage(_ context.Context) (*Page, error) {
+	idx := m.nextIdx
+	m.nextIdx++
+	p := &Page{Index: idx}
+	m.pages[idx] = p
+	return p, nil
+}
+func (m *mockTxPager) AddFreePage(_ context.Context, _ PageIndex) error { return nil }
+func (m *mockTxPager) GetOverflowPage(ctx context.Context, idx PageIndex) (*Page, error) {
+	return m.ReadPage(ctx, idx)
+}
+
+func TestParseVectorLiteral(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    VectorPointer
+		wantErr bool
+	}{
+		{
+			name:  "basic 3d vector",
+			input: "[1.0, 2.0, 3.0]",
+			want:  VectorPointer{Dims: 3, Data: []float32{1.0, 2.0, 3.0}},
+		},
+		{
+			name:  "single dimension",
+			input: "[0.5]",
+			want:  VectorPointer{Dims: 1, Data: []float32{0.5}},
+		},
+		{
+			name:  "negative values",
+			input: "[-1.5, 2.5, -3.0]",
+			want:  VectorPointer{Dims: 3, Data: []float32{-1.5, 2.5, -3.0}},
+		},
+		{
+			name:  "whitespace handling",
+			input: "[ 1.0 , 2.0 , 3.0 ]",
+			want:  VectorPointer{Dims: 3, Data: []float32{1.0, 2.0, 3.0}},
+		},
+		{
+			name:    "missing brackets",
+			input:   "1.0, 2.0, 3.0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid float",
+			input:   "[1.0, abc, 3.0]",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVectorLiteral(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Dims, got.Dims)
+			assert.Equal(t, tt.want.Data, got.Data)
+		})
+	}
+}
+
+func TestFormatVector(t *testing.T) {
+	vp := VectorPointer{Dims: 3, Data: []float32{1.0, 2.5, -3.0}}
+	got := FormatVector(vp)
+	assert.Equal(t, "[1, 2.5, -3]", got)
+
+	empty := VectorPointer{}
+	assert.Equal(t, "[]", FormatVector(empty))
+}
+
+func TestL2Distance(t *testing.T) {
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	b := VectorPointer{Dims: 3, Data: []float32{4, 6, 3}}
+	dist, err := L2Distance(a, b)
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, dist, 0.0001)
+
+	same := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	dist, err = L2Distance(a, same)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, dist, 0.0001)
+
+	// dimension mismatch
+	c := VectorPointer{Dims: 2, Data: []float32{1, 2}}
+	_, err = L2Distance(a, c)
+	require.Error(t, err)
+}
+
+func TestCosineDistance(t *testing.T) {
+	// identical vectors → distance 0
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	same := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	dist, err := CosineDistance(a, same)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, dist, 0.0001)
+
+	// orthogonal vectors → distance 1
+	x := VectorPointer{Dims: 2, Data: []float32{1, 0}}
+	y := VectorPointer{Dims: 2, Data: []float32{0, 1}}
+	dist, err = CosineDistance(x, y)
+	require.NoError(t, err)
+	assert.InDelta(t, 1.0, dist, 0.0001)
+
+	// dimension mismatch
+	c := VectorPointer{Dims: 2, Data: []float32{1, 2}}
+	_, err = CosineDistance(a, c)
+	require.Error(t, err)
+
+	// zero vector
+	zero := VectorPointer{Dims: 2, Data: []float32{0, 0}}
+	_, err = CosineDistance(x, zero)
+	require.Error(t, err)
+}
+
+func TestVectorPointerMarshalUnmarshal(t *testing.T) {
+	original := VectorPointer{Dims: 1536, FirstPage: PageIndex(42)}
+	buf := make([]byte, 8)
+	original.Marshal(buf, 0)
+
+	var decoded VectorPointer
+	decoded.Unmarshal(buf, 0)
+	assert.Equal(t, original.Dims, decoded.Dims)
+	assert.Equal(t, original.FirstPage, decoded.FirstPage)
+}
+
+func TestVectorPointerSize(t *testing.T) {
+	vp := VectorPointer{Dims: 1536}
+	assert.Equal(t, uint64(8), vp.Size())
+}
+
+func TestL2DistanceKnownValues(t *testing.T) {
+	// distance between (0,0) and (3,4) = 5
+	a := VectorPointer{Dims: 2, Data: []float32{0, 0}}
+	b := VectorPointer{Dims: 2, Data: []float32{3, 4}}
+	dist, err := L2Distance(a, b)
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, dist, 0.0001)
+}
+
+func TestCosineDistanceAntiParallel(t *testing.T) {
+	// opposite directions → distance 2
+	a := VectorPointer{Dims: 1, Data: []float32{1}}
+	b := VectorPointer{Dims: 1, Data: []float32{-1}}
+	dist, err := CosineDistance(a, b)
+	require.NoError(t, err)
+	assert.InDelta(t, 2.0, dist, 0.0001)
+}
+
+func TestToVectorPointer(t *testing.T) {
+	// already a VectorPointer
+	vp := VectorPointer{Dims: 2, Data: []float32{1.0, 2.0}}
+	got, err := toVectorPointer(vp)
+	require.NoError(t, err)
+	assert.Equal(t, vp, got)
+
+	// from string
+	got, err = toVectorPointer("[1.0, 2.0]")
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), got.Dims)
+
+	// from TextPointer
+	got, err = toVectorPointer(NewTextPointer([]byte("[1.0, 2.0]")))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), got.Dims)
+
+	// unsupported type
+	_, err = toVectorPointer(42)
+	require.Error(t, err)
+}
+
+func TestRowSizeVector(t *testing.T) {
+	col := Column{Name: "embedding", Kind: Vector, Size: 3}
+	vp := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	row := Row{
+		Columns: []Column{col},
+		Values:  []OptionalValue{{Valid: true, Value: vp}},
+	}
+	assert.Equal(t, uint64(8), row.Size(), "vector always contributes 8 bytes inline")
+}
+
+func TestRowMarshalVector(t *testing.T) {
+	col := Column{Name: "embedding", Kind: Vector, Size: 3}
+	vp := VectorPointer{Dims: 3, FirstPage: PageIndex(7)}
+	row := Row{
+		Columns: []Column{col},
+		Values:  []OptionalValue{{Valid: true, Value: vp}},
+	}
+	buf, err := row.Marshal()
+	require.NoError(t, err)
+	require.Len(t, buf, 8)
+	// Dims = 3 stored at offset 0
+	assert.Equal(t, uint32(3), unmarshalUint32(buf, 0))
+	// FirstPage = 7 stored at offset 4
+	assert.Equal(t, uint32(7), unmarshalUint32(buf, 4))
+}
+
+func TestTypeCodeVector(t *testing.T) {
+	assert.Equal(t, TypeCodeVector, kindToTypeCode(Vector))
+	assert.Equal(t, 8, typeCodeFixedSize(TypeCodeVector))
+}
+
+func TestCosineDistanceParallel(t *testing.T) {
+	// parallel unit vectors → distance 0
+	a := VectorPointer{Dims: 3, Data: []float32{1, 0, 0}}
+	b := VectorPointer{Dims: 3, Data: []float32{1, 0, 0}}
+	dist, err := CosineDistance(a, b)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, dist, 0.0001)
+}
+
+// roundTripDist ensures L2Distance computation is within float32 precision.
+func TestL2DistancePrecision(t *testing.T) {
+	a := VectorPointer{Dims: 4, Data: []float32{0.1, 0.2, 0.3, 0.4}}
+	b := VectorPointer{Dims: 4, Data: []float32{0.5, 0.6, 0.7, 0.8}}
+	dist, err := L2Distance(a, b)
+	require.NoError(t, err)
+	// expected = sqrt(0.16 * 4) = sqrt(0.64) = 0.8
+	assert.InDelta(t, 0.8, dist, 0.0001)
+}
+
+func TestL2DistanceIsSymmetric(t *testing.T) {
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	b := VectorPointer{Dims: 3, Data: []float32{4, 5, 6}}
+	d1, err := L2Distance(a, b)
+	require.NoError(t, err)
+	d2, err := L2Distance(b, a)
+	require.NoError(t, err)
+	assert.InDelta(t, d1, d2, 0.0001)
+}
+
+func TestCosineDistanceIsSymmetric(t *testing.T) {
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	b := VectorPointer{Dims: 3, Data: []float32{4, 5, 6}}
+	d1, err := CosineDistance(a, b)
+	require.NoError(t, err)
+	d2, err := CosineDistance(b, a)
+	require.NoError(t, err)
+	assert.InDelta(t, d1, d2, 0.0001)
+}
+
+func TestCosineDistanceRange(t *testing.T) {
+	// cosine distance must be in [0, 2]
+	pairs := [][2]VectorPointer{
+		{{Dims: 2, Data: []float32{1, 0}}, {Dims: 2, Data: []float32{0, 1}}},
+		{{Dims: 2, Data: []float32{1, 1}}, {Dims: 2, Data: []float32{-1, 1}}},
+		{{Dims: 2, Data: []float32{3, 4}}, {Dims: 2, Data: []float32{-3, -4}}},
+	}
+	for _, pair := range pairs {
+		dist, err := CosineDistance(pair[0], pair[1])
+		require.NoError(t, err)
+		assert.True(t, dist >= 0 && dist <= 2+1e-6, "cosine distance %v out of [0,2]", dist)
+	}
+}
+
+// Ensure float32 overflow pages round-trip correctly for a small vector.
+func TestVectorOverflowRoundTrip(t *testing.T) {
+	pager := newMockTxPager()
+	ctx := context.Background()
+	col := Column{Name: "emb", Kind: Vector, Size: 4}
+
+	vp := VectorPointer{Dims: 4, Data: []float32{1.1, 2.2, 3.3, 4.4}}
+	row := Row{
+		Columns: []Column{col},
+		Values:  []OptionalValue{{Valid: true, Value: vp}},
+	}
+
+	var err error
+	row, err = row.storeOverflowVectors(ctx, pager)
+	require.NoError(t, err)
+
+	stored := row.Values[0].Value.(VectorPointer)
+	assert.NotEqual(t, PageIndex(0), stored.FirstPage, "FirstPage must be set after storing")
+
+	// Simulate a fresh read from disk by clearing in-memory data.
+	stored.Data = nil
+	row.Values[0] = OptionalValue{Valid: true, Value: stored}
+
+	row, err = row.readOverflowVectors(ctx, pager)
+	require.NoError(t, err)
+
+	loaded := row.Values[0].Value.(VectorPointer)
+	assert.Equal(t, uint32(4), loaded.Dims)
+	for i, f := range []float32{1.1, 2.2, 3.3, 4.4} {
+		assert.InDelta(t, f, loaded.Data[i], 0.0001, "component %d mismatch", i)
+	}
+}
+
+func TestVectorOverflowMultiPage(t *testing.T) {
+	pager := newMockTxPager()
+	ctx := context.Background()
+
+	// MaxOverflowPageData / 4 = ~1021 floats per page; use 2500 to span 3 pages.
+	dims := uint32(2500)
+	data := make([]float32, dims)
+	for i := range data {
+		data[i] = float32(i) * 0.001
+	}
+	vp := VectorPointer{Dims: dims, Data: data}
+
+	col := Column{Name: "big", Kind: Vector, Size: dims}
+	row := Row{
+		Columns: []Column{col},
+		Values:  []OptionalValue{{Valid: true, Value: vp}},
+	}
+
+	var err error
+	row, err = row.storeOverflowVectors(ctx, pager)
+	require.NoError(t, err)
+
+	stored := row.Values[0].Value.(VectorPointer)
+	stored.Data = nil
+	row.Values[0] = OptionalValue{Valid: true, Value: stored}
+
+	row, err = row.readOverflowVectors(ctx, pager)
+	require.NoError(t, err)
+
+	loaded := row.Values[0].Value.(VectorPointer)
+	assert.Equal(t, dims, loaded.Dims)
+	assert.Len(t, loaded.Data, int(dims))
+	for i, f := range data {
+		assert.InDelta(t, f, loaded.Data[i], 0.0001, "component %d mismatch", i)
+	}
+}
+
+// TestL2DistanceDimensionMismatch checks the correct error is returned.
+func TestL2DistanceDimensionMismatch(t *testing.T) {
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	b := VectorPointer{Dims: 2, Data: []float32{1, 2}}
+	_, err := L2Distance(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dimension mismatch")
+}
+
+func TestCosineDistanceDimensionMismatch(t *testing.T) {
+	a := VectorPointer{Dims: 3, Data: []float32{1, 2, 3}}
+	b := VectorPointer{Dims: 2, Data: []float32{1, 2}}
+	_, err := CosineDistance(a, b)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dimension mismatch")
+}
+
+// TestFormatVectorRoundTrip verifies that FormatVector then ParseVectorLiteral is lossless
+// within float32 precision.
+func TestFormatVectorRoundTrip(t *testing.T) {
+	original := []float32{-1.5, 0, 3.14159, math.MaxFloat32 / 2}
+	vp := VectorPointer{Dims: uint32(len(original)), Data: original}
+	s := FormatVector(vp)
+	parsed, err := ParseVectorLiteral(s)
+	require.NoError(t, err)
+	assert.Equal(t, vp.Dims, parsed.Dims)
+	for i, f := range original {
+		assert.InDelta(t, f, parsed.Data[i], math.Abs(float64(f))*1e-5+1e-10, "component %d", i)
+	}
+}

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -474,7 +474,8 @@ func isBuiltinFunction(name string) bool {
 		"EXTRACT", "DATE_PART",
 		"TO_TIMESTAMP",
 		"JSON_EXTRACT", "JSON_VALID", "JSON_TYPE", "JSON_ARRAY_LENGTH", "JSON_CONTAINS",
-		"MATCH", "TS_RANK":
+		"MATCH", "TS_RANK",
+		"VEC_L2", "VEC_COSINE":
 		return true
 	}
 	return isWindowFunction(name)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -39,7 +39,7 @@ var reservedWords = []string{
 	// arithmetic operators (JSON arrow ops must come before "-" for longest-match tokenization)
 	"+", "->>", "->", "-", "/",
 	// column types
-	"BOOLEAN", "INT4", "INT8", "REAL", "DOUBLE", "TEXT", "VARCHAR(", "TIMESTAMP", "JSON", "UUID",
+	"BOOLEAN", "INT4", "INT8", "REAL", "DOUBLE", "TEXT", "VARCHAR(", "TIMESTAMP", "JSON", "UUID", "VECTOR(",
 	// statement types
 	"EXPLAIN ANALYZE", "EXPLAIN",
 	"CREATE TABLE", "DROP TABLE", "CREATE FULLTEXT INDEX", "CREATE INVERTED INDEX", "CREATE INDEX", "DROP INDEX",
@@ -81,6 +81,7 @@ const (
 	stepCreateTableColumn
 	stepCreateTableColumnDef
 	stepCreateTableVarcharLength
+	stepCreateTableVectorLength
 	stepCreateTableColumnPrimaryKey
 	stepCreateTableColumnNullNotNull
 	stepCreateTableColumnUnique
@@ -305,6 +306,7 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 			stepCreateTableColumn,
 			stepCreateTableColumnDef,
 			stepCreateTableVarcharLength,
+			stepCreateTableVectorLength,
 			stepCreateTableColumnPrimaryKey,
 			stepCreateTableColumnNullNotNull,
 			stepCreateTableColumnUnique,

--- a/internal/parser/table.go
+++ b/internal/parser/table.go
@@ -74,9 +74,12 @@ func (p *parserItem) doParseCreateTable() error {
 		}
 		p.pop()
 		p.Columns[len(p.Columns)-1].Kind = col.Kind
-		if col.Kind == minisql.Varchar {
+		switch col.Kind {
+		case minisql.Varchar:
 			p.step = stepCreateTableVarcharLength
-		} else {
+		case minisql.Vector:
+			p.step = stepCreateTableVectorLength
+		default:
 			p.Columns[len(p.Columns)-1].Size = col.Size
 			p.step = stepCreateTableColumnPrimaryKey
 		}
@@ -97,6 +100,23 @@ func (p *parserItem) doParseCreateTable() error {
 		closingParens := p.peek()
 		if closingParens != ")" {
 			return p.errorf("at CREATE TABLE: expecting closing parenthesis after varchar size")
+		}
+		p.pop()
+		p.step = stepCreateTableColumnPrimaryKey
+	case stepCreateTableVectorLength:
+		sizeToken := p.peek()
+		dims, err := strconv.ParseUint(sizeToken, 10, 32)
+		if err != nil {
+			return p.errorf("at CREATE TABLE: vector dimension '%s' must be an integer", sizeToken)
+		}
+		if dims == 0 {
+			return p.errorf("at CREATE TABLE: vector dimension must be a positive integer")
+		}
+		p.pop()
+		p.Columns[len(p.Columns)-1].Size = uint32(dims)
+		closingParens := p.peek()
+		if closingParens != ")" {
+			return p.errorf("at CREATE TABLE: expecting closing parenthesis after vector dimension")
 		}
 		p.pop()
 		p.step = stepCreateTableColumnPrimaryKey
@@ -567,6 +587,8 @@ func isColumnDef(token string) (minisql.Column, bool) {
 		return minisql.Column{Kind: minisql.JSON}, true
 	case "UUID":
 		return minisql.Column{Kind: minisql.UUID, Size: 16}, true
+	case "VECTOR(":
+		return minisql.Column{Kind: minisql.Vector}, true
 	default:
 		return minisql.Column{}, false
 	}

--- a/internal/parser/vector_test.go
+++ b/internal/parser/vector_test.go
@@ -1,0 +1,133 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql/internal/minisql"
+)
+
+func TestParse_VectorColumn(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCase{
+		{
+			"CREATE TABLE with vector column",
+			"CREATE TABLE docs (id int8 primary key, embedding vector(3));",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "docs",
+					Columns: []minisql.Column{
+						{Name: "id", Kind: minisql.Int8, Size: 8, Nullable: false},
+						{Name: "embedding", Kind: minisql.Vector, Size: 3, Nullable: true},
+					},
+					PrimaryKey: minisql.NewPrimaryKey(
+						minisql.PrimaryKeyName("docs"),
+						[]minisql.Column{{Name: "id", Kind: minisql.Int8, Size: 8, Nullable: false}},
+						false,
+					),
+				},
+			},
+			nil,
+		},
+		{
+			"CREATE TABLE vector not null",
+			"CREATE TABLE embeddings (id int8 primary key, vec vector(1536) not null);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "embeddings",
+					Columns: []minisql.Column{
+						{Name: "id", Kind: minisql.Int8, Size: 8, Nullable: false},
+						{Name: "vec", Kind: minisql.Vector, Size: 1536, Nullable: false},
+					},
+					PrimaryKey: minisql.NewPrimaryKey(
+						minisql.PrimaryKeyName("embeddings"),
+						[]minisql.Column{{Name: "id", Kind: minisql.Int8, Size: 8, Nullable: false}},
+						false,
+					),
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, aTestCase := range testCases {
+		t.Run(aTestCase.Name, func(t *testing.T) {
+			t.Parallel()
+			got, err := New().Parse(context.Background(), aTestCase.SQL)
+			if aTestCase.Err != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, aTestCase.Err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, aTestCase.Expected, got)
+		})
+	}
+}
+
+func TestParse_VecL2Function(t *testing.T) {
+	t.Parallel()
+
+	sql := `SELECT id, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist FROM docs ORDER BY dist LIMIT 5;`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	assert.Equal(t, minisql.Select, stmt.Kind)
+
+	// Verify VEC_L2 is parsed as a function expression.
+	var found bool
+	for _, f := range stmt.Fields {
+		if f.Expr != nil && f.Expr.FuncName == "VEC_L2" {
+			found = true
+			assert.Equal(t, "dist", f.Alias)
+			assert.Len(t, f.Expr.Args, 2)
+		}
+	}
+	assert.True(t, found, "VEC_L2 expression not found in SELECT fields")
+}
+
+func TestParse_VecCosineFunction(t *testing.T) {
+	t.Parallel()
+
+	sql := `SELECT id, VEC_COSINE(embedding, '[1.0, 0.0]') AS dist FROM docs ORDER BY dist LIMIT 10;`
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stmt := stmts[0]
+	var found bool
+	for _, f := range stmt.Fields {
+		if f.Expr != nil && f.Expr.FuncName == "VEC_COSINE" {
+			found = true
+			assert.Equal(t, "dist", f.Alias)
+			assert.Len(t, f.Expr.Args, 2)
+		}
+	}
+	assert.True(t, found, "VEC_COSINE expression not found in SELECT fields")
+}
+
+func TestParse_VectorColumnDDLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	sql := "CREATE TABLE docs (id int8 primary key, embedding vector(1536) not null);"
+	stmts, err := New().Parse(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	ddl := stmts[0].DDL()
+	assert.Contains(t, ddl, "vector(1536)", "DDL must include vector dimension")
+
+	// Round-trip: parse the generated DDL.
+	stmts2, err := New().Parse(context.Background(), ddl)
+	require.NoError(t, err)
+	require.Len(t, stmts2, 1)
+	assert.Equal(t, stmts[0].Columns, stmts2[0].Columns)
+}

--- a/rows.go
+++ b/rows.go
@@ -87,6 +87,8 @@ func (r *Rows) Next(dest []driver.Value) error {
 			dest[i] = minisql.FromMicroseconds(int64(v)).GoTime()
 		case minisql.UUIDValue:
 			dest[i] = v.String()
+		case minisql.VectorPointer:
+			dest[i] = minisql.FormatVector(v)
 		default:
 			dest[i] = aRow.Values[i].Value
 		}
@@ -179,6 +181,19 @@ func (r *Rows) rowViewDriverValue(view minisql.RowView, destIdx, fieldIdx int) (
 			return nil, err
 		}
 		return value.String(), nil
+	case minisql.Vector:
+		value, err := view.ValueAtWithOverflow(r.ctx, r.rowViewPager, fieldIdx)
+		if err != nil {
+			return nil, err
+		}
+		if !value.Valid {
+			return nil, nil
+		}
+		vp, ok := value.Value.(minisql.VectorPointer)
+		if !ok {
+			return nil, fmt.Errorf("expected VectorPointer for vector column")
+		}
+		return minisql.FormatVector(vp), nil
 	default:
 		value, err := view.ValueAt(fieldIdx)
 		if err != nil {


### PR DESCRIPTION
…unctions

Implements Phase 1 of vector search support:

- New VECTOR(n) column type that stores n-dimensional float32 embeddings. Column.Size holds the dimension count; data always lives on overflow pages. The 8-byte inline leaf cell stores dims + first overflow page index.

- ParseVectorLiteral / FormatVector convert between '[f0, f1, ...]' string literals and VectorPointer values.

- VEC_L2(col, literal) returns the Euclidean distance; VEC_COSINE(col, literal) returns the cosine distance (1 - cosine_similarity). Both functions are recognised by the parser and evaluated at query time, enabling ORDER BY dist LIMIT k nearest-neighbor queries.

- Overflow storage: storeOverflowVectors / readOverflowVectors mirror the existing text overflow path and are wired into MaterializeWithOverflow, the parallel scan single-phase path, and both cursor write paths.

- compareValue guards against panic when comparing VectorPointer (which contains a []float32 slice and is therefore not directly comparable).

- 48 new tests: unit tests for distance functions, marshal round-trips, multi-page overflow, parser CREATE TABLE / DDL round-trip, and e2e tests covering INSERT/SELECT, VEC_L2 nearest-neighbor, VEC_COSINE top-k, UPDATE, NULL vectors, combined WHERE filter, and 1536-dim overflow.