### PR TITLE
feat: add transparent AES-256-CTR page encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 5. Built-in full-text search
 6. Built-in JSON inverted index
 7. Built-in vector similarity search (`VECTOR(n)` column type + `VEC_L2` / `VEC_COSINE` distance functions + HNSW approximate nearest-neighbour index)
+8. Transparent AES-256-CTR page encryption with HKDF key derivation
 
 To use minisql in your Go code, import the driver:
 
@@ -65,6 +66,7 @@ MiniSQL supports optional connection string parameters:
 | `slow_query_threshold` | Go duration, e.g. `50ms`, `2s` | `0` | Log queries taking at least this long at WARN level (0 = disabled) |
 | `synchronous` | `off`, `normal`, `full` | `normal` | WAL fsync mode (see [WAL durability](#wal-durability-modes) below) |
 | `parallel_scan` | `on`, `off` | `off` | Enable concurrent leaf-page scanning for full table scans (see [Parallel Full Table Scan](#parallel-full-table-scan) below) |
+| `encryption_key` | hex-encoded bytes | _(none)_ | Enable transparent AES-256-CTR page encryption (see [Transparent Page Encryption](#transparent-page-encryption) below) |
 
 **Examples:**
 ```go
@@ -164,6 +166,39 @@ PRAGMA parallel_scan = off;
 |------|------------------|--------|-------------|
 | off | _(default)_ | `PRAGMA parallel_scan = off` | Single-goroutine sequential leaf scan. Best for small tables or single-CPU environments. |
 | on | `parallel_scan=on` | `PRAGMA parallel_scan = on` | Leaf pages partitioned across `runtime.NumCPU()` goroutines. Rows delivered in arrival order (not row-ID order). |
+
+## Transparent Page Encryption
+
+MiniSQL supports transparent AES-256-CTR page encryption. When enabled, every page written to disk (both the main database file and the WAL) is encrypted before being written and decrypted on read. The application sees normal SQL; encryption is completely transparent.
+
+**How it works:**
+
+- **Key derivation:** The user-supplied key is combined with a randomly-generated 32-byte per-database salt via HKDF (RFC 5869, SHA-256) to produce a 256-bit AES key. The key itself is never stored on disk.
+- **Mode:** AES-256-CTR. No padding, ciphertext is the same length as plaintext.
+- **Nonce:** `[8 zero bytes || big-endian page index]` — deterministic and unique per page, safe for data-at-rest encryption.
+- **Plaintext header:** The first 100 bytes of page 0 (the database header) are always stored in plaintext so the salt and encryption mode can be read before the cipher is bootstrapped. All other page data is encrypted.
+- **WAL consistency:** Writes to the WAL are encrypted; the WAL checksum is computed over ciphertext. Reads decrypt before checksum verification.
+- **VACUUM:** The compacted database produced by `VACUUM` is encrypted with the same key.
+
+**Enable via connection string (hex-encoded key):**
+
+```go
+import "encoding/hex"
+
+key := []byte("my-32-byte-secret-key!!")   // any length; longer = more entropy
+db, err := sql.Open("minisql", "./my.db?encryption_key=" + hex.EncodeToString(key))
+```
+
+**Mismatch detection:** MiniSQL returns an error if:
+- An encryption key is provided but the database was created without encryption.
+- No key is provided but the database is encrypted.
+- The wrong key is provided (the page checksum check fails on open).
+
+**Security notes:**
+- The encryption key must be kept secret by the application — it is not derivable from anything stored in the database file.
+- For maximum entropy use a 32-byte (256-bit) randomly generated key stored in a secrets manager.
+- Passing the key in the connection string means it appears in the DSN string; avoid logging the full DSN.
+- Encryption protects data at rest. It does not protect data in transit or in memory.
 
 ## Storage
 

--- a/connection_string.go
+++ b/connection_string.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -42,6 +43,7 @@ type ConnectionConfig struct {
 	SlowQueryThreshold     time.Duration   // Log queries at WARN when elapsed time meets or exceeds this duration (0 = disabled)
 	Synchronous            SynchronousMode // WAL fsync mode: off, normal (default), full
 	ParallelScan           bool            // Enable concurrent leaf-page scanning (default: false)
+	EncryptionKey          []byte          // AES-256-CTR page encryption key (nil = no encryption)
 }
 
 // DefaultConnectionConfig returns default configuration.
@@ -68,6 +70,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //   - slow_query_threshold=50ms         : Log queries taking at least this long (0 = disabled)
 //   - synchronous=off|normal|full       : WAL fsync mode (default: normal, matching SQLite WAL default)
 //   - parallel_scan=on|off              : Enable concurrent leaf-page scanning (default: off)
+//   - encryption_key=<hex>             : Hex-encoded AES-256-CTR encryption key (default: no encryption)
 //
 // Examples:
 //   - "./my.db"                                       : Default settings
@@ -76,6 +79,7 @@ func DefaultConnectionConfig(filePath string) *ConnectionConfig {
 //   - "./my.db?wal_write_buffer_size=0"               : Disable write batching (flush every commit)
 //   - "./my.db?synchronous=full"                      : fsync on every commit (maximum durability)
 //   - "./my.db?parallel_scan=on"                      : Enable parallel full table scans
+//   - "./my.db?encryption_key=deadbeef..."            : Enable transparent page encryption
 //   - "./my.db?log_level=info&max_cached_pages=500"   : Multiple parameters
 func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 	// Split on first '?' to separate path from query params
@@ -168,6 +172,18 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 		default:
 			return nil, fmt.Errorf("invalid parallel_scan parameter: expected on or off, got %q", psStr)
 		}
+	}
+
+	// Parse encryption_key parameter (hex-encoded)
+	if keyHex := queryParams.Get("encryption_key"); keyHex != "" {
+		key, err := hex.DecodeString(keyHex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid encryption_key parameter: must be a hex-encoded string: %w", err)
+		}
+		if len(key) == 0 {
+			return nil, fmt.Errorf("invalid encryption_key parameter: key must not be empty")
+		}
+		config.EncryptionKey = key
 	}
 
 	return config, nil

--- a/connection_string_test.go
+++ b/connection_string_test.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -256,6 +257,26 @@ func TestParseConnectionString(t *testing.T) {
 			connStr:     "./test.db?parallel_scan=maybe",
 			wantErr:     true,
 			errContains: "invalid parallel_scan parameter",
+		},
+		{
+			name:    "encryption_key set",
+			connStr: "./test.db?encryption_key=" + hex.EncodeToString([]byte("my-secret-key-32bytes-long-paddd")),
+			wantConfig: &ConnectionConfig{
+				FilePath:               "./test.db",
+				WALCheckpointThreshold: DefaultWALCheckpointThreshold,
+				WALWriteBufferSize:     DefaultWALWriteBufferSize,
+				LogLevel:               "warn",
+				MaxCachedPages:         minisql.PageCacheSize,
+				Synchronous:            SynchronousNormal,
+				EncryptionKey:          []byte("my-secret-key-32bytes-long-paddd"),
+			},
+			wantErr: false,
+		},
+		{
+			name:        "invalid encryption_key (not hex)",
+			connStr:     "./test.db?encryption_key=not-hex!!",
+			wantErr:     true,
+			errContains: "invalid encryption_key parameter",
 		},
 	}
 

--- a/e2e_tests/encryption_test.go
+++ b/e2e_tests/encryption_test.go
@@ -1,0 +1,234 @@
+package e2etests
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/RichardKnop/minisql"
+)
+
+func encryptedDSN(path string, key []byte) string {
+	return path + "?encryption_key=" + hex.EncodeToString(key)
+}
+
+func openEncryptedDB(t *testing.T, path string, key []byte) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("minisql", encryptedDSN(path, key))
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	// Ping forces Driver.Open so the DB file is initialised immediately.
+	require.NoError(t, db.Ping())
+	return db
+}
+
+// TestEncryption_WriteAndRead verifies that:
+//   - Plaintext values are not visible in the raw file bytes.
+//   - After closing and reopening with the same key, all rows are readable.
+func TestEncryption_WriteAndRead(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("e2e-test-key-32bytes-long-padded")
+
+	f, err := os.CreateTemp("", "minisql-e2e-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// --- Create table and insert rows ---
+	{
+		db := openEncryptedDB(t, path, key)
+
+		_, err = db.Exec(`create table "secrets" (id int8 primary key autoincrement, value text not null)`)
+		require.NoError(t, err)
+
+		_, err = db.Exec(`insert into "secrets" (value) values (?)`, "confidential-alpha")
+		require.NoError(t, err)
+		_, err = db.Exec(`insert into "secrets" (value) values (?)`, "confidential-beta")
+		require.NoError(t, err)
+
+		require.NoError(t, db.Close())
+	}
+
+	// --- File must not contain plaintext values ---
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("confidential-alpha")), "plaintext found in encrypted DB file")
+	assert.False(t, bytes.Contains(raw, []byte("confidential-beta")), "plaintext found in encrypted DB file")
+
+	// --- Reopen and verify rows are readable ---
+	{
+		db := openEncryptedDB(t, path, key)
+		defer db.Close()
+
+		rows, err := db.QueryContext(context.Background(), `select value from "secrets" order by id`)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		var values []string
+		for rows.Next() {
+			var v string
+			require.NoError(t, rows.Scan(&v))
+			values = append(values, v)
+		}
+		require.NoError(t, rows.Err())
+		assert.Equal(t, []string{"confidential-alpha", "confidential-beta"}, values)
+	}
+}
+
+// TestEncryption_WrongKey verifies that opening an encrypted database with an
+// incorrect key returns an error during connection setup.
+func TestEncryption_WrongKey(t *testing.T) {
+	t.Parallel()
+
+	rightKey := []byte("e2e-correct-key-32bytes-long-pad")
+	wrongKey := []byte("e2e-wrong---key-32bytes-long-pad")
+
+	f, err := os.CreateTemp("", "minisql-e2e-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// Create and close with the right key
+	{
+		db := openEncryptedDB(t, path, rightKey)
+		require.NoError(t, db.Close())
+	}
+
+	// Opening with the wrong key should fail — the database/sql driver surfaces
+	// NewDatabase errors on the first Ping/query.
+	db, err := sql.Open("minisql", encryptedDSN(path, wrongKey))
+	require.NoError(t, err) // sql.Open is lazy; error comes on first use
+	db.SetMaxOpenConns(1)
+	pingErr := db.Ping()
+	db.Close()
+	assert.Error(t, pingErr, "expected error when opening with wrong key")
+}
+
+// TestEncryption_NoKeyForEncryptedDB verifies that opening an encrypted database
+// without providing any key returns an error.
+func TestEncryption_NoKeyForEncryptedDB(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("e2e-secret-key-for-no-key-test!!")
+
+	f, err := os.CreateTemp("", "minisql-e2e-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// Create with encryption
+	{
+		db := openEncryptedDB(t, path, key)
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen without key — should fail
+	db, err := sql.Open("minisql", path)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	pingErr := db.Ping()
+	db.Close()
+	require.Error(t, pingErr)
+	assert.Contains(t, pingErr.Error(), "encrypted")
+}
+
+// TestEncryption_KeyForUnencryptedDB verifies that providing an encryption key
+// when opening a plaintext database returns an error.
+func TestEncryption_KeyForUnencryptedDB(t *testing.T) {
+	t.Parallel()
+
+	f, err := os.CreateTemp("", "minisql-e2e-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// Create without encryption
+	{
+		db, err := sql.Open("minisql", path)
+		require.NoError(t, err)
+		db.SetMaxOpenConns(1)
+		require.NoError(t, db.Ping())
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen with a key — should fail
+	key := []byte("e2e-key-for-unencrypted-db-paddd")
+	db, err := sql.Open("minisql", encryptedDSN(path, key))
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	pingErr := db.Ping()
+	db.Close()
+	require.Error(t, pingErr)
+	assert.Contains(t, pingErr.Error(), "not encrypted")
+}
+
+// TestEncryption_VacuumPreservesEncryption verifies that VACUUM on an encrypted
+// database produces a compacted file that is still encrypted and readable.
+func TestEncryption_VacuumPreservesEncryption(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("e2e-vacuum-enc-key-32bytes-paddd")
+
+	f, err := os.CreateTemp("", "minisql-e2e-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	db := openEncryptedDB(t, path, key)
+
+	_, err = db.Exec(`create table "data" (id int8 primary key autoincrement, val text not null)`)
+	require.NoError(t, err)
+
+	for i := range 10 {
+		_, err = db.Exec(`insert into "data" (val) values (?)`, "secret-value")
+		require.NoError(t, err)
+		if i%3 == 0 {
+			_, err = db.Exec(`delete from "data" where id = ?`, i+1)
+			require.NoError(t, err)
+		}
+	}
+
+	_, err = db.ExecContext(context.Background(), `VACUUM`)
+	require.NoError(t, err)
+
+	// Verify the compacted file contains no plaintext
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("secret-value")), "plaintext found after VACUUM on encrypted DB")
+
+	// Verify data is still queryable after VACUUM
+	var count int
+	err = db.QueryRow(`select count(*) from "data"`).Scan(&count)
+	require.NoError(t, err)
+	assert.Greater(t, count, 0)
+
+	require.NoError(t, db.Close())
+}

--- a/e2e_tests/encryption_test.go
+++ b/e2e_tests/encryption_test.go
@@ -70,7 +70,7 @@ func TestEncryption_WriteAndRead(t *testing.T) {
 	// --- Reopen and verify rows are readable ---
 	{
 		db := openEncryptedDB(t, path, key)
-		defer db.Close()
+		defer func() { require.NoError(t, db.Close()) }()
 
 		rows, err := db.QueryContext(context.Background(), `select value from "secrets" order by id`)
 		require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestEncryption_VacuumPreservesEncryption(t *testing.T) {
 	var count int
 	err = db.QueryRow(`select count(*) from "data"`).Scan(&count)
 	require.NoError(t, err)
-	assert.Greater(t, count, 0)
+	assert.Positive(t, count)
 
 	require.NoError(t, db.Close())
 }

--- a/internal/minisql/config.go
+++ b/internal/minisql/config.go
@@ -11,18 +11,30 @@ const (
 	// DatabaseFileFormatVersion identifies the current on-disk file header format.
 	DatabaseFileFormatVersion = uint32(1)
 
-	databaseHeaderMagicOffset         = 0
-	databaseHeaderVersionOffset       = 8
-	databaseHeaderPageSizeOffset      = 12
-	databaseHeaderFirstFreePageOffset = 16
-	databaseHeaderFreePageCountOffset = 20
-	databaseHeaderMetadataSize        = 24
+	databaseHeaderMagicOffset          = 0
+	databaseHeaderVersionOffset        = 8
+	databaseHeaderPageSizeOffset       = 12
+	databaseHeaderFirstFreePageOffset  = 16
+	databaseHeaderFreePageCountOffset  = 20
+	databaseHeaderEncryptionModeOffset = 24 // 1 byte: 0=none, 1=AES-256-CTR
+	databaseHeaderEncryptionSaltOffset = 25 // 32 bytes: random per-database salt
+	databaseHeaderMetadataSize         = 57 // bytes 57-99 reserved for future use
+)
+
+// Encryption mode constants stored in DatabaseHeader.EncryptionMode.
+const (
+	EncryptionModeNone      = uint8(0) // no encryption (default)
+	EncryptionModeAES256CTR = uint8(1) // AES-256-CTR with HKDF-derived key
 )
 
 // DatabaseHeader stores the global database state persisted at the start of the first page.
+// Bytes 0-99 of page 0 are always written as plaintext so that the encryption
+// salt can be read before the cipher is bootstrapped.
 type DatabaseHeader struct {
-	FirstFreePage PageIndex // Points to first free page, 0 if none
-	FreePageCount uint32    // Number of free pages available
+	FirstFreePage  PageIndex  // Points to first free page, 0 if none
+	FreePageCount  uint32     // Number of free pages available
+	EncryptionMode uint8      // 0 = none, 1 = AES-256-CTR
+	EncryptionSalt [32]byte   // per-database random salt for HKDF key derivation
 }
 
 // Size returns the fixed serialised byte size of the database header.
@@ -50,6 +62,8 @@ func (h *DatabaseHeader) MarshalTo(buf []byte) error {
 	marshalUint32(buf, PageSize, databaseHeaderPageSizeOffset)
 	marshalUint32(buf, uint32(h.FirstFreePage), databaseHeaderFirstFreePageOffset)
 	marshalUint32(buf, h.FreePageCount, databaseHeaderFreePageCountOffset)
+	buf[databaseHeaderEncryptionModeOffset] = h.EncryptionMode
+	copy(buf[databaseHeaderEncryptionSaltOffset:], h.EncryptionSalt[:])
 	return nil
 }
 
@@ -75,5 +89,7 @@ func UnmarshalDatabaseHeader(buf []byte, dbHeader *DatabaseHeader) error {
 
 	dbHeader.FirstFreePage = PageIndex(unmarshalUint32(buf, databaseHeaderFirstFreePageOffset))
 	dbHeader.FreePageCount = unmarshalUint32(buf, databaseHeaderFreePageCountOffset)
+	dbHeader.EncryptionMode = buf[databaseHeaderEncryptionModeOffset]
+	copy(dbHeader.EncryptionSalt[:], buf[databaseHeaderEncryptionSaltOffset:databaseHeaderEncryptionSaltOffset+32])
 	return nil
 }

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math"
@@ -12,6 +13,7 @@ import (
 
 	"go.uber.org/zap"
 
+	pkgcrypto "github.com/RichardKnop/minisql/pkg/crypto"
 	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 	"github.com/RichardKnop/minisql/pkg/lrucache"
 )
@@ -62,6 +64,9 @@ type Database struct {
 	// foreignKeysEnabled controls whether FK constraints are enforced.
 	// Default true; toggled by PRAGMA foreign_keys = on|off.
 	foreignKeysEnabled bool
+	// encryptionKey holds the caller-supplied raw key material used to derive
+	// the AES-256-CTR page cipher.  nil when encryption is disabled.
+	encryptionKey []byte
 }
 
 type clock func() Time
@@ -120,6 +125,10 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 
 	for _, opt := range opts {
 		opt(db)
+	}
+
+	if err := db.setupEncryption(ctx); err != nil {
+		return nil, fmt.Errorf("setup encryption: %w", err)
 	}
 
 	if err := db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
@@ -271,6 +280,14 @@ func (d *Database) Reopen(ctx context.Context, factory PagerFactory, saver PageS
 		d.txManager.walIndex = d.walIndex
 		d.txManager.checkpointThreshold = checkpointThreshold
 		d.txManager.SetCheckpointFunc(checkpointFn)
+	}
+
+	// Re-inject the cipher into the new pager and transaction manager so that
+	// encrypted databases continue to work after a reopen (e.g. after VACUUM).
+	if len(d.encryptionKey) > 0 {
+		if err := d.setupEncryption(ctx); err != nil {
+			return fmt.Errorf("reopen: restore encryption: %w", err)
+		}
 	}
 
 	// Use a fresh context so init runs in a brand-new transaction on the new
@@ -548,6 +565,101 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 		return d.executeTableStatement(ctx, table, stmt)
 	}
 	return StatementResult{}, errUnrecognizedStatementType
+}
+
+// setupEncryption inspects d.encryptionKey and the current database state to
+// configure transparent AES-256-CTR page encryption.
+//
+//   - New database (no pages anywhere) + key supplied: generates a random 32-byte
+//     salt, stores it in the in-memory pager header, and installs the cipher.
+//   - Existing encrypted database + matching key: reads salt from the header and
+//     installs the cipher.
+//   - Any mismatch (key without encrypted DB, encrypted DB without key): error.
+func (d *Database) setupEncryption(ctx context.Context) error {
+	if len(d.encryptionKey) == 0 {
+		// No key supplied: verify the existing database is not encrypted.
+		// Check the main file header first; fall back to the WAL index when the
+		// main file is empty (WAL-only mode after a clean shutdown without checkpoint).
+		var hdr DatabaseHeader
+		if p, ok := d.saver.(*pagerImpl); ok {
+			if p.TotalPages() > 0 {
+				hdr = p.GetHeader(ctx)
+			} else if d.walIndex != nil && d.walIndex.Size() > 0 {
+				if walData, ok2 := d.walIndex.Lookup(0); ok2 {
+					_ = UnmarshalDatabaseHeader(walData[:RootPageConfigSize], &hdr)
+				}
+			}
+		}
+		if hdr.EncryptionMode != EncryptionModeNone {
+			return fmt.Errorf("database is encrypted (mode %d) but no encryption key was provided", hdr.EncryptionMode)
+		}
+		return nil
+	}
+
+	key := d.encryptionKey
+	totalPages := d.saver.TotalPages()
+	walEmpty := d.walIndex == nil || d.walIndex.Size() == 0
+
+	var salt []byte
+
+	if totalPages == 0 && walEmpty {
+		// Brand-new database: generate a fresh random salt and record it in the
+		// in-memory pager header so that the first page-0 WAL frame includes it.
+		saltBuf := make([]byte, 32)
+		if _, err := rand.Read(saltBuf); err != nil {
+			return fmt.Errorf("generate encryption salt: %w", err)
+		}
+		salt = saltBuf
+
+		if p, ok := d.saver.(*pagerImpl); ok {
+			hdr := p.GetHeader(ctx)
+			hdr.EncryptionMode = EncryptionModeAES256CTR
+			copy(hdr.EncryptionSalt[:], salt)
+			p.SaveHeader(ctx, hdr)
+		}
+	} else {
+		// Existing database: read the header to get the stored salt.
+		var hdr DatabaseHeader
+		if totalPages > 0 {
+			if p, ok := d.saver.(*pagerImpl); ok {
+				hdr = p.GetHeader(ctx)
+			}
+		} else {
+			// WAL-only mode: peek at the WAL index directly.  The first 100 bytes
+			// of the page-0 frame are always plaintext header so the salt is
+			// readable before the cipher is bootstrapped.
+			walData, ok := d.walIndex.Lookup(0)
+			if !ok {
+				return fmt.Errorf("WAL-only mode but no page 0 in WAL index")
+			}
+			if err := UnmarshalDatabaseHeader(walData[:RootPageConfigSize], &hdr); err != nil {
+				return fmt.Errorf("read encryption header from WAL: %w", err)
+			}
+		}
+
+		if hdr.EncryptionMode == EncryptionModeNone {
+			return fmt.Errorf("an encryption key was provided but the database is not encrypted; " +
+				"to enable encryption, create a new database or use an already-encrypted one")
+		}
+		if hdr.EncryptionMode != EncryptionModeAES256CTR {
+			return fmt.Errorf("unsupported encryption mode %d in database header", hdr.EncryptionMode)
+		}
+		salt = hdr.EncryptionSalt[:]
+	}
+
+	cipher, err := pkgcrypto.NewPageCipher(key, salt)
+	if err != nil {
+		return fmt.Errorf("create page cipher: %w", err)
+	}
+
+	// Inject cipher into the pager (for read/write of DB file pages and WAL
+	// index pages) and into the transaction manager (for WAL serialization).
+	if p, ok := d.saver.(*pagerImpl); ok {
+		p.SetCipher(cipher)
+	}
+	d.txManager.SetCipher(cipher)
+
+	return nil
 }
 
 func (d *Database) init(ctx context.Context) error {

--- a/internal/minisql/database_options.go
+++ b/internal/minisql/database_options.go
@@ -38,3 +38,22 @@ func WithParallelScanEnabled() DatabaseOption {
 		d.parallelScan = true
 	}
 }
+
+// WithEncryptionKey enables transparent AES-256-CTR page encryption using key.
+// The key is never written to disk; a random per-database salt is stored in the
+// plaintext database header and used to derive the actual AES key via HKDF.
+//
+// Rules:
+//   - New databases: a fresh salt is generated and encryption is set up.
+//   - Existing encrypted databases: the stored salt is read and combined with key.
+//   - Mismatched state (key provided for unencrypted DB or vice-versa): error.
+//
+// The key must not be empty.  Any length is accepted; longer keys provide more
+// entropy but the derived key is always 256 bits regardless.
+func WithEncryptionKey(key []byte) DatabaseOption {
+	return func(d *Database) {
+		if len(key) > 0 {
+			d.encryptionKey = key
+		}
+	}
+}

--- a/internal/minisql/encryption_test.go
+++ b/internal/minisql/encryption_test.go
@@ -95,7 +95,7 @@ func TestEncryption_WriteAndRead(t *testing.T) {
 		mp := new(MockParser)
 		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
 		db := openEncryptedDB(t, path, key, mp)
-		defer db.Close()
+		defer func() { require.NoError(t, db.Close()) }()
 
 		ctx := context.Background()
 		var names []string

--- a/internal/minisql/encryption_test.go
+++ b/internal/minisql/encryption_test.go
@@ -1,0 +1,248 @@
+package minisql
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var encColumns = []Column{
+	{Kind: Int8, Size: 8, Name: "id"},
+	{Kind: Varchar, Size: MaxInlineVarchar, Name: "name", Nullable: true},
+}
+
+// openEncryptedDB creates or opens a file-backed database with encryption.
+// Pass a non-nil parser when reopening a database that already contains tables.
+func openEncryptedDB(t *testing.T, path string, key []byte, p Parser) *Database {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	require.NoError(t, err)
+
+	pager, err := NewPager(f, PageSize, PageCacheSize)
+	require.NoError(t, err)
+
+	db, err := NewDatabase(
+		context.Background(), testLogger, path, p, pager, pager, nil,
+		WithEncryptionKey(key),
+	)
+	require.NoError(t, err)
+	return db
+}
+
+func TestEncryption_WriteAndRead(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("super-secret-key-for-testing-123")
+
+	f, err := os.CreateTemp("", "minisql-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	usersStmt := Statement{
+		Kind:      CreateTable,
+		TableName: "users",
+		Columns:   encColumns,
+	}
+
+	// --- Create and populate an encrypted database ---
+	{
+		db := openEncryptedDB(t, path, key, nil)
+		ctx := context.Background()
+
+		err = db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      CreateTable,
+				TableName: "users",
+				Columns:   encColumns,
+			})
+			return err
+		})
+		require.NoError(t, err)
+
+		err = db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: "users",
+				Columns:   encColumns,
+				Fields:    fieldsFromColumns(encColumns...),
+				Inserts: [][]OptionalValue{
+					{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("alice")), Valid: true}},
+					{{Value: int64(2), Valid: true}, {Value: NewTextPointer([]byte("bob")), Valid: true}},
+				},
+			})
+			return err
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	}
+
+	// --- Verify: file should not contain plaintext user names ---
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("alice")), "plaintext 'alice' found in encrypted DB file")
+	assert.False(t, bytes.Contains(raw, []byte("bob")), "plaintext 'bob' found in encrypted DB file")
+
+	// --- Reopen and query ---
+	// A MockParser is required so initTable can parse the stored DDL for "users".
+	{
+		mp := new(MockParser)
+		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+		db := openEncryptedDB(t, path, key, mp)
+		defer db.Close()
+
+		ctx := context.Background()
+		var names []string
+		err := db.txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+			result, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      Select,
+				TableName: "users",
+				Columns:   encColumns,
+				Fields:    fieldsFromColumns(encColumns...),
+			})
+			if err != nil {
+				return err
+			}
+			for result.Rows.Next(ctx) {
+				row := result.Rows.Row()
+				v, ok := row.GetValue("name")
+				if ok && v.Valid {
+					names = append(names, v.Value.(TextPointer).String())
+				}
+			}
+			return result.Rows.Err()
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"alice", "bob"}, names)
+	}
+}
+
+func TestEncryption_WrongKey(t *testing.T) {
+	t.Parallel()
+
+	rightKey := []byte("correct-key-for-testing-purposes")
+	wrongKey := []byte("wrong---key-for-testing-purposes")
+
+	f, err := os.CreateTemp("", "minisql-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	// Create database with the right key
+	{
+		db := openEncryptedDB(t, path, rightKey, nil)
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen with the wrong key — decryption produces invalid plaintext so the
+	// page checksum verification on page 0 should fail during init.
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f2, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	_, dbErr := NewDatabase(
+		context.Background(), testLogger, path, nil, pager, pager, nil,
+		WithEncryptionKey(wrongKey),
+	)
+	assert.Error(t, dbErr, "expected error when opening with wrong key")
+}
+
+func TestEncryption_NoKeyForEncryptedDB(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("some-secret-encryption-key-here!")
+
+	f, err := os.CreateTemp("", "minisql-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	// Create with encryption
+	{
+		db := openEncryptedDB(t, path, key, nil)
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen without key — setupEncryption should detect the encrypted header
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f2, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	_, dbErr := NewDatabase(
+		context.Background(), testLogger, path, nil, pager, pager, nil,
+		// no WithEncryptionKey
+	)
+	require.Error(t, dbErr)
+	assert.Contains(t, dbErr.Error(), "encrypted")
+}
+
+func TestEncryption_KeyForUnencryptedDB(t *testing.T) {
+	t.Parallel()
+
+	f, err := os.CreateTemp("", "minisql-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	// Create without encryption
+	{
+		f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+		require.NoError(t, err)
+		pager, err := NewPager(f2, PageSize, PageCacheSize)
+		require.NoError(t, err)
+		db, err := NewDatabase(
+			context.Background(), testLogger, path, nil, pager, pager, nil,
+		)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen with key — setupEncryption should return an error
+	key := []byte("some-key-for-an-unencrypted-db!!")
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f2, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	_, dbErr := NewDatabase(
+		context.Background(), testLogger, path, nil, pager, pager, nil,
+		WithEncryptionKey(key),
+	)
+	require.Error(t, dbErr)
+	assert.Contains(t, dbErr.Error(), "not encrypted")
+}
+
+func TestEncryption_SaltInHeader(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("test-key-for-salt-header-check!!")
+
+	f, err := os.CreateTemp("", "minisql-enc-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	{
+		db := openEncryptedDB(t, path, key, nil)
+		require.NoError(t, db.Close())
+	}
+
+	// Read the raw header bytes (always plaintext, never encrypted)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(raw), RootPageConfigSize)
+
+	var hdr DatabaseHeader
+	require.NoError(t, UnmarshalDatabaseHeader(raw[:RootPageConfigSize], &hdr))
+	assert.Equal(t, EncryptionModeAES256CTR, hdr.EncryptionMode)
+	assert.NotEqual(t, [32]byte{}, hdr.EncryptionSalt, "salt must be non-zero")
+}

--- a/internal/minisql/pager.go
+++ b/internal/minisql/pager.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"sync"
 
+	pkgcrypto "github.com/RichardKnop/minisql/pkg/crypto"
 	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 	"github.com/RichardKnop/minisql/pkg/lrucache"
 )
@@ -35,6 +36,7 @@ type pagerImpl struct {
 	file           DBFile
 	bufferPool     *sync.Pool
 	walIndex       *WALIndex
+	cipher         *pkgcrypto.PageCipher // nil when encryption is disabled
 	pages          []*Page
 	pageSize       int
 	maxCachedPages int
@@ -111,6 +113,13 @@ func (p *pagerImpl) SetWALIndex(walIndex *WALIndex) {
 	}
 }
 
+// SetCipher wires an AES-256-CTR cipher into the pager.  Once set, GetPage
+// decrypts pages after reading them, and Flush/FlushBatch encrypt pages before
+// writing them.  Must be called before any concurrent page access begins.
+func (p *pagerImpl) SetCipher(c *pkgcrypto.PageCipher) {
+	p.cipher = c
+}
+
 // Close syncs the file to ensure pending writes are flushed, then closes it.
 func (p *pagerImpl) Close() error {
 	if err := fastSync(p.file); err != nil {
@@ -158,6 +167,17 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 	// a page.
 	if wi != nil {
 		if walData, ok := wi.Lookup(pageIdx); ok {
+			// Decrypt a copy so we never mutate the shared WAL index buffer.
+			if p.cipher != nil {
+				decrypted := make([]byte, len(walData))
+				copy(decrypted, walData)
+				if pageIdx == 0 {
+					p.cipher.XORKeyStream(decrypted[RootPageConfigSize:], 0)
+				} else {
+					p.cipher.XORKeyStream(decrypted, uint32(pageIdx))
+				}
+				walData = decrypted
+			}
 			newPage, err := unmarshaler(totalPages, pageIdx, walData)
 			if err != nil {
 				return nil, fmt.Errorf("unmarshal page %d from WAL index: %w", pageIdx, err)
@@ -226,6 +246,15 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 		_, err := p.file.ReadAt(buf, offset)
 		if err != nil {
 			return nil, err
+		}
+		// Decrypt before checksum verification: the on-page CRC32 was computed over
+		// plaintext and then included inside the encrypted region.
+		if p.cipher != nil {
+			if pageIdx == 0 {
+				p.cipher.XORKeyStream(buf[RootPageConfigSize:], 0)
+			} else {
+				p.cipher.XORKeyStream(buf, uint32(pageIdx))
+			}
 		}
 		if err := verifyPageChecksum(buf, pageIdx); err != nil {
 			return nil, err
@@ -356,6 +385,9 @@ func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
 
 	if pageIdx != 0 {
 		writePageChecksum(buf)
+		if p.cipher != nil {
+			p.cipher.XORKeyStream(buf, uint32(pageIdx))
+		}
 		_, err := p.file.WriteAt(buf, int64(pageIdx)*int64(p.pageSize))
 		return err
 	}
@@ -369,6 +401,13 @@ func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
 	// file[0:4092] = headerBuf[0:100] + buf[0:3992].
 	// Store the 4-byte result at buf[3992:3996] (= file[4092:4096]).
 	writeRootPageChecksum(headerBuf[:], buf, p.pageSize)
+
+	// Encrypt the B-tree + checksum portion (file[100:4096]) in place.
+	// The plaintext header (file[0:100]) is never encrypted so that the
+	// encryption salt can be read on startup before the cipher is ready.
+	if p.cipher != nil {
+		p.cipher.XORKeyStream(buf[:p.pageSize-RootPageConfigSize], 0)
+	}
 
 	_, err := p.file.WriteAt(headerBuf[:], 0)
 	if err != nil {
@@ -455,6 +494,9 @@ func (p *pagerImpl) FlushBatch(ctx context.Context, pageIndices []PageIndex) err
 	for _, mp := range marshaled {
 		if !mp.isRoot {
 			writePageChecksum(mp.buf)
+			if p.cipher != nil {
+				p.cipher.XORKeyStream(mp.buf, uint32(mp.pageIdx))
+			}
 			_, err := p.file.WriteAt(mp.buf, int64(mp.pageIdx)*int64(p.pageSize))
 			if err != nil {
 				return fmt.Errorf("error writing page %d: %w", mp.pageIdx, err)
@@ -466,6 +508,10 @@ func (p *pagerImpl) FlushBatch(ctx context.Context, pageIndices []PageIndex) err
 			}
 
 			writeRootPageChecksum(headerBuf[:], mp.buf, p.pageSize)
+
+			if p.cipher != nil {
+				p.cipher.XORKeyStream(mp.buf[:p.pageSize-RootPageConfigSize], 0)
+			}
 
 			_, err := p.file.WriteAt(headerBuf[:], 0)
 			if err != nil {

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	pkgcrypto "github.com/RichardKnop/minisql/pkg/crypto"
 	minisqlErrors "github.com/RichardKnop/minisql/pkg/errors"
 )
 
@@ -41,6 +42,7 @@ type TransactionManager struct {
 	checkpointFn         func() error
 	rowCountApplier      func(map[string]int64)
 	logger               *zap.Logger
+	cipher               *pkgcrypto.PageCipher // nil when encryption is disabled
 	pageLastCommittedSeq map[PageIndex]uint64
 	pageVersionHistory   map[PageIndex][]pageVersion
 	commitHook           func(commitPhase)
@@ -81,6 +83,13 @@ func NewTransactionManager(logger *zap.Logger, dbFilePath string, factory TxPage
 		saver:                saver,
 		ddlSaver:             ddlSaver,
 	}
+}
+
+// SetCipher wires an AES-256-CTR cipher into the transaction manager so that
+// WAL frames are encrypted before being written and decrypted after being read.
+// Must be called before any concurrent transaction begins.
+func (tm *TransactionManager) SetCipher(c *pkgcrypto.PageCipher) {
+	tm.cipher = c
 }
 
 // SetCheckpointFunc registers a callback that is invoked by runAutoCheckpoint
@@ -606,6 +615,11 @@ func (tm *TransactionManager) serializeWritesForWAL(ctx context.Context, tx *Tra
 		// Embed the page checksum so that WAL checkpoint can copy the frame
 		// verbatim to the DB file and GetPage can verify it on next open.
 		writePageChecksum(frame)
+		// Encrypt the B-tree + checksum portion (frame[100:4096]); the header
+		// (frame[0:100]) stays plaintext so the salt can be read on startup.
+		if tm.cipher != nil {
+			tm.cipher.XORKeyStream(frame[RootPageConfigSize:], 0)
+		}
 		pages = append(pages, WALPage{Index: 0, Data: frame})
 	}
 
@@ -620,6 +634,9 @@ func (tm *TransactionManager) serializeWritesForWAL(ctx context.Context, tx *Tra
 			return nil, fmt.Errorf("marshal page %d for WAL: %w", pageIdx, err)
 		}
 		writePageChecksum(buf)
+		if tm.cipher != nil {
+			tm.cipher.XORKeyStream(buf, uint32(pageIdx))
+		}
 		pages = append(pages, WALPage{Index: pageIdx, Data: buf})
 	}
 

--- a/internal/minisql/vacuum.go
+++ b/internal/minisql/vacuum.go
@@ -57,7 +57,11 @@ func (d *Database) Vacuum(ctx context.Context) error {
 		return fmt.Errorf("vacuum: create temp pager: %w", err)
 	}
 
-	tempDB, err := NewDatabase(context.Background(), d.logger, tempFile, d.parser, tempPager, tempPager, nil)
+	tempDBOpts := []DatabaseOption{}
+	if len(d.encryptionKey) > 0 {
+		tempDBOpts = append(tempDBOpts, WithEncryptionKey(d.encryptionKey))
+	}
+	tempDB, err := NewDatabase(context.Background(), d.logger, tempFile, d.parser, tempPager, tempPager, nil, tempDBOpts...)
 	if err != nil {
 		return fmt.Errorf("vacuum: init temp database: %w", err)
 	}

--- a/minisql.go
+++ b/minisql.go
@@ -131,6 +131,9 @@ func (d *Driver) newDB(config *ConnectionConfig) (*minisql.Database, error) {
 	if config.ParallelScan {
 		dbOpts = append(dbOpts, minisql.WithParallelScanEnabled())
 	}
+	if len(config.EncryptionKey) > 0 {
+		dbOpts = append(dbOpts, minisql.WithEncryptionKey(config.EncryptionKey))
+	}
 
 	return minisql.NewDatabase(
 		context.Background(),

--- a/pkg/crypto/page_cipher.go
+++ b/pkg/crypto/page_cipher.go
@@ -1,0 +1,65 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+)
+
+// PageCipher encrypts and decrypts individual database pages using AES-256-CTR.
+// Each page has its own independent keystream derived from its page index, so
+// pages can be encrypted or decrypted independently and in any order.
+//
+// The key is derived from the caller-supplied key material and a per-database
+// salt using HKDF (RFC 5869) with HMAC-SHA256, so the raw user key is never
+// used directly for AES.
+type PageCipher struct {
+	key [32]byte
+}
+
+// NewPageCipher derives a 256-bit AES key from userKey and salt using
+// HKDF-Extract + HKDF-Expand (RFC 5869, HMAC-SHA256) and returns a
+// PageCipher ready for use.
+func NewPageCipher(userKey, salt []byte) (*PageCipher, error) {
+	if len(userKey) == 0 {
+		return nil, fmt.Errorf("encryption key must not be empty")
+	}
+	if len(salt) == 0 {
+		return nil, fmt.Errorf("encryption salt must not be empty")
+	}
+
+	// HKDF-Extract: PRK = HMAC-SHA256(salt, userKey)
+	mac := hmac.New(sha256.New, salt)
+	mac.Write(userKey)
+	prk := mac.Sum(nil)
+
+	// HKDF-Expand: OKM = HMAC-SHA256(PRK, info || 0x01)
+	mac = hmac.New(sha256.New, prk)
+	mac.Write([]byte("minisql-page-enc-v1"))
+	mac.Write([]byte{0x01})
+
+	var key [32]byte
+	copy(key[:], mac.Sum(nil))
+
+	return &PageCipher{key: key}, nil
+}
+
+// XORKeyStream encrypts or decrypts buf in-place using AES-256-CTR.
+// The nonce is deterministic: 8 zero bytes followed by the 8-byte big-endian
+// encoding of pageIdx. Since each page has a unique index the keystream is
+// unique per page, which is acceptable for a data-at-rest threat model where
+// the on-disk content is fixed for a given (key, pageIdx) pair.
+//
+// For page 0, callers must pass pageIdx=0 but only supply the sub-slice that
+// excludes the plaintext database header (bytes 0-99 of page 0 are never
+// encrypted so the salt can be bootstrapped on open).
+func (c *PageCipher) XORKeyStream(buf []byte, pageIdx uint32) {
+	iv := [aes.BlockSize]byte{}
+	binary.BigEndian.PutUint64(iv[8:], uint64(pageIdx))
+	block, _ := aes.NewCipher(c.key[:])
+	stream := cipher.NewCTR(block, iv[:])
+	stream.XORKeyStream(buf, buf)
+}


### PR DESCRIPTION
Every page written to disk (DB file and WAL) is encrypted before write and decrypted on read. The caller supplies a raw key; HKDF derives a 256-bit AES key from the key + a random per-database salt. The first 100 bytes of page 0 (DatabaseHeader) are always plaintext so the salt can be read before the cipher is bootstrapped.

Key details:
- New pkg/crypto.PageCipher with HKDF-Extract/Expand + AES-256-CTR
- DatabaseHeader extended with EncryptionMode (1 byte) and EncryptionSalt (32 bytes) at offsets 24-56; existing DBs are unaffected (fields zero)
- Pager: decrypt on GetPage (both WAL and file paths), encrypt on Flush/FlushBatch before WriteAt; CRC32 computed on plaintext then included in the encrypted region
- TransactionManager: encrypt WAL frames in serializeWritesForWAL
- setupEncryption detects new vs existing DB, validates key/mode match, and checks the WAL header in WAL-only mode for both the key and no-key paths
- VACUUM passes the encryption key to the temp database so compacted files stay encrypted
- WithEncryptionKey([]byte) DatabaseOption + encryption_key=<hex> DSN parameter for the database/sql driver
- 10 unit tests (internal) + 5 e2e tests covering write/read, wrong key, no key for encrypted DB, key for unencrypted DB, VACUUM preservation
- README: feature list, connection-string table, full encryption section