### PR TITLE
feat: replace bare error sentinels with typed, actionable errors

### DIFF
--- a/e2e_tests/alter_table_test.go
+++ b/e2e_tests/alter_table_test.go
@@ -3,6 +3,8 @@ package e2etests
 import (
 	"context"
 	"database/sql"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // TestAlterTable_AddColumn verifies that a new column can be added to an existing
@@ -243,7 +245,9 @@ func (s *TestSuite) TestAlterTable_RenameTo() {
 	// Old name should be gone.
 	_, err = s.db.ExecContext(ctx, `select * from "items";`)
 	s.Require().Error(err)
-	s.Require().ErrorContains(err, `table does not exist`)
+	var noTblErr minisqlErrors.ErrNoSuchTable
+	s.Require().ErrorAs(err, &noTblErr)
+	s.Equal("items", noTblErr.Name)
 
 	// New name should work.
 	var id int64

--- a/e2e_tests/database_test.go
+++ b/e2e_tests/database_test.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	_ "github.com/RichardKnop/minisql"
 	"github.com/RichardKnop/minisql/internal/minisql"
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 type schema struct {
@@ -65,7 +66,9 @@ func (s *TestSuite) TestCreateTable() {
 	s.Run("Create table fails if table already exists", func() {
 		_, err := s.db.Exec(createUsersTableSQL)
 		s.Require().Error(err)
-		s.Equal("table already exists", err.Error())
+		var tblExistsErr minisqlErrors.ErrTableAlreadyExists
+		s.Require().ErrorAs(err, &tblExistsErr)
+		s.NotEmpty(tblExistsErr.Name)
 	})
 
 	s.Run("Create table with IF NOT EXISTS does not fail if table exists", func() {

--- a/e2e_tests/select_test.go
+++ b/e2e_tests/select_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 func (s *TestSuite) TestSelect() {
@@ -52,7 +53,9 @@ values(100, 'Johnathan_Walker250+new@ptr6k.page', 'Johnathan Walker', '2024-01-0
 values('Johnathan Walker', 'Johnathan_Walker250@ptr6k.page', '2024-01-02 15:30:27');`)
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, minisql.ErrDuplicateKey)
-		s.Equal("failed to insert key for unique index key__users__email: duplicate key", err.Error())
+		var uvErr minisqlErrors.ErrUniqueViolation
+		s.Require().ErrorAs(err, &uvErr)
+		s.Equal("users", uvErr.Table)
 		s.Nil(result)
 	})
 

--- a/internal/minisql/alter_table.go
+++ b/internal/minisql/alter_table.go
@@ -3,6 +3,8 @@ package minisql
 import (
 	"context"
 	"fmt"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // executeAlterTable dispatches an ALTER TABLE statement to the appropriate
@@ -13,7 +15,7 @@ func (d *Database) executeAlterTable(ctx context.Context, stmt Statement) error 
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.TableName)
+		return minisqlErrors.ErrNoSuchTable{Name: stmt.TableName}
 	}
 
 	switch stmt.AlterTableAction {

--- a/internal/minisql/check.go
+++ b/internal/minisql/check.go
@@ -2,17 +2,13 @@ package minisql
 
 import (
 	"fmt"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
-// ErrCheckConstraintViolation is returned when an INSERT or UPDATE row fails a CHECK constraint.
-type ErrCheckConstraintViolation struct {
-	ColumnName string
-	Expr       string
-}
-
-func (e ErrCheckConstraintViolation) Error() string {
-	return fmt.Sprintf("check constraint violation on column %q: %s", e.ColumnName, e.Expr)
-}
+// ErrCheckConstraintViolation aliases the public type so internal and e2e
+// tests can reference it via either package without an import cycle.
+type ErrCheckConstraintViolation = minisqlErrors.ErrCheckConstraintViolation
 
 // validateCheckConstraints verifies that row satisfies every column-level CHECK
 // constraint defined in columns.  Returns ErrCheckConstraintViolation on the

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -18,10 +18,6 @@ import (
 
 var (
 	errUnrecognizedStatementType = errors.New("unrecognised statement type")
-	errTableDoesNotExist         = errors.New("table does not exist")
-	errTableAlreadyExists        = errors.New("table already exists")
-	errIndexDoesNotExist         = errors.New("index does not exist")
-	errIndexAlreadyExists        = errors.New("index already exists")
 	errIndexOnJSONColumn         = errors.New("b-tree index on JSON column is not supported")
 )
 
@@ -291,7 +287,7 @@ func (d *Database) Reopen(ctx context.Context, factory PagerFactory, saver PageS
 func (d *Database) pagerFactory(ctx context.Context, tableName, indexName string) (Pager, error) {
 	table, ok := d.lockedProvider.GetTable(ctx, tableName)
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", errTableDoesNotExist, tableName)
+		return nil, minisqlErrors.ErrNoSuchTable{Name: tableName}
 	}
 	if indexName == "" {
 		return d.factory.ForTable(table.Columns), nil
@@ -308,7 +304,7 @@ func (d *Database) pagerFactory(ctx context.Context, tableName, indexName string
 			}
 		}
 		if len(columns) == 0 {
-			return nil, errIndexDoesNotExist
+			return nil, minisqlErrors.ErrNoSuchIndex{Name: indexName}
 		}
 	}
 
@@ -546,7 +542,7 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 
 		table, ok := d.GetTable(ctx, stmt.TableName)
 		if !ok {
-			return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.TableName)
+			return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: stmt.TableName}
 		}
 
 		return d.executeTableStatement(ctx, table, stmt)
@@ -980,7 +976,7 @@ func (d *Database) executeDDLStatement(ctx context.Context, stmt Statement) (Sta
 			return StatementResult{}, err
 		}
 		if !exists {
-			return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.TableName)
+			return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: stmt.TableName}
 		}
 		table, err = d.tableFromSQL(ctx, tableSchema)
 		if err != nil {
@@ -1099,7 +1095,7 @@ func (d *Database) executeUnion(ctx context.Context, stmt Statement) (StatementR
 	for i, s := range stmts {
 		table, ok := d.GetTable(ctx, s.TableName)
 		if !ok {
-			return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, s.TableName)
+			return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: s.TableName}
 		}
 
 		result, err := d.executeTableStatement(ctx, table, s)
@@ -1173,7 +1169,7 @@ func (d *Database) executeUnionAllStreaming(ctx context.Context, stmts []Stateme
 	for i, s := range stmts {
 		table, ok := d.GetTable(ctx, s.TableName)
 		if !ok {
-			return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, s.TableName)
+			return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: s.TableName}
 		}
 
 		result, err := d.executeTableStatement(ctx, table, s)
@@ -1221,7 +1217,7 @@ func (d *Database) createTable(ctx context.Context, stmt Statement) (*Table, err
 		if stmt.IfNotExists {
 			return d.tables[stmt.TableName], nil
 		}
-		return nil, errTableAlreadyExists
+		return nil, minisqlErrors.ErrTableAlreadyExists{Name: stmt.TableName}
 	}
 
 	d.logger.Sugar().With("name", stmt.TableName).Debug("creating table")
@@ -1384,7 +1380,7 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, name)
+		return minisqlErrors.ErrNoSuchTable{Name: name}
 	}
 	tableToDelete := d.tables[name]
 
@@ -1522,7 +1518,7 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 		if stmt.IfNotExists {
 			return nil
 		}
-		return errIndexAlreadyExists
+		return minisqlErrors.ErrIndexAlreadyExists{Name: stmt.IndexName}
 	}
 
 	// Resolve index columns from the table schema, or build a synthetic column for expression indexes.
@@ -2022,7 +2018,7 @@ func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {
 		return err
 	}
 	if !exists {
-		return errIndexDoesNotExist
+		return minisqlErrors.ErrNoSuchIndex{Name: stmt.IndexName}
 	}
 	stmts, err := d.parser.Parse(ctx, schema.DDL)
 	if err != nil {
@@ -2038,7 +2034,7 @@ func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, schema.TableName)
+		return minisqlErrors.ErrNoSuchTable{Name: schema.TableName}
 	}
 	table, err := d.tableFromSQL(ctx, tableSchema)
 	if err != nil {

--- a/internal/minisql/database_test.go
+++ b/internal/minisql/database_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 func TestNewDatabase(t *testing.T) {
@@ -423,7 +425,9 @@ func TestDatabase_CreateIndex(t *testing.T) {
 			return err
 		})
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "table does not exist")
+		var noTblErr minisqlErrors.ErrNoSuchTable
+		require.ErrorAs(t, err, &noTblErr)
+		assert.Equal(t, "bogus", noTblErr.Name)
 	})
 
 	t.Run("Create index", func(t *testing.T) {
@@ -471,7 +475,9 @@ func TestDatabase_CreateIndex(t *testing.T) {
 			return err
 		})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errIndexAlreadyExists)
+		var idxExistsErr minisqlErrors.ErrIndexAlreadyExists
+		require.ErrorAs(t, err, &idxExistsErr)
+		assert.Equal(t, "foo_bar", idxExistsErr.Name)
 	})
 
 	t.Run("Drop index when index does not exist", func(t *testing.T) {
@@ -484,7 +490,9 @@ func TestDatabase_CreateIndex(t *testing.T) {
 			return err
 		})
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errIndexDoesNotExist)
+		var noIdxErr minisqlErrors.ErrNoSuchIndex
+		require.ErrorAs(t, err, &noIdxErr)
+		assert.Equal(t, "bogus", noIdxErr.Name)
 	})
 
 	t.Run("Drop index", func(t *testing.T) {

--- a/internal/minisql/explain.go
+++ b/internal/minisql/explain.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 var errExplainUnsupportedStatement = errors.New("EXPLAIN currently supports SELECT statements only")
@@ -59,7 +61,7 @@ func (d *Database) executeExplain(ctx context.Context, stmt Statement) (Statemen
 
 	table, ok := d.GetTable(ctx, inner.TableName)
 	if !ok {
-		return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, inner.TableName)
+		return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: inner.TableName}
 	}
 
 	inner.TableName = table.Name
@@ -170,7 +172,7 @@ func (d *Database) executeExplainCTEs(ctx context.Context, inner Statement, anal
 
 	mainTable, ok := d.GetTable(mainCtx, mainStmt.TableName)
 	if !ok {
-		return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, mainStmt.TableName)
+		return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: mainStmt.TableName}
 	}
 	mainStmt.Columns = mainTable.Columns
 

--- a/internal/minisql/hash_join.go
+++ b/internal/minisql/hash_join.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/RichardKnop/minisql/pkg/bloom"
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 const (
@@ -74,7 +75,7 @@ func buildHashBuckets(ctx context.Context, plan QueryPlan, provider TableProvide
 		innerScan := plan.Scans[join.RightScanIndex]
 		innerTable, ok := provider.GetTable(ctx, innerScan.TableName)
 		if !ok {
-			return nil, fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+			return nil, minisqlErrors.ErrNoSuchTable{Name: innerScan.TableName}
 		}
 		// Size the Bloom filter using the inner table's row-count estimate.
 		// Fall back to bloomMinN when no statistics are available.

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // ScanType selects the execution strategy the query planner assigns to a Scan.
@@ -1742,7 +1744,7 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 	if len(p.Scans) == 1 {
 		t, ok := provider.GetTable(ctx, p.Scans[0].TableName)
 		if !ok {
-			return fmt.Errorf("%w: %s", errTableDoesNotExist, p.Scans[0].TableName)
+			return minisqlErrors.ErrNoSuchTable{Name: p.Scans[0].TableName}
 		}
 
 		switch p.Scans[0].Type {
@@ -1775,7 +1777,7 @@ func (p QueryPlan) Execute(ctx context.Context, provider TableProvider, selected
 	for _, scan := range p.Scans {
 		t, ok := provider.GetTable(ctx, scan.TableName)
 		if !ok {
-			return fmt.Errorf("%w: %s", errTableDoesNotExist, scan.TableName)
+			return minisqlErrors.ErrNoSuchTable{Name: scan.TableName}
 		}
 
 		switch scan.Type {

--- a/internal/minisql/query_plan_join.go
+++ b/internal/minisql/query_plan_join.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // joinMemo holds precomputed, per-join-level state that is constant across all
@@ -474,7 +476,7 @@ func (t *Table) planJoinQueryGreedy(ctx context.Context, stmt Statement) (QueryP
 			fromTableName := plan.Scans[leftScanIndex].TableName
 			ft, ftOk := t.provider.GetTable(ctx, fromTableName)
 			if !ftOk {
-				return QueryPlan{}, false, fmt.Errorf("%w: %s", errTableDoesNotExist, fromTableName)
+				return QueryPlan{}, false, minisqlErrors.ErrNoSuchTable{Name: fromTableName}
 			}
 			fromTable = ft
 		}
@@ -573,13 +575,13 @@ func (t *Table) flattenJoinTree(
 		} else {
 			fromTable, ok = t.provider.GetTable(ctx, fromScan.TableName)
 			if !ok {
-				return fmt.Errorf("%w: %s", errTableDoesNotExist, fromScan.TableName)
+				return minisqlErrors.ErrNoSuchTable{Name: fromScan.TableName}
 			}
 		}
 
 		joinedTable, ok := t.provider.GetTable(ctx, join.TableName)
 		if !ok {
-			return fmt.Errorf("%w: %s", errTableDoesNotExist, join.TableName)
+			return minisqlErrors.ErrNoSuchTable{Name: join.TableName}
 		}
 
 		joinColumnPairs, err := extractJoinColumnPairs(
@@ -993,7 +995,7 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 	baseScan := p.Scans[0]
 	baseTable, ok := provider.GetTable(ctx, baseScan.TableName)
 	if !ok {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, baseScan.TableName)
+		return minisqlErrors.ErrNoSuchTable{Name: baseScan.TableName}
 	}
 
 	// Precompute per-join-level state that is constant across all outer rows.
@@ -1004,7 +1006,7 @@ func (p QueryPlan) executeNestedLoopJoin(ctx context.Context, provider TableProv
 		innerScan := p.Scans[join.RightScanIndex]
 		innerTable, innerOK := provider.GetTable(ctx, innerScan.TableName)
 		if !innerOK {
-			return fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+			return minisqlErrors.ErrNoSuchTable{Name: innerScan.TableName}
 		}
 
 		var combinedCols []Column
@@ -1581,7 +1583,7 @@ func (p QueryPlan) executeRightJoinPass(ctx context.Context, provider TableProvi
 	baseScan := p.Scans[0]
 	baseTable, ok := provider.GetTable(ctx, baseScan.TableName)
 	if !ok {
-		return fmt.Errorf("%w: %s", errTableDoesNotExist, baseScan.TableName)
+		return minisqlErrors.ErrNoSuchTable{Name: baseScan.TableName}
 	}
 	baseFields := fieldsFromColumns(baseTable.Columns...)
 
@@ -1593,7 +1595,7 @@ func (p QueryPlan) executeRightJoinPass(ctx context.Context, provider TableProvi
 		innerScan := p.Scans[join.RightScanIndex]
 		innerTable, ok := provider.GetTable(ctx, innerScan.TableName)
 		if !ok {
-			return fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+			return minisqlErrors.ErrNoSuchTable{Name: innerScan.TableName}
 		}
 		innerFields := fieldsFromColumns(innerTable.Columns...)
 
@@ -1702,7 +1704,7 @@ func (p QueryPlan) buildRightJoinNullRow(ctx context.Context, provider TableProv
 	baseScan := p.Scans[0]
 	baseTable, ok := provider.GetTable(ctx, baseScan.TableName)
 	if !ok {
-		return Row{}, fmt.Errorf("%w: %s", errTableDoesNotExist, baseScan.TableName)
+		return Row{}, minisqlErrors.ErrNoSuchTable{Name: baseScan.TableName}
 	}
 
 	// Build the combined row scan-by-scan (base first, then each join in order).
@@ -1718,7 +1720,7 @@ func (p QueryPlan) buildRightJoinNullRow(ctx context.Context, provider TableProv
 	} else {
 		join0Table, ok := provider.GetTable(ctx, join0Scan.TableName)
 		if !ok {
-			return Row{}, fmt.Errorf("%w: %s", errTableDoesNotExist, join0Scan.TableName)
+			return Row{}, minisqlErrors.ErrNoSuchTable{Name: join0Scan.TableName}
 		}
 		firstInnerRow = nullRowForColumns(join0Table.Columns)
 	}
@@ -1735,7 +1737,7 @@ func (p QueryPlan) buildRightJoinNullRow(ctx context.Context, provider TableProv
 		} else {
 			jiTable, ok := provider.GetTable(ctx, jiScan.TableName)
 			if !ok {
-				return Row{}, fmt.Errorf("%w: %s", errTableDoesNotExist, jiScan.TableName)
+				return Row{}, minisqlErrors.ErrNoSuchTable{Name: jiScan.TableName}
 			}
 			innerRow = nullRowForColumns(jiTable.Columns)
 		}

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // ErrNoMoreRows is returned by an Iterator's row function when the result set is exhausted.
@@ -1919,7 +1921,7 @@ func (t *Table) selectHashJoinDirectRowView(
 	outerScan := plan.Scans[0]
 	outerTable, ok := t.provider.GetTable(ctx, outerScan.TableName)
 	if !ok {
-		return StatementResult{}, true, fmt.Errorf("%w: %s", errTableDoesNotExist, outerScan.TableName)
+		return StatementResult{}, true, minisqlErrors.ErrNoSuchTable{Name: outerScan.TableName}
 	}
 	if outerTable.virtualRows != nil || outerTable.parallelScan {
 		return StatementResult{}, false, nil
@@ -1932,7 +1934,7 @@ func (t *Table) selectHashJoinDirectRowView(
 
 	innerTable, ok := t.provider.GetTable(ctx, innerScan.TableName)
 	if !ok {
-		return StatementResult{}, true, fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+		return StatementResult{}, true, minisqlErrors.ErrNoSuchTable{Name: innerScan.TableName}
 	}
 
 	combinedCols := buildCombinedColumns(outerTable.Columns, outerScan.TableAlias, innerTable.Columns, innerScan.TableAlias)
@@ -2019,7 +2021,7 @@ func (t *Table) selectINLJDirectRowView(
 	outerScan := plan.Scans[0]
 	outerTable, ok := t.provider.GetTable(ctx, outerScan.TableName)
 	if !ok {
-		return StatementResult{}, true, fmt.Errorf("%w: %s", errTableDoesNotExist, outerScan.TableName)
+		return StatementResult{}, true, minisqlErrors.ErrNoSuchTable{Name: outerScan.TableName}
 	}
 	if outerTable.virtualRows != nil || outerTable.parallelScan {
 		return StatementResult{}, false, nil
@@ -2039,7 +2041,7 @@ func (t *Table) selectINLJDirectRowView(
 
 	innerTable, ok := t.provider.GetTable(ctx, innerScan.TableName)
 	if !ok {
-		return StatementResult{}, true, fmt.Errorf("%w: %s", errTableDoesNotExist, innerScan.TableName)
+		return StatementResult{}, true, minisqlErrors.ErrNoSuchTable{Name: innerScan.TableName}
 	}
 	if !innerTable.isUniquePointIndex(innerScan.IndexName) {
 		return StatementResult{}, false, nil

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"unicode/utf8"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // insertPrepCache holds the static column-order metadata for a prepared INSERT
@@ -1893,13 +1895,13 @@ func (s Statement) validateColumnValue(table *Table, col Column, val OptionalVal
 		isPkColumn = true
 	}
 	if !val.Valid && isPkColumn && !table.PrimaryKey.Autoincrement {
-		return fmt.Errorf("primary key on field %q cannot be NULL", col.Name)
+		return minisqlErrors.ErrNotNullViolation{Table: table.Name, Column: col.Name}
 	}
 	if !val.Valid && !col.Nullable && !isPkColumn {
-		return fmt.Errorf("field %q cannot be NULL", col.Name)
+		return minisqlErrors.ErrNotNullViolation{Table: table.Name, Column: col.Name}
 	}
 	if err := isValueValidForColumn(col, val); err != nil {
-		return fmt.Errorf("invalid field value: %w", err)
+		return minisqlErrors.ErrTypeMismatch{Table: table.Name, Column: col.Name, Expected: col.Kind.String(), Detail: err.Error()}
 	}
 	return nil
 }

--- a/internal/minisql/table_unique_index.go
+++ b/internal/minisql/table_unique_index.go
@@ -2,10 +2,13 @@ package minisql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 // UniqueIndex associates a unique-enforcing B+ tree index with its metadata.
@@ -59,6 +62,13 @@ func (t *Table) insertUniqueIndexKey(ctx context.Context, uniqueIndex UniqueInde
 	}
 
 	if err := uniqueIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
+		if errors.Is(err, ErrDuplicateKey) {
+			cols := make([]string, len(uniqueIndex.Columns))
+			for i, c := range uniqueIndex.Columns {
+				cols[i] = c.Name
+			}
+			return minisqlErrors.NewUniqueViolation(t.Name, uniqueIndex.Name, cols, err)
+		}
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
 	}
 
@@ -95,6 +105,13 @@ func (t *Table) insertUniqueCompositeIndexKey(ctx context.Context, uniqueIndex U
 	}
 
 	if err := uniqueIndex.Index.Insert(ctx, ck, rowID); err != nil {
+		if errors.Is(err, ErrDuplicateKey) {
+			cols := make([]string, len(uniqueIndex.Columns))
+			for i, c := range uniqueIndex.Columns {
+				cols[i] = c.Name
+			}
+			return minisqlErrors.NewUniqueViolation(t.Name, uniqueIndex.Name, cols, err)
+		}
 		return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
 	}
 
@@ -136,6 +153,13 @@ func (t *Table) updateUniqueIndexKey(ctx context.Context, uniqueIndex UniqueInde
 		// We try to insert new index key first to avoid leaving table in inconsistent state
 		// If the new index key is already taken, we return an error without modifying the existing row
 		if err := uniqueIndex.Index.Insert(ctx, castedKey, rowID); err != nil {
+			if errors.Is(err, ErrDuplicateKey) {
+				cols := make([]string, len(uniqueIndex.Columns))
+				for i, c := range uniqueIndex.Columns {
+					cols[i] = c.Name
+				}
+				return minisqlErrors.NewUniqueViolation(t.Name, uniqueIndex.Name, cols, err)
+			}
 			return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
 		}
 	}
@@ -194,6 +218,13 @@ func (t *Table) updateCompositeUniqueIndexKey(ctx context.Context, uniqueIndex U
 		// If the new index key is already taken, we return an error without modifying the existing row
 		ck := NewCompositeKey(uniqueIndex.Columns, newKeyValues...)
 		if err := uniqueIndex.Index.Insert(ctx, ck, rowID); err != nil {
+			if errors.Is(err, ErrDuplicateKey) {
+				cols := make([]string, len(uniqueIndex.Columns))
+				for i, c := range uniqueIndex.Columns {
+					cols[i] = c.Name
+				}
+				return minisqlErrors.NewUniqueViolation(t.Name, uniqueIndex.Name, cols, err)
+			}
 			return fmt.Errorf("failed to insert key for unique index %s: %w", uniqueIndex.Name, err)
 		}
 	}

--- a/internal/minisql/update_from.go
+++ b/internal/minisql/update_from.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+
+	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
 type ctxKeyUpdateFromRows struct{}
@@ -32,7 +34,7 @@ func updateFromRowsFromContext(ctx context.Context) ([]Row, bool) {
 func (d *Database) executeUpdateFrom(ctx context.Context, stmt Statement) (StatementResult, error) {
 	targetTable, ok := d.tables[stmt.TableName]
 	if !ok {
-		return StatementResult{}, fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.TableName)
+		return StatementResult{}, minisqlErrors.ErrNoSuchTable{Name: stmt.TableName}
 	}
 
 	// FROM rows are pre-materialised in ExecuteStatement (before the write lock
@@ -178,7 +180,7 @@ func (d *Database) materialiseFromSource(ctx context.Context, stmt Statement) ([
 
 	fromTable, ok := d.tables[stmt.UpdateFromTable]
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", errTableDoesNotExist, stmt.UpdateFromTable)
+		return nil, minisqlErrors.ErrNoSuchTable{Name: stmt.UpdateFromTable}
 	}
 	if fromAlias == "" {
 		fromAlias = stmt.UpdateFromTable

--- a/pkg/errors/constraints.go
+++ b/pkg/errors/constraints.go
@@ -1,0 +1,74 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrUniqueViolation is returned when an INSERT or UPDATE would create a
+// duplicate value in a unique index or primary key.
+type ErrUniqueViolation struct {
+	Table   string
+	Index   string
+	Columns []string
+	cause   error // typically ErrDuplicateKey; preserved for errors.Is chains
+}
+
+// NewUniqueViolation constructs an ErrUniqueViolation. Pass the raw
+// ErrDuplicateKey sentinel as cause so that errors.Is(err, ErrDuplicateKey)
+// continues to work for callers who already rely on that check.
+func NewUniqueViolation(table, index string, columns []string, cause error) ErrUniqueViolation {
+	return ErrUniqueViolation{Table: table, Index: index, Columns: columns, cause: cause}
+}
+
+func (e ErrUniqueViolation) Error() string {
+	return fmt.Sprintf(
+		"unique constraint violation on table %q index %q: duplicate value in column(s) (%s)",
+		e.Table, e.Index, strings.Join(e.Columns, ", "),
+	)
+}
+
+// Unwrap lets errors.Is(err, ErrDuplicateKey) traverse the chain.
+func (e ErrUniqueViolation) Unwrap() error { return e.cause }
+
+// ErrNotNullViolation is returned when an INSERT or UPDATE would store NULL
+// in a NOT NULL column.
+type ErrNotNullViolation struct {
+	Table  string
+	Column string
+}
+
+func (e ErrNotNullViolation) Error() string {
+	return fmt.Sprintf("not null constraint violation on table %q: field %q cannot be NULL", e.Table, e.Column)
+}
+
+// ErrTypeMismatch is returned when a supplied value cannot be stored in the
+// target column due to an incompatible type.
+type ErrTypeMismatch struct {
+	Table    string
+	Column   string
+	Expected string
+	Detail   string // optional human-readable detail from the underlying validator
+}
+
+func (e ErrTypeMismatch) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("type mismatch on table %q column %q: %s", e.Table, e.Column, e.Detail)
+	}
+	return fmt.Sprintf("type mismatch on table %q column %q: expected %s", e.Table, e.Column, e.Expected)
+}
+
+// ErrCheckConstraintViolation is returned when an INSERT or UPDATE row fails
+// a CHECK constraint.
+type ErrCheckConstraintViolation struct {
+	Table      string
+	ColumnName string
+	Expr       string
+}
+
+func (e ErrCheckConstraintViolation) Error() string {
+	if e.Table != "" {
+		return fmt.Sprintf("check constraint violation on table %q column %q: %s", e.Table, e.ColumnName, e.Expr)
+	}
+	return fmt.Sprintf("check constraint violation on column %q: %s", e.ColumnName, e.Expr)
+}

--- a/pkg/errors/schema.go
+++ b/pkg/errors/schema.go
@@ -1,0 +1,43 @@
+package errors
+
+import "fmt"
+
+// ErrNoSuchTable is returned when a statement references a table that does not
+// exist in the database schema.
+type ErrNoSuchTable struct {
+	Name string
+}
+
+func (e ErrNoSuchTable) Error() string {
+	return fmt.Sprintf("table %q does not exist", e.Name)
+}
+
+// ErrTableAlreadyExists is returned when CREATE TABLE is called for a table
+// whose name already exists in the schema.
+type ErrTableAlreadyExists struct {
+	Name string
+}
+
+func (e ErrTableAlreadyExists) Error() string {
+	return fmt.Sprintf("table %q already exists", e.Name)
+}
+
+// ErrNoSuchIndex is returned when a statement references an index that does not
+// exist in the database schema.
+type ErrNoSuchIndex struct {
+	Name string
+}
+
+func (e ErrNoSuchIndex) Error() string {
+	return fmt.Sprintf("index %q does not exist", e.Name)
+}
+
+// ErrIndexAlreadyExists is returned when CREATE INDEX is called for an index
+// whose name already exists in the schema.
+type ErrIndexAlreadyExists struct {
+	Name string
+}
+
+func (e ErrIndexAlreadyExists) Error() string {
+	return fmt.Sprintf("index %q already exists", e.Name)
+}


### PR DESCRIPTION
Introduce pkg/errors/constraints.go and pkg/errors/schema.go with structured error types that carry enough context (table name, column name, index name, etc.) for callers to act on errors programmatically rather than string-matching.

- ErrUniqueViolation{Table, Index, Columns} wraps ErrDuplicateKey so existing errors.Is(err, ErrDuplicateKey) chains continue to work
- ErrNotNullViolation{Table, Column} replaces bare fmt.Errorf strings
- ErrTypeMismatch{Table, Column, Expected, Detail} preserves the inner validator message so existing ErrorContains assertions still pass
- ErrCheckConstraintViolation moved to pkg/errors (Table field added); internal package exposes it as a type alias to avoid import cycles
- ErrNoSuchTable, ErrTableAlreadyExists, ErrNoSuchIndex, ErrIndexAlreadyExists replace five private package-level sentinels and all 22+ fmt.Errorf("%w: %s", sentinel, name) call sites

All 3759 tests pass; golangci-lint reports no issues.