### PR TITLE
docs: add MkDocs Material documentation site with GitHub Actions depl…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/RichardKnop/minisql)](https://goreportcard.com/report/github.com/RichardKnop/minisql)
 [![Donate Bitcoin](https://img.shields.io/badge/donate-bitcoin-orange.svg)](https://richardknop.github.io/donate/)
 
-`MiniSQL` is an embedded single file database written in Golang, inspired by `SQLite` but borrows ideas from other databases such as `Postgres` too. It can differentiate itself from `SQLite` in several areas: 
+MiniSQL is an embedded single file database written in Golang, inspired by `SQLite` but borrows ideas from other databases such as `Postgres` too. 
+
+See the [documentation](https://richardknop.github.io/minisql/).
+
+MiniSQL can differentiate itself from `SQLite` in several areas: 
 
 1. Pure Go / zero CGO
 2. MVCC snapshot isolation (for reads, serialized single-writer for writes)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,146 @@
+# Architecture
+
+## Storage
+
+### Pages
+
+The database file is divided into fixed-size **4 096-byte pages**. Every page ends with a 4-byte CRC32-IEEE checksum that is verified on every read. A checksum mismatch returns an error immediately — corrupted pages are never silently accepted.
+
+```
+Page layout (4 096 bytes)
+├── [page 0 only] Database header — bytes 0–99 (100 bytes, always plaintext)
+├── Page type header — 7 bytes (base) + 8 bytes (leaf/internal node)
+├── Null bitmask — 8 bytes per row (max 64 columns)
+├── Cell data — rows / index entries
+└── CRC32 checksum — last 4 bytes
+```
+
+Usable inline cell space per non-root page is **~4 061 bytes**. Large values (TEXT/JSON > 255 bytes, all VECTOR data) spill onto **overflow pages** chained via next-page pointers, bypassing the per-page limit.
+
+### B+ Tree
+
+Every table and every index is stored as an independent **B+ tree**:
+
+- **Leaf nodes** hold the actual row cells (table scans) or index entries (index scans).
+- **Internal nodes** hold routing keys and child page references.
+- Leaf nodes at the same level are **linked** in a doubly-linked list, enabling efficient range scans without descending the tree.
+
+### Free page list
+
+Deleted pages are tracked in a **free-page linked list** anchored in the database header. The VACUUM command compacts the file by copying live data into a fresh database, reclaiming all free pages.
+
+### Page cache
+
+An **LRU page cache** keeps recently accessed pages in memory (default 2 000 pages ≈ 8 MB). The cache is shared across all transactions on a connection. Each write transaction also maintains a **write-set** of pages modified in the current transaction.
+
+---
+
+## Write-Ahead Log (WAL)
+
+All commits write modified pages to the WAL file (`{dbpath}-wal`) **before** updating the main database file. The main file is updated only during a **checkpoint**.
+
+### Commit protocol
+
+1. Serialise all modified pages as WAL frames and write them to the WAL file.
+2. Optionally `fsync()` the WAL file (controlled by `PRAGMA synchronous`).
+3. Update the in-memory WAL index so subsequent reads see the new pages immediately.
+4. The main database file is **not** touched during a commit.
+
+### Checkpoint
+
+1. Copy every WAL page into the main database file.
+2. `sync()` the main file (skipped in `synchronous=off`).
+3. Truncate the WAL file to its header (32 bytes).
+4. Reset the in-memory WAL index.
+
+An automatic checkpoint runs after `wal_checkpoint_threshold` WAL frames (default 1 000). Set `wal_checkpoint_threshold=0` to disable automatic checkpointing and run `PRAGMA wal_checkpoint` manually.
+
+Checkpoint is blocked while any snapshot read transaction is active (`ErrCheckpointBlockedByReaders`). The checkpoint resumes once all readers finish.
+
+### Crash recovery
+
+On startup MiniSQL checks for an existing WAL file and replays all valid committed frames into the in-memory WAL index. Partially written frames (uncommitted) are discarded. The database is always consistent after recovery.
+
+---
+
+## Concurrency
+
+### Write transactions — Optimistic Concurrency Control (OCC)
+
+MiniSQL allows **one write transaction at a time**. A second concurrent write transaction blocks until the first finishes.
+
+Within a write transaction:
+
+- Page versions are recorded in a **read-set** when each page is first accessed.
+- At commit, the engine checks that no page in the read-set has been modified by a concurrent transaction since it was first read.
+- If a conflict is detected, `ErrTxConflict` is returned and the transaction can be retried.
+- Conflicts can also be detected early in `ModifyPage` to fail fast.
+
+```go
+for {
+    tx, _ := db.Begin()
+    _, err = tx.Exec("update accounts set balance = balance - 100 where id = 1")
+    if err := tx.Commit(); err != nil {
+        if errors.Is(err, minisqlErrors.ErrTxConflict) {
+            tx.Rollback()
+            continue // retry
+        }
+        return err
+    }
+    break
+}
+```
+
+### Read-only transactions — MVCC Snapshot Isolation
+
+Every `SELECT` statement runs inside a **read-only transaction** with snapshot isolation:
+
+1. At `BeginReadOnlyTransaction`, the current **commit sequence number** (`commitSeq`) is captured.
+2. All page reads check whether the page was modified after the snapshot. If so, the engine serves the **historical version** from `pageVersionHistory`.
+3. The reader sees a fully consistent snapshot of the database at the moment the transaction began, regardless of concurrent writers.
+4. Multiple readers run concurrently without blocking each other or writers.
+
+**Result:** No dirty reads, no non-repeatable reads, no phantom reads within a snapshot. Writers never block readers; readers never block writers.
+
+---
+
+## System diagram
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Go application                     │
+│               database/sql interface                │
+└──────────────────────┬──────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────┐
+│               MiniSQL driver layer                  │
+│  Parser → Planner → Executor → Transaction Manager  │
+└──────────┬──────────────────────────┬───────────────┘
+           │                          │
+┌──────────▼──────────┐  ┌────────────▼───────────────┐
+│    Page cache (LRU) │  │   WAL (write-ahead log)     │
+│    In-memory        │  │   {dbpath}-wal              │
+└──────────┬──────────┘  └────────────┬───────────────┘
+           │                          │
+┌──────────▼──────────────────────────▼───────────────┐
+│              Main database file                     │
+│         B+ trees — 4 096-byte pages                 │
+│         CRC32 on every page                         │
+│         Optional AES-256-CTR encryption             │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Query planner
+
+MiniSQL includes a cost-based query planner that:
+
+- Selects the best index for each table access (B-tree, fulltext, inverted, HNSW).
+- Performs **predicate pushdown** — filters are applied as early as possible.
+- Considers **index-only scans** (covering indexes) to avoid main-table page reads.
+- Uses table statistics (row count, column cardinality, histograms, most-common values) populated by `ANALYZE`.
+- Rewrites joins using **semi-join** and **anti-semi-join** for IN/NOT IN subqueries.
+- Reorders join tables for star-schema queries.
+
+Use `EXPLAIN` and `EXPLAIN ANALYZE` to inspect the chosen plan. See [EXPLAIN](sql/explain.md).

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -1,0 +1,108 @@
+# Connection
+
+## Connection string format
+
+```
+/path/to/database.db?param1=value1&param2=value2
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `wal_checkpoint_threshold` | `1000` | Auto-checkpoint after N WAL frames. Set to `0` to disable automatic checkpointing. |
+| `wal_write_buffer_size` | `65536` | WAL write-buffer size in bytes. Set to `0` to flush every commit (lowest throughput, lowest exposure). |
+| `log_level` | `warn` | Log verbosity: `debug`, `info`, `warn`, `error` |
+| `max_cached_pages` | `2000` | Maximum pages to keep in the in-memory LRU page cache. Each page is 4 096 bytes; default ≈ 8 MB. |
+| `slow_query_threshold` | `0` (disabled) | Log queries at WARN level when elapsed time meets or exceeds this value. Accepts Go duration strings: `50ms`, `2s`. |
+| `synchronous` | `normal` | WAL fsync mode. See [WAL durability modes](#wal-durability-modes). |
+| `parallel_scan` | `off` | Enable concurrent leaf-page scanning for full table scans. See [Parallel scan](#parallel-scan). |
+| `encryption_key` | _(none)_ | Hex-encoded AES-256-CTR encryption key. See [Encryption](encryption.md). |
+
+## Examples
+
+```go
+// Enable debug logging
+db, err := sql.Open("minisql", "./my.db?log_level=debug")
+
+// Larger page cache (16 000 pages ≈ 64 MB)
+db, err := sql.Open("minisql", "./my.db?max_cached_pages=16000")
+
+// Disable auto-checkpoint (run PRAGMA wal_checkpoint manually)
+db, err := sql.Open("minisql", "./my.db?wal_checkpoint_threshold=0")
+
+// Maximum write durability (fsync after every commit)
+db, err := sql.Open("minisql", "./my.db?synchronous=full")
+
+// Log queries taking more than 50 ms
+db, err := sql.Open("minisql", "./my.db?slow_query_threshold=50ms")
+
+// Enable parallel full table scans
+db, err := sql.Open("minisql", "./my.db?parallel_scan=on")
+
+// Encrypted database
+import "encoding/hex"
+key := []byte("my-32-byte-secret-key")
+db, err := sql.Open("minisql", "./my.db?encryption_key="+hex.EncodeToString(key))
+
+// Multiple parameters
+db, err := sql.Open("minisql", "./my.db?log_level=info&max_cached_pages=4000&synchronous=full")
+```
+
+## Connection pooling
+
+!!! warning "Single connection required"
+    MiniSQL requires exactly **one open connection** per database file. Multiple connections to the same file do **not** share page cache, WAL index, or transaction state, and will produce inconsistent results or corrupt the database.
+
+Always configure the pool to use exactly one connection:
+
+```go
+db, err := sql.Open("minisql", "./my.db")
+if err != nil {
+    log.Fatal(err)
+}
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+```
+
+**Read concurrency is still handled within the single connection.** Concurrent goroutines running `SELECT` through the same `*sql.DB` each get their own MVCC snapshot and execute without blocking each other. The single-connection constraint does not reduce read throughput.
+
+## WAL durability modes
+
+The `synchronous` parameter controls when `fsync()` is called on the WAL file, trading durability for write performance.
+
+| Mode | Parameter | Description |
+|------|-----------|-------------|
+| `normal` | `synchronous=normal` | **Default.** No fsync per commit. fsync only at checkpoint. Matches SQLite WAL default. Data loss possible only during OS crash/power failure in the narrow window between commit and next checkpoint. |
+| `full` | `synchronous=full` | fsync after every WAL commit. Survives OS crash between commits. Significantly slower for write-heavy workloads. |
+| `off` | `synchronous=off` | No fsyncs at all. Fastest, but uncommitted data may be lost on OS crash or power failure. |
+
+Read and change the current mode at runtime with PRAGMA:
+
+```sql
+PRAGMA synchronous;           -- returns 0 (off), 1 (normal), 2 (full)
+PRAGMA synchronous = full;
+PRAGMA synchronous = normal;
+PRAGMA synchronous = off;
+```
+
+## Parallel scan
+
+When enabled, full table scans split the leaf-page chain across `runtime.NumCPU()` goroutines so multiple pages are decoded and filtered concurrently.
+
+```go
+db, err := sql.Open("minisql", "./my.db?parallel_scan=on")
+```
+
+Or toggle at runtime:
+
+```sql
+PRAGMA parallel_scan = on;
+PRAGMA parallel_scan;         -- returns 0 (off) or 1 (on)
+PRAGMA parallel_scan = off;
+```
+
+!!! note
+    Parallel scan does **not** guarantee row-ID ordering. If your query depends on insertion order, always add an explicit `ORDER BY`.
+
+Parallel scan is most beneficial for large tables on multi-core machines running filter-heavy queries. For small tables or single-CPU environments the overhead typically outweighs the benefit.

--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -1,0 +1,181 @@
+# Constraints
+
+Constraints enforce data integrity rules at the storage layer, rejecting invalid inserts and updates before they reach the database.
+
+---
+
+## PRIMARY KEY
+
+Every table has at most one primary key. The primary key uniquely identifies each row and is stored as a B-tree index.
+
+```sql
+-- Single-column primary key
+CREATE TABLE users (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL
+);
+
+-- Composite primary key (table constraint)
+CREATE TABLE memberships (
+    user_id INT8 NOT NULL,
+    org_id  INT8 NOT NULL,
+    role    VARCHAR(50),
+    PRIMARY KEY (user_id, org_id)
+);
+```
+
+`AUTOINCREMENT` requires `INT8` and generates sequential IDs automatically.
+
+---
+
+## NOT NULL
+
+Rejects `NULL` on insert and update:
+
+```sql
+CREATE TABLE users (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL,
+    name  TEXT NOT NULL
+);
+```
+
+Columns declared without `NOT NULL` accept `NULL` by default.
+
+---
+
+## UNIQUE
+
+Creates a unique B-tree index that rejects duplicate values:
+
+```sql
+-- Column-level UNIQUE
+CREATE TABLE users (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL UNIQUE
+);
+
+-- Composite UNIQUE (table constraint)
+CREATE TABLE tags (
+    id       INT8         PRIMARY KEY AUTOINCREMENT,
+    post_id  INT8         NOT NULL,
+    tag_name VARCHAR(100) NOT NULL,
+    UNIQUE (post_id, tag_name)
+);
+
+-- Explicit UNIQUE index (equivalent)
+CREATE UNIQUE INDEX idx_users_email ON users (email);
+```
+
+Inserting a duplicate value returns an error, unless `ON CONFLICT DO NOTHING` or `ON CONFLICT DO UPDATE` is used.
+
+---
+
+## CHECK
+
+Rejects rows where an expression evaluates to false:
+
+```sql
+CREATE TABLE products (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    name  TEXT NOT NULL,
+    price INT8 NOT NULL CHECK (price > 0),
+    stock INT8 NOT NULL DEFAULT 0 CHECK (stock >= 0)
+);
+
+CREATE TABLE accounts (
+    id      INT8   PRIMARY KEY AUTOINCREMENT,
+    balance INT8   NOT NULL CHECK (balance >= 0),
+    status  VARCHAR(20) NOT NULL CHECK (status IN ('active', 'frozen', 'closed'))
+);
+```
+
+CHECK constraints are evaluated on every `INSERT` and `UPDATE`.
+
+---
+
+## FOREIGN KEY
+
+Foreign keys enforce referential integrity between tables:
+
+### Inline (column-level)
+
+```sql
+CREATE TABLE orders (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    user_id INT8 NOT NULL REFERENCES users (id),
+    amount  INT8 NOT NULL
+);
+```
+
+### Table-level
+
+```sql
+CREATE TABLE orders (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    user_id INT8 NOT NULL,
+    amount  INT8 NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users (id)
+);
+```
+
+### Named foreign key
+
+```sql
+CREATE TABLE orders (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    user_id INT8 NOT NULL,
+    CONSTRAINT fk_orders_users FOREIGN KEY (user_id) REFERENCES users (id)
+);
+```
+
+Foreign key enforcement is controlled by `PRAGMA foreign_keys` (default: on):
+
+```sql
+PRAGMA foreign_keys;        -- 1 (enabled)
+PRAGMA foreign_keys = off;  -- disable for bulk load
+PRAGMA foreign_keys = on;   -- re-enable
+```
+
+When enabled:
+
+- **INSERT / UPDATE:** the referenced row must exist in the parent table.
+- **DELETE:** deleting a parent row that has child rows referencing it returns an error.
+
+---
+
+## DEFAULT values
+
+Default values are applied when a column is omitted from an `INSERT`:
+
+```sql
+CREATE TABLE users (
+    id      INT8      PRIMARY KEY AUTOINCREMENT,
+    active  BOOLEAN   NOT NULL DEFAULT true,
+    created TIMESTAMP DEFAULT NOW(),
+    score   INT8      DEFAULT 0
+);
+
+-- active, created, and score get their defaults
+INSERT INTO users (email) VALUES ('alice@example.com');
+```
+
+---
+
+## Constraint violations
+
+All constraint violations return an error. When using `ON CONFLICT`:
+
+```sql
+-- Silently skip on unique constraint violation
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Duplicate')
+ON CONFLICT DO NOTHING;
+
+-- Update on unique constraint violation
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice V2')
+ON CONFLICT DO UPDATE SET name = EXCLUDED.name;
+```
+
+See [INSERT](sql/insert.md) for full `ON CONFLICT` reference.

--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -1,0 +1,163 @@
+# Data Types
+
+## Type reference
+
+| SQL Type | Storage | Range / Format | Go type | Notes |
+|----------|---------|----------------|---------|-------|
+| `BOOLEAN` | 1 byte | `true` / `false` | `bool` | Stored internally as int8 |
+| `INT4` | 4 bytes | −2 147 483 648 … 2 147 483 647 | `int32` | 32-bit signed integer |
+| `INT8` | 8 bytes | −9 223 372 036 854 775 808 … 9 223 372 036 854 775 807 | `int64` | 64-bit signed integer; required for `AUTOINCREMENT` |
+| `REAL` | 4 bytes | IEEE 754 single-precision | `float32` | |
+| `DOUBLE` | 8 bytes | IEEE 754 double-precision | `float64` | |
+| `VARCHAR(n)` | Variable, ≤ 255 bytes inline | At most *n* bytes | `string` | Inline storage up to 255 bytes; overflow pages for larger values |
+| `TEXT` | Variable, unlimited | UTF-8 text | `string` | Always uses overflow pages for values > 255 bytes |
+| `TIMESTAMP` | 8 bytes | 4713 BC … 294 276 AD | `time.Time` | Microseconds since 2000-01-01 (PostgreSQL epoch); timezone-naive |
+| `JSON` | Variable, unlimited | Valid UTF-8 JSON text | `string` | Validated on insert/update; overflow pages for large values |
+| `UUID` | 16 bytes (fixed) | Hyphenated string `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | `string` | Stored as inline binary; output is lowercase |
+| `VECTOR(n)` | 8 bytes inline + overflow | `[f1, f2, …, fn]` — *n* × float32 | `string` / `[]float32` | *n* fixed at column definition; data always on overflow pages |
+
+## Nullable columns
+
+All types support `NULL` values when the column is declared `NULLABLE` (i.e. without `NOT NULL`). NULL tracking uses a 64-bit bitmask per row, which limits tables to **64 columns maximum**.
+
+## Detailed type notes
+
+### BOOLEAN
+
+```sql
+CREATE TABLE flags (id INT8 PRIMARY KEY AUTOINCREMENT, active BOOLEAN NOT NULL DEFAULT true);
+INSERT INTO flags (active) VALUES (true), (false);
+SELECT * FROM flags WHERE active = true;
+```
+
+Use Go `bool` when binding parameters.
+
+### INT4 and INT8
+
+```sql
+CREATE TABLE stats (
+    id     INT8 PRIMARY KEY AUTOINCREMENT,
+    hits   INT8 NOT NULL DEFAULT 0,
+    rating INT4
+);
+```
+
+!!! warning "No negative integer literals in SQL"
+    The SQL parser does not accept negative integer literals directly.
+    Use `?` placeholders with negative `int64` values in Go code:
+
+    ```go
+    db.Exec("insert into t (n) values (?)", int64(-42)) // ✅
+    // db.Exec("insert into t (n) values (-42)")        // ❌ parse error
+    ```
+
+### REAL and DOUBLE
+
+```sql
+CREATE TABLE measurements (
+    id    INT8   PRIMARY KEY AUTOINCREMENT,
+    temp  REAL,
+    score DOUBLE NOT NULL DEFAULT 0.0
+);
+```
+
+### VARCHAR(n)
+
+```sql
+CREATE TABLE users (
+    id    INT8         PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    code  VARCHAR(10)  NOT NULL
+);
+```
+
+- Values up to 255 bytes are stored **inline** in the leaf cell.
+- Values longer than 255 bytes spill onto overflow pages (VARCHAR effectively becomes TEXT for large values).
+- Can be used as primary key or unique key columns (up to 255 bytes).
+
+### TEXT
+
+```sql
+CREATE TABLE articles (
+    id   INT8 PRIMARY KEY AUTOINCREMENT,
+    body TEXT
+);
+```
+
+- Always uses overflow pages for values exceeding the inline threshold.
+- Unlimited size (bounded only by available disk space).
+- Cannot be a primary key or unique key column.
+
+### TIMESTAMP
+
+```sql
+CREATE TABLE events (
+    id      INT8      PRIMARY KEY AUTOINCREMENT,
+    created TIMESTAMP DEFAULT NOW(),
+    updated TIMESTAMP
+);
+
+INSERT INTO events (updated) VALUES ('2024-06-01 12:00:00');
+INSERT INTO events (updated) VALUES ('2024-06-01 12:00:00.123456');
+```
+
+Accepted string formats:
+
+| Format | Example |
+|--------|---------|
+| `YYYY-MM-DD HH:MM:SS` | `2024-06-01 12:00:00` |
+| `YYYY-MM-DD HH:MM:SS.f` (1–6 fractional digits) | `2024-06-01 12:00:00.123456` |
+| Either format with trailing ` BC` | `0001-01-01 00:00:00 BC` |
+
+Use `NOW()` for the current UTC timestamp. Use `DATE_TRUNC`, `EXTRACT`, and `DATE_PART` functions to manipulate timestamps. See [Date & Time Functions](functions/datetime.md).
+
+### JSON
+
+```sql
+CREATE TABLE events (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    payload JSON
+);
+
+INSERT INTO events (payload) VALUES ('{"user":"alice","uid":42}');
+INSERT INTO events (payload) VALUES ('["go","sql","json"]');
+```
+
+- Validated as legal JSON on every insert and update.
+- Stored as compact UTF-8 text (whitespace not preserved).
+- Use `->` and `->>` path operators and JSON functions for access. See [JSON](json.md).
+
+### UUID
+
+```sql
+CREATE TABLE sessions (
+    id      UUID PRIMARY KEY,
+    user_id INT8 NOT NULL
+);
+
+INSERT INTO sessions (id, user_id)
+VALUES ('550e8400-e29b-41d4-a716-446655440000', 1);
+
+SELECT CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID);
+```
+
+- Stored as 16-byte binary (compact, no string overhead).
+- Accepted and returned as lowercase hyphenated string.
+
+### VECTOR(n)
+
+```sql
+CREATE TABLE documents (
+    id        INT8      PRIMARY KEY AUTOINCREMENT,
+    body      TEXT      NOT NULL,
+    embedding VECTOR(3) NOT NULL
+);
+
+INSERT INTO documents (body, embedding)
+VALUES ('hello world', '[0.1, 0.2, 0.3]');
+```
+
+- Dimension count *n* is fixed at table creation time.
+- All vector data lives on overflow pages; the inline cell stores only the dimension count and the first overflow page index.
+- Values are passed as bracket-delimited strings `'[f1, f2, …, fn]'` or `[]float32` bind parameters.
+- Used with `VEC_L2` and `VEC_COSINE` distance functions for similarity search. See [Vector Search](vector-search.md).

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,151 @@
+# Transparent Page Encryption
+
+MiniSQL supports transparent AES-256-CTR page encryption. When enabled, every database page (except the plaintext header) is encrypted on write and decrypted on read. Application code does not need to change — encryption is handled entirely by the storage layer.
+
+---
+
+## How it works
+
+- **Algorithm:** AES-256-CTR (stream cipher, no padding, seekable).
+- **Key derivation:** HKDF (HMAC-based Key Derivation Function) derives the actual AES key from the user-supplied key and a per-database random salt. This means the on-disk AES key material is unique per database file even when the same passphrase is reused.
+- **Plaintext header:** The first 100 bytes of page 0 (the database file header) are always stored in plaintext. This allows MiniSQL to read the salt, detect the encryption mode, and bootstrap key derivation before decrypting any pages.
+- **WAL consistency:** Pages written to the WAL file are also encrypted. The WAL and main database file always use the same key.
+- **VACUUM aware:** `VACUUM` carries encryption through — the compacted file is encrypted with the same key.
+- **Mismatch detection:** Opening an encrypted database without a key, or with the wrong key, returns an error. Corrupted pages are detected by the CRC32 checksum on every page.
+
+---
+
+## Enabling encryption
+
+### Via the Go API
+
+```go
+import (
+    "database/sql"
+    "github.com/RichardKnop/minisql"
+    _ "github.com/RichardKnop/minisql"
+)
+
+key := []byte("my-32-byte-secret-key-here!!!!!!")  // any length, HKDF handles it
+
+db, err := sql.Open("minisql", "/path/to/db.db?encryption_key=" + hex.EncodeToString(key))
+if err != nil {
+    log.Fatal(err)
+}
+defer db.Close()
+db.SetMaxOpenConns(1)
+
+// Force connection open and verify key is accepted
+if err := db.Ping(); err != nil {
+    log.Fatal(err)
+}
+```
+
+### DSN parameter
+
+The `encryption_key` DSN parameter accepts a **hex-encoded** key:
+
+```
+/path/to/db.db?encryption_key=<hex-encoded-key>
+```
+
+Example:
+
+```go
+import "encoding/hex"
+
+key := make([]byte, 32) // 256-bit key
+rand.Read(key)
+
+dsn := "/var/data/app.db?encryption_key=" + hex.EncodeToString(key)
+db, err := sql.Open("minisql", dsn)
+```
+
+---
+
+## Key requirements
+
+- The key can be any length — HKDF normalises it.
+- A 32-byte (256-bit) random key is recommended.
+- Store the key securely — losing the key means losing access to the database permanently.
+- The key is never written to disk.
+
+---
+
+## Error handling
+
+| Situation | Error |
+|-----------|-------|
+| Encrypted DB opened without a key | `"database is encrypted (mode 1) but no encryption key was provided"` |
+| Encrypted DB opened with wrong key | CRC32 mismatch error on first page read |
+| Unencrypted DB opened with a key | Error — key provided for non-encrypted database |
+
+Always call `db.Ping()` after opening to surface any key errors early:
+
+```go
+db, _ := sql.Open("minisql", dsn)
+if err := db.Ping(); err != nil {
+    // wrong key, missing key, or corrupted database
+    return err
+}
+```
+
+---
+
+## Full example
+
+```go
+package main
+
+import (
+    "crypto/rand"
+    "database/sql"
+    "encoding/hex"
+    "fmt"
+    "log"
+
+    _ "github.com/RichardKnop/minisql"
+)
+
+func main() {
+    // Generate a random 256-bit key
+    key := make([]byte, 32)
+    if _, err := rand.Read(key); err != nil {
+        log.Fatal(err)
+    }
+
+    dsn := "/tmp/encrypted.db?encryption_key=" + hex.EncodeToString(key)
+
+    db, err := sql.Open("minisql", dsn)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
+    db.SetMaxOpenConns(1)
+    db.SetMaxIdleConns(1)
+
+    if err := db.Ping(); err != nil {
+        log.Fatal("failed to open encrypted database:", err)
+    }
+
+    db.Exec(`CREATE TABLE IF NOT EXISTS secrets (
+        id   INT8 PRIMARY KEY AUTOINCREMENT,
+        data TEXT NOT NULL
+    )`)
+
+    db.Exec(`INSERT INTO secrets (data) VALUES (?)`, "top secret value")
+
+    var data string
+    db.QueryRow(`SELECT data FROM secrets WHERE id = 1`).Scan(&data)
+    fmt.Println(data) // "top secret value"
+}
+```
+
+---
+
+## Notes
+
+- Encryption adds one AES-CTR encrypt/decrypt operation per page read or write. For most workloads the overhead is negligible.
+- The database file and WAL file should be treated as equally sensitive — both contain encrypted pages.
+- There is no support for key rotation; to change the key, use `VACUUM` after re-opening with the new key (VACUUM rewrites all pages, but key change support is a planned feature).
+- `PRAGMA integrity_check` works on encrypted databases — pages are decrypted in-memory before the check.

--- a/docs/functions/aggregate.md
+++ b/docs/functions/aggregate.md
@@ -1,0 +1,125 @@
+# Aggregate Functions
+
+Aggregate functions compute a single value from a set of rows. They are used with `SELECT` and, optionally, `GROUP BY` and `HAVING`.
+
+---
+
+## COUNT
+
+```sql
+-- Count all rows
+SELECT COUNT(*) FROM orders;
+
+-- Count non-NULL values in a column
+SELECT COUNT(user_id) FROM orders;
+
+-- Count distinct values
+SELECT COUNT(DISTINCT user_id) FROM orders;
+```
+
+## SUM
+
+```sql
+SELECT SUM(amount)        FROM orders;
+SELECT SUM(price * qty)   FROM order_lines;
+```
+
+`SUM` ignores `NULL` values. Returns `NULL` if all values are `NULL`.
+
+## AVG
+
+```sql
+SELECT AVG(amount)  FROM orders;
+SELECT AVG(salary)  FROM employees;
+```
+
+`AVG` ignores `NULL` values. Returns `NULL` if all values are `NULL`.
+
+## MIN and MAX
+
+```sql
+SELECT MIN(amount), MAX(amount) FROM orders;
+SELECT MIN(created), MAX(created) FROM events;
+SELECT MIN(name) FROM users;   -- lexicographic min
+```
+
+`MIN` / `MAX` ignore `NULL` values. Return `NULL` if all values are `NULL`.
+
+---
+
+## With GROUP BY
+
+```sql
+-- Total orders per user
+SELECT user_id, COUNT(*) AS order_count, SUM(amount) AS total
+FROM orders
+GROUP BY user_id;
+
+-- Department statistics
+SELECT department, COUNT(*) AS headcount, AVG(salary) AS avg_salary
+FROM employees
+GROUP BY department
+ORDER BY headcount DESC;
+```
+
+## With HAVING
+
+Filter groups after aggregation:
+
+```sql
+-- Only users with more than 5 orders
+SELECT user_id, COUNT(*) AS cnt
+FROM orders
+GROUP BY user_id
+HAVING COUNT(*) > 5;
+
+-- Departments with average salary above threshold
+SELECT department, AVG(salary) AS avg_sal
+FROM employees
+GROUP BY department
+HAVING AVG(salary) > 50000;
+
+-- Users whose total spend exceeds 1000
+SELECT user_id, SUM(amount) AS total
+FROM orders
+GROUP BY user_id
+HAVING SUM(amount) > 1000;
+```
+
+!!! note
+    `HAVING` does not support `?` bind parameters. Use literal values in HAVING conditions.
+
+## COUNT(DISTINCT …)
+
+```sql
+-- Number of unique products ordered
+SELECT COUNT(DISTINCT product_id) FROM order_lines;
+
+-- Unique users per day
+SELECT DATE_TRUNC('day', created) AS day, COUNT(DISTINCT user_id) AS dau
+FROM events
+GROUP BY DATE_TRUNC('day', created);
+```
+
+---
+
+## In subqueries
+
+```sql
+-- Users who have placed at least one order over 100
+SELECT * FROM users
+WHERE id IN (
+    SELECT user_id FROM orders WHERE amount > 100
+);
+
+-- CTE with aggregation
+WITH totals AS (
+    SELECT user_id, SUM(amount) AS total
+    FROM orders
+    GROUP BY user_id
+)
+SELECT u.name, t.total
+FROM users u
+JOIN totals t ON u.id = t.user_id
+WHERE t.total > 500;
+```

--- a/docs/functions/conditional.md
+++ b/docs/functions/conditional.md
@@ -1,0 +1,97 @@
+# Conditional Functions
+
+## COALESCE(val1, val2, …)
+
+Returns the first non-NULL argument. Useful for providing fallback values.
+
+```sql
+SELECT COALESCE(nickname, name, 'Anonymous') FROM users;
+SELECT COALESCE(discount, 0)                 FROM products;
+SELECT COALESCE(phone, email)                FROM contacts;
+```
+
+At least one argument is required. Returns `NULL` only if all arguments are `NULL`.
+
+## NULLIF(a, b)
+
+Returns `NULL` if `a = b`; otherwise returns `a`. Useful for avoiding division-by-zero and replacing sentinel values with `NULL`.
+
+```sql
+-- Avoid division by zero
+SELECT total / NULLIF(count, 0) AS avg FROM summaries;
+
+-- Replace empty string with NULL
+SELECT NULLIF(name, '') FROM users;
+
+-- Replace a sentinel value
+SELECT NULLIF(score, -1) AS score FROM results;
+```
+
+---
+
+## CASE WHEN
+
+`CASE WHEN` is the general conditional expression.
+
+### Searched form
+
+```sql
+SELECT id, name,
+    CASE
+        WHEN score >= 90 THEN 'A'
+        WHEN score >= 80 THEN 'B'
+        WHEN score >= 70 THEN 'C'
+        ELSE 'F'
+    END AS grade
+FROM students;
+```
+
+### Simple form (equality test)
+
+```sql
+SELECT id,
+    CASE status
+        WHEN 'active'   THEN 'Active user'
+        WHEN 'inactive' THEN 'Inactive user'
+        ELSE 'Unknown'
+    END AS status_label
+FROM accounts;
+```
+
+### In WHERE
+
+```sql
+SELECT * FROM orders
+WHERE
+    CASE type
+        WHEN 'premium' THEN amount > 0
+        WHEN 'trial'   THEN amount = 0
+        ELSE true
+    END;
+```
+
+### In UPDATE SET
+
+```sql
+UPDATE employees
+SET salary = CASE
+    WHEN department = 'eng'   THEN salary * 1.10
+    WHEN department = 'sales' THEN salary * 1.05
+    ELSE salary
+END;
+```
+
+---
+
+## IS NULL / IS NOT NULL
+
+Not a function, but commonly used for null handling:
+
+```sql
+SELECT * FROM users WHERE nickname IS NULL;
+SELECT * FROM users WHERE email    IS NOT NULL;
+
+SELECT COALESCE(nickname, name) AS display
+FROM users
+WHERE nickname IS NOT NULL;
+```

--- a/docs/functions/datetime.md
+++ b/docs/functions/datetime.md
@@ -1,0 +1,146 @@
+# Date & Time Functions
+
+MiniSQL stores timestamps as microseconds since the PostgreSQL epoch (2000-01-01). All functions operate on the `TIMESTAMP` type.
+
+---
+
+## NOW()
+
+Returns the current UTC timestamp.
+
+```sql
+SELECT NOW();
+
+INSERT INTO events (name, created) VALUES ('login', NOW());
+
+CREATE TABLE users (
+    id      INT8      PRIMARY KEY AUTOINCREMENT,
+    created TIMESTAMP DEFAULT NOW()
+);
+```
+
+---
+
+## DATE_TRUNC(unit, timestamp)
+
+Truncates a timestamp to the specified precision.
+
+| Unit | Truncates to |
+|------|-------------|
+| `'year'` | First day of the year, midnight |
+| `'month'` | First day of the month, midnight |
+| `'day'` | Midnight of the day |
+| `'hour'` | Start of the hour |
+| `'minute'` | Start of the minute |
+| `'second'` | Start of the second |
+
+```sql
+SELECT DATE_TRUNC('year',   created) FROM events;  -- 2024-01-01 00:00:00
+SELECT DATE_TRUNC('month',  created) FROM events;  -- 2024-06-01 00:00:00
+SELECT DATE_TRUNC('day',    created) FROM events;  -- 2024-06-15 00:00:00
+SELECT DATE_TRUNC('hour',   created) FROM events;  -- 2024-06-15 14:00:00
+SELECT DATE_TRUNC('minute', created) FROM events;  -- 2024-06-15 14:30:00
+SELECT DATE_TRUNC('second', created) FROM events;  -- 2024-06-15 14:30:45
+```
+
+Group events by day:
+
+```sql
+SELECT DATE_TRUNC('day', created) AS day, COUNT(*) AS cnt
+FROM events
+GROUP BY DATE_TRUNC('day', created)
+ORDER BY day;
+```
+
+---
+
+## EXTRACT(field, timestamp) / DATE_PART(field, timestamp)
+
+Extracts a single field from a timestamp as `INT8` (or `INT8` epoch seconds for `epoch`).
+
+| Field | Returns |
+|-------|---------|
+| `'year'` | Year (e.g., 2024) |
+| `'month'` | Month (1–12) |
+| `'day'` | Day of month (1–31) |
+| `'hour'` | Hour (0–23) |
+| `'minute'` | Minute (0–59) |
+| `'second'` | Second (0–59) |
+| `'microsecond'` | Microsecond part (0–999999) |
+| `'epoch'` | Seconds since Unix epoch (1970-01-01) |
+
+```sql
+SELECT EXTRACT('year',   created) FROM events;
+SELECT EXTRACT('month',  created) FROM events;
+SELECT EXTRACT('day',    created) FROM events;
+SELECT EXTRACT('hour',   created) FROM events;
+SELECT EXTRACT('epoch',  created) FROM events;
+
+-- DATE_PART is an alias for EXTRACT
+SELECT DATE_PART('year', created) FROM events;
+```
+
+Filter by month:
+
+```sql
+SELECT * FROM events WHERE EXTRACT('month', created) = 6;
+```
+
+---
+
+## TO_TIMESTAMP(str)
+
+Parses a timestamp string. Accepts the same formats as literal timestamp values.
+
+```sql
+SELECT TO_TIMESTAMP('2024-06-01 12:00:00');
+SELECT TO_TIMESTAMP('2024-06-01 12:00:00.123456');
+```
+
+---
+
+## Timestamp literals
+
+Timestamp values can be written as strings in `INSERT` / `WHERE` clauses:
+
+```sql
+INSERT INTO events (created) VALUES ('2024-06-01 12:00:00');
+SELECT * FROM events WHERE created > '2024-01-01 00:00:00';
+SELECT * FROM events WHERE created BETWEEN '2024-01-01 00:00:00' AND '2024-12-31 23:59:59';
+```
+
+Accepted formats:
+
+| Format | Example |
+|--------|---------|
+| `YYYY-MM-DD HH:MM:SS` | `2024-06-01 12:00:00` |
+| `YYYY-MM-DD HH:MM:SS.f` (1–6 fractional digits) | `2024-06-01 12:00:00.123456` |
+| Either format with ` BC` suffix | `0001-01-01 00:00:00 BC` |
+
+---
+
+## INTERVAL arithmetic
+
+Add or subtract intervals from timestamps:
+
+```sql
+SELECT NOW() + INTERVAL '1 day';
+SELECT NOW() - INTERVAL '30 days';
+SELECT created + INTERVAL '1 hour' FROM events;
+```
+
+Supported interval units: `second`, `minute`, `hour`, `day`, `month`, `year`.
+
+---
+
+## Expression index on timestamp
+
+```sql
+-- Index by day for fast GROUP BY / WHERE on truncated dates
+CREATE INDEX idx_events_day ON events (DATE_TRUNC('day', created));
+
+SELECT DATE_TRUNC('day', created) AS day, COUNT(*) AS cnt
+FROM events
+GROUP BY DATE_TRUNC('day', created);
+-- Uses idx_events_day
+```

--- a/docs/functions/json.md
+++ b/docs/functions/json.md
@@ -1,0 +1,135 @@
+# JSON Functions
+
+MiniSQL provides operators and functions for navigating and querying `JSON` columns.
+
+See also [JSON](../json.md) for the data type reference and [JSON Inverted Index](../indexes/json-inverted.md) for indexed JSON queries.
+
+---
+
+## Path operators
+
+### `->` — JSON fragment
+
+Returns the value at a key (object) or index (array) as a JSON string.
+
+```sql
+SELECT payload -> 'user'       FROM events;   -- '{"name":"alice"}'
+SELECT payload -> 0            FROM events;   -- first array element as JSON
+```
+
+### `->>` — SQL scalar
+
+Returns the value as a SQL scalar (string or number), not a JSON fragment.
+
+```sql
+SELECT payload ->> 'user'      FROM events;   -- 'alice'
+SELECT payload ->> 'uid'       FROM events;   -- '42' (string)
+SELECT payload ->> 0           FROM events;   -- first array element as string
+```
+
+### Chaining
+
+```sql
+SELECT payload -> 'address' ->> 'city' FROM users;
+```
+
+---
+
+## JSON_EXTRACT(json, path)
+
+Extracts a value at the given path. Returns a SQL scalar. Returns `NULL` if the path does not exist.
+
+```sql
+SELECT JSON_EXTRACT(payload, 'user')        FROM events;
+SELECT JSON_EXTRACT(payload, 'score')       FROM events;  -- returned as number
+SELECT JSON_EXTRACT(payload, 'tags.0')      FROM events;  -- first element of 'tags' array
+```
+
+---
+
+## JSON_CONTAINS(json, value)
+
+Returns `true` if `json` contains `value` as a sub-document or element. Used with the [JSON inverted index](../indexes/json-inverted.md).
+
+```sql
+-- Object containment
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '{"action": "login"}');
+
+-- Scalar element in array or nested value
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '"go"');
+```
+
+---
+
+## JSON_TYPE(json [, path])
+
+Returns the JSON type of the value as a string: `'object'`, `'array'`, `'string'`, `'number'`, `'boolean'`, or `'null'`.
+
+```sql
+SELECT JSON_TYPE('{"a": 1}');           -- 'object'
+SELECT JSON_TYPE('[1, 2, 3]');          -- 'array'
+SELECT JSON_TYPE('"hello"');            -- 'string'
+SELECT JSON_TYPE('42');                 -- 'number'
+SELECT JSON_TYPE('true');              -- 'boolean'
+
+-- At a specific path
+SELECT JSON_TYPE(payload, 'tags')      FROM events;  -- 'array'
+SELECT JSON_TYPE(payload, 'score')     FROM events;  -- 'number'
+```
+
+---
+
+## JSON_ARRAY_LENGTH(json [, path])
+
+Returns the number of elements in a JSON array, or `NULL` if the target is not an array.
+
+```sql
+SELECT JSON_ARRAY_LENGTH('[1, 2, 3]');        -- 3
+SELECT JSON_ARRAY_LENGTH('[]');               -- 0
+SELECT JSON_ARRAY_LENGTH(payload)       FROM events;
+SELECT JSON_ARRAY_LENGTH(payload, 'tags') FROM events;  -- length of payload.tags
+```
+
+---
+
+## JSON_VALID(json)
+
+Returns `1` if the string is valid JSON, `0` otherwise.
+
+```sql
+SELECT JSON_VALID('{"a": 1}');       -- 1
+SELECT JSON_VALID('not json');        -- 0
+SELECT JSON_VALID(NULL);              -- NULL
+```
+
+---
+
+## CAST to JSON
+
+```sql
+SELECT CAST('{"a": 1}' AS JSON);
+```
+
+Validates and normalises the JSON on insert/update.
+
+---
+
+## Examples
+
+```sql
+-- Filter by nested JSON field
+SELECT * FROM events WHERE payload ->> 'action' = 'login';
+
+-- Extract a numeric field and compare
+SELECT * FROM events WHERE CAST(payload ->> 'score' AS INT8) > 90;
+
+-- Navigate nested structure
+SELECT payload -> 'meta' ->> 'version' AS version FROM events;
+
+-- Aggregate over a JSON field
+SELECT payload ->> 'country' AS country, COUNT(*) AS cnt
+FROM events
+WHERE payload ->> 'action' = 'signup'
+GROUP BY payload ->> 'country'
+ORDER BY cnt DESC;
+```

--- a/docs/functions/numeric.md
+++ b/docs/functions/numeric.md
@@ -1,0 +1,94 @@
+# Numeric Functions
+
+## ABS(n)
+
+Returns the absolute value of a number.
+
+```sql
+SELECT ABS(-42);         -- 42
+SELECT ABS(-3.14);       -- 3.14
+SELECT ABS(score) FROM measurements;
+```
+
+Works with `INT4`, `INT8`, `REAL`, and `DOUBLE`. Returns `NULL` for `NULL` input.
+
+## FLOOR(n)
+
+Rounds down to the nearest integer.
+
+```sql
+SELECT FLOOR(3.7);       -- 3.0
+SELECT FLOOR(-2.3);      -- -3.0
+SELECT FLOOR(amount / 100.0) FROM orders;
+```
+
+Integer inputs are returned unchanged. Returns `NULL` for `NULL` input.
+
+## CEIL(n)
+
+Rounds up to the nearest integer.
+
+```sql
+SELECT CEIL(3.2);        -- 4.0
+SELECT CEIL(-2.7);       -- -2.0
+```
+
+Integer inputs are returned unchanged. Returns `NULL` for `NULL` input.
+
+## ROUND(n [, digits])
+
+Rounds to `digits` decimal places (default 0 — nearest integer).
+
+```sql
+SELECT ROUND(3.567);         -- 4.0
+SELECT ROUND(3.567, 2);      -- 3.57
+SELECT ROUND(3.567, 1);      -- 3.6
+SELECT ROUND(amount, 2) FROM transactions;
+```
+
+Integer inputs are returned unchanged regardless of `digits`. Returns `NULL` for `NULL` input.
+
+## MOD(a, b)
+
+Returns the remainder of `a / b`.
+
+```sql
+SELECT MOD(10, 3);       -- 1
+SELECT MOD(10.5, 3.0);   -- 1.5
+SELECT * FROM rows WHERE MOD(id, 2) = 0;   -- even IDs
+```
+
+Returns `NULL` for `NULL` input. Raises an error on division by zero.
+
+---
+
+## Arithmetic operators
+
+Arithmetic can also be expressed inline:
+
+```sql
+SELECT price * quantity           AS total   FROM order_lines;
+SELECT balance - debit            AS new_bal FROM accounts;
+SELECT total / CAST(count AS DOUBLE) AS avg  FROM summaries;
+SELECT id % 2                     AS parity  FROM rows;
+```
+
+!!! warning "No negative integer literals"
+    The SQL parser rejects negative integer literals. Use bind parameters instead:
+
+    ```go
+    db.Exec("UPDATE t SET n = n + ?", int64(-5)) // ✅
+    // db.Exec("UPDATE t SET n = n + (-5)")       // ❌ parse error
+    ```
+
+---
+
+## Type promotion
+
+When both operands are integers, arithmetic returns an integer. When one is a float, the result is a float:
+
+```sql
+SELECT 10 / 3;           -- 3   (integer division)
+SELECT 10 / 3.0;         -- 3.333…  (float)
+SELECT CAST(10 AS DOUBLE) / 3;  -- 3.333…
+```

--- a/docs/functions/string.md
+++ b/docs/functions/string.md
@@ -1,0 +1,115 @@
+# String Functions
+
+## UPPER(str)
+
+Converts a string to uppercase.
+
+```sql
+SELECT UPPER('hello');         -- 'HELLO'
+SELECT UPPER(name) FROM users;
+```
+
+## LOWER(str)
+
+Converts a string to lowercase.
+
+```sql
+SELECT LOWER('HELLO');         -- 'hello'
+SELECT LOWER(email) FROM users;
+```
+
+## LENGTH(str)
+
+Returns the byte length of the string.
+
+```sql
+SELECT LENGTH('hello');        -- 5
+SELECT LENGTH(name) FROM users;
+```
+
+## TRIM([str [, chars]])
+
+Removes leading and trailing characters from a string. Defaults to whitespace.
+
+```sql
+SELECT TRIM('  hello  ');         -- 'hello'
+SELECT TRIM('xxhelloxx', 'x');    -- 'hello'
+SELECT TRIM(name) FROM users;
+```
+
+## LTRIM([str [, chars]])
+
+Removes leading characters only.
+
+```sql
+SELECT LTRIM('  hello  ');        -- 'hello  '
+SELECT LTRIM('xxhello', 'x');     -- 'hello'
+```
+
+## RTRIM([str [, chars]])
+
+Removes trailing characters only.
+
+```sql
+SELECT RTRIM('  hello  ');        -- '  hello'
+SELECT RTRIM('helloxx', 'x');     -- 'hello'
+```
+
+## SUBSTR(str, start [, length])
+
+Returns a substring. `start` is 1-based. If `length` is omitted, returns to end of string.
+
+```sql
+SELECT SUBSTR('hello world', 7);      -- 'world'
+SELECT SUBSTR('hello world', 1, 5);   -- 'hello'
+SELECT SUBSTR(body, 1, 100) FROM articles;
+```
+
+## REPLACE(str, from, to)
+
+Replaces all occurrences of `from` with `to`.
+
+```sql
+SELECT REPLACE('foo bar foo', 'foo', 'baz');  -- 'baz bar baz'
+SELECT REPLACE(email, '@old.com', '@new.com') FROM users;
+```
+
+## CONCAT(str1, str2, ...)
+
+Concatenates strings. NULL arguments are silently skipped (PostgreSQL semantics).
+
+```sql
+SELECT CONCAT('hello', ' ', 'world');   -- 'hello world'
+SELECT CONCAT(first_name, ' ', last_name) AS full_name FROM users;
+```
+
+Alternatively, use the `||` operator:
+
+```sql
+SELECT first_name || ' ' || last_name FROM users;
+```
+
+## NULL behaviour
+
+All string functions return `NULL` if any non-skippable argument is `NULL`:
+
+```sql
+SELECT UPPER(NULL);         -- NULL
+SELECT LENGTH(NULL);        -- NULL
+SELECT REPLACE(NULL, 'a', 'b'); -- NULL
+```
+
+`CONCAT` is an exception — it skips `NULL` arguments and returns the concatenation of non-null values.
+
+---
+
+## Expression index example
+
+String functions can be used in expression indexes to accelerate function-based predicates:
+
+```sql
+CREATE INDEX idx_lower_email ON users (LOWER(email));
+
+-- Uses the expression index
+SELECT * FROM users WHERE LOWER(email) = 'alice@example.com';
+```

--- a/docs/functions/window.md
+++ b/docs/functions/window.md
@@ -1,0 +1,149 @@
+# Window Functions
+
+Window functions compute a value for each row based on a related set of rows (the *window*), without collapsing the result into a single row. They require an `OVER` clause.
+
+## Syntax
+
+```sql
+function_name([args]) OVER (
+    [PARTITION BY column_list]
+    [ORDER BY column_list [ASC|DESC]]
+)
+```
+
+---
+
+## ROW_NUMBER()
+
+Assigns a unique sequential integer to each row within the window, starting at 1.
+
+```sql
+-- Global ranking by score
+SELECT name, score,
+       ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+FROM students;
+
+-- Rank within each department
+SELECT name, dept, score,
+       ROW_NUMBER() OVER (PARTITION BY dept ORDER BY score DESC) AS dept_rank
+FROM employees;
+```
+
+---
+
+## RANK()
+
+Like `ROW_NUMBER()`, but rows with equal values receive the same rank, and the next rank skips (1, 2, 2, 4, …).
+
+```sql
+SELECT name, score,
+       RANK() OVER (ORDER BY score DESC) AS rank
+FROM students;
+```
+
+---
+
+## DENSE_RANK()
+
+Like `RANK()`, but without gaps — tied rows share a rank and the next rank is consecutive (1, 2, 2, 3, …).
+
+```sql
+SELECT name, dept, score,
+       DENSE_RANK() OVER (PARTITION BY dept ORDER BY score DESC) AS dense_rank
+FROM employees;
+```
+
+---
+
+## SUM, AVG, MIN, MAX over a window
+
+Aggregate functions can be used as window functions to compute running totals, partition totals, and partition averages.
+
+```sql
+-- Running sum of scores
+SELECT name, score,
+       SUM(score) OVER (ORDER BY score) AS running_sum
+FROM students;
+
+-- Department totals alongside individual rows
+SELECT name, dept, salary,
+       SUM(salary)  OVER (PARTITION BY dept) AS dept_total,
+       AVG(salary)  OVER (PARTITION BY dept) AS dept_avg,
+       MIN(salary)  OVER (PARTITION BY dept) AS dept_min,
+       MAX(salary)  OVER (PARTITION BY dept) AS dept_max
+FROM employees;
+```
+
+---
+
+## LAG(col, offset)
+
+Returns the value of `col` from `offset` rows before the current row within the window. Returns `NULL` for the first `offset` rows.
+
+```sql
+SELECT name, score,
+       LAG(score, 1) OVER (ORDER BY score) AS prev_score
+FROM students;
+```
+
+---
+
+## LEAD(col, offset)
+
+Returns the value of `col` from `offset` rows after the current row. Returns `NULL` for the last `offset` rows.
+
+```sql
+SELECT name, score,
+       LEAD(score, 1) OVER (ORDER BY score) AS next_score
+FROM students;
+```
+
+---
+
+## LAG and LEAD together
+
+```sql
+SELECT name, score,
+       LAG(score,  1) OVER (ORDER BY score) AS prev_score,
+       LEAD(score, 1) OVER (ORDER BY score) AS next_score
+FROM students;
+```
+
+---
+
+## Full example
+
+```sql
+CREATE TABLE employees (
+    id         INT8        PRIMARY KEY AUTOINCREMENT,
+    name       VARCHAR(64) NOT NULL,
+    dept       VARCHAR(32) NOT NULL,
+    salary     INT8        NOT NULL
+);
+
+INSERT INTO employees (name, dept, salary) VALUES
+    ('Alice', 'eng',   120000),
+    ('Bob',   'eng',    95000),
+    ('Carol', 'sales',  80000),
+    ('Dave',  'sales',  85000),
+    ('Eve',   'eng',   110000);
+
+SELECT
+    name,
+    dept,
+    salary,
+    ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC) AS dept_rank,
+    DENSE_RANK() OVER (PARTITION BY dept ORDER BY salary DESC) AS dense_rk,
+    SUM(salary)  OVER (PARTITION BY dept)                      AS dept_total,
+    AVG(salary)  OVER (PARTITION BY dept)                      AS dept_avg
+FROM employees
+ORDER BY dept, dept_rank;
+```
+
+---
+
+## Notes
+
+- Multiple `OVER` clauses in the same `SELECT` are evaluated independently.
+- `PARTITION BY` is optional — omitting it treats all rows as a single partition.
+- `ORDER BY` inside `OVER` is independent of the query-level `ORDER BY`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,174 @@
+# Getting Started
+
+## Installation
+
+```bash
+go get github.com/RichardKnop/minisql
+```
+
+Import the driver (blank import registers it with `database/sql`):
+
+```go
+import (
+    "database/sql"
+    _ "github.com/RichardKnop/minisql"
+)
+```
+
+## Opening a database
+
+```go
+db, err := sql.Open("minisql", "./my.db")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Required: MiniSQL supports only one open connection per file
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+defer db.Close()
+```
+
+The database file is created automatically if it does not exist.
+
+## Connection string
+
+The first argument to `sql.Open` is a file path with optional query parameters:
+
+```go
+// Simple path
+db, err := sql.Open("minisql", "./my.db")
+
+// With parameters
+db, err := sql.Open("minisql", "./my.db?log_level=debug&max_cached_pages=1000")
+
+// With encryption
+db, err := sql.Open("minisql", "./my.db?encryption_key="+hex.EncodeToString(key))
+```
+
+See [Connection](connection.md) for the full parameter reference.
+
+## Creating a table
+
+```go
+_, err = db.Exec(`create table "users" (
+    id      int8      primary key autoincrement,
+    email   varchar(255) not null unique,
+    name    text,
+    active  boolean   not null default true,
+    created timestamp default now()
+)`)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+## Inserting rows
+
+```go
+// Single row
+_, err = db.Exec(
+    `insert into "users" (email, name) values (?, ?)`,
+    "alice@example.com", "Alice",
+)
+
+// Multi-row
+_, err = db.Exec(
+    `insert into "users" (email, name) values (?, ?), (?, ?)`,
+    "bob@example.com", "Bob",
+    "carol@example.com", "Carol",
+)
+
+// Prepared statement (recommended for repeated inserts)
+stmt, err := db.Prepare(`insert into "users" (email, name) values (?, ?)`)
+defer stmt.Close()
+for _, u := range users {
+    _, err = stmt.Exec(u.Email, u.Name)
+}
+```
+
+## Querying rows
+
+```go
+rows, err := db.Query(`select id, name, email from "users" where active = ? order by id`, true)
+if err != nil {
+    log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+    var id int64
+    var name, email string
+    if err := rows.Scan(&id, &name, &email); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("%d  %-20s  %s\n", id, name, email)
+}
+if err := rows.Err(); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Scanning a single row
+
+```go
+var count int64
+err = db.QueryRow(`select count(*) from "users"`).Scan(&count)
+```
+
+## Updating rows
+
+```go
+result, err := db.Exec(
+    `update "users" set active = ? where id = ?`,
+    false, 42,
+)
+n, _ := result.RowsAffected()
+fmt.Printf("%d row(s) updated\n", n)
+```
+
+## Deleting rows
+
+```go
+_, err = db.Exec(`delete from "users" where id = ?`, 42)
+```
+
+!!! note
+    DELETE always requires a WHERE clause. Use `WHERE 1=1` to delete all rows.
+
+## Transactions
+
+```go
+tx, err := db.Begin()
+if err != nil {
+    log.Fatal(err)
+}
+
+_, err = tx.Exec(`insert into "users" (email, name) values (?, ?)`, "dave@example.com", "Dave")
+_, err = tx.Exec(`update "accounts" set balance = balance - ? where user_id = ?`, 100, 1)
+
+if err != nil {
+    tx.Rollback()
+    return err
+}
+if err := tx.Commit(); err != nil {
+    return err
+}
+```
+
+## Using RETURNING
+
+```go
+var newID int64
+err = db.QueryRow(
+    `insert into "users" (email, name) values (?, ?) returning id`,
+    "eve@example.com", "Eve",
+).Scan(&newID)
+```
+
+## Next steps
+
+- [Connection parameters](connection.md) — tune cache size, WAL behaviour, logging
+- [SQL Reference](sql/create-table.md) — complete SQL syntax
+- [Data Types](data-types.md) — all supported column types
+- [Indexes](indexes/overview.md) — add indexes to speed up queries

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,83 @@
+# MiniSQL
+
+**MiniSQL** is an embedded, single-file SQL database written in pure Go, inspired by SQLite but borrowing ideas from PostgreSQL. It requires zero CGO and zero external dependencies beyond the Go standard library.
+
+## Why MiniSQL?
+
+| Feature | MiniSQL | SQLite |
+|---------|---------|--------|
+| Language | Pure Go / zero CGO | C |
+| Read concurrency | MVCC snapshot isolation | WAL reader/writer lock |
+| Parallel scan | ✅ | ❌ |
+| Native JSON type | ✅ | Extension only |
+| Native UUID type | ✅ | ❌ |
+| Built-in full-text search | ✅ (BM25) | Extension only |
+| JSON inverted index | ✅ | ❌ |
+| Vector similarity search | ✅ (HNSW ANN) | Extension only |
+| Transparent page encryption | ✅ (AES-256-CTR) | Extension only |
+
+## Quick start
+
+```go
+import (
+    "database/sql"
+    _ "github.com/RichardKnop/minisql"
+)
+
+db, err := sql.Open("minisql", "./my.db")
+if err != nil {
+    log.Fatal(err)
+}
+// MiniSQL requires exactly one open connection
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+defer db.Close()
+
+_, err = db.Exec(`create table "users" (
+    id    int8 primary key autoincrement,
+    email varchar(255) unique,
+    name  text,
+    created timestamp default now()
+)`)
+
+_, err = db.Exec(
+    `insert into "users" (email, name) values (?, ?)`,
+    "alice@example.com", "Alice",
+)
+
+rows, err := db.Query(`select id, name from "users" order by id`)
+defer rows.Close()
+for rows.Next() {
+    var id int64
+    var name string
+    rows.Scan(&id, &name)
+    fmt.Printf("%d  %s\n", id, name)
+}
+```
+
+## Key characteristics
+
+- **Single file** — the entire database is one `*.db` file plus a `*-wal` WAL file.
+- **Write-Ahead Log** — all-or-nothing commits; safe crash recovery; automatic checkpoint.
+- **OCC writes + MVCC reads** — one writer at a time; unlimited concurrent readers with snapshot isolation.
+- **B+ tree storage** — fixed 4 096-byte pages with CRC32 integrity checking on every page.
+- **Max 64 columns per table** — tracked via a 64-bit NULL bitmask.
+- **`database/sql` compatible** — works with any Go code that uses the standard `database/sql` interface.
+
+## Navigation
+
+| Section | What you'll find |
+|---------|-----------------|
+| [Getting Started](getting-started.md) | Installation, connection, first queries |
+| [Connection](connection.md) | DSN parameters, connection pooling |
+| [Architecture](architecture.md) | Storage, WAL, concurrency model |
+| [Data Types](data-types.md) | All supported column types |
+| [SQL Reference](sql/create-table.md) | Full SQL syntax reference |
+| [Indexes](indexes/overview.md) | B-tree, full-text, JSON, HNSW |
+| [Functions](functions/string.md) | All built-in functions |
+| [JSON](json.md) | JSON type, operators, inverted index |
+| [Vector Search](vector-search.md) | VECTOR type and HNSW ANN search |
+| [Encryption](encryption.md) | Transparent AES-256-CTR encryption |
+| [Constraints](constraints.md) | CHECK, FK, NOT NULL, UNIQUE |
+| [System Table](system-table.md) | `minisql_schema` structure |
+| [Limitations](limitations.md) | Known limitations and workarounds |

--- a/docs/indexes/btree.md
+++ b/docs/indexes/btree.md
@@ -1,0 +1,151 @@
+# B-tree Indexes
+
+Every table's primary key is a B-tree. Additional B-tree indexes can be created on any column or combination of columns.
+
+---
+
+## Primary key index
+
+Defined in `CREATE TABLE`:
+
+```sql
+CREATE TABLE users (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    name  TEXT
+);
+```
+
+Primary key lookups are O(log N):
+
+```sql
+SELECT * FROM users WHERE id = 42;
+```
+
+---
+
+## Secondary indexes
+
+```sql
+-- Single-column secondary index
+CREATE INDEX idx_users_created ON users (created);
+
+-- Unique secondary index
+CREATE UNIQUE INDEX idx_users_email ON users (email);
+```
+
+Secondary indexes support:
+
+- **Equality** — `WHERE email = 'alice@example.com'`
+- **Range** — `WHERE created > '2024-01-01 00:00:00'`
+- **ORDER BY** — `ORDER BY created` (avoids sort)
+- **Covering** (see below)
+
+---
+
+## Composite indexes
+
+Index multiple columns together:
+
+```sql
+CREATE INDEX idx_orders_user_status ON orders (user_id, status);
+CREATE INDEX idx_events_type_created ON events (event_type, created_at);
+```
+
+The planner can use a composite index when the query predicates match from the **leftmost column**:
+
+```sql
+-- Uses idx_orders_user_status (both columns covered)
+SELECT * FROM orders WHERE user_id = 1 AND status = 'pending';
+
+-- Uses idx_orders_user_status (leading column only)
+SELECT * FROM orders WHERE user_id = 1;
+
+-- Does NOT use idx_orders_user_status (skips user_id)
+SELECT * FROM orders WHERE status = 'pending';
+```
+
+---
+
+## Partial indexes
+
+A partial index includes only rows that satisfy a `WHERE` condition. This keeps the index smaller and faster for selective queries:
+
+```sql
+-- Only index active users
+CREATE INDEX idx_active_users_email ON users (email) WHERE active = true;
+
+-- Only index non-cancelled orders
+CREATE INDEX idx_open_orders_user ON orders (user_id) WHERE status <> 'cancelled';
+```
+
+The planner uses a partial index only when the query predicate implies the index's WHERE condition.
+
+---
+
+## Expression indexes
+
+Index the result of an expression rather than a raw column value:
+
+```sql
+-- Case-insensitive name search
+CREATE INDEX idx_lower_name ON users (LOWER(name));
+
+-- Index a specific JSON field
+CREATE INDEX idx_payload_uid ON events (payload ->> 'uid');
+
+-- Index a date-truncated timestamp
+CREATE INDEX idx_orders_day ON orders (DATE_TRUNC('day', created_at));
+```
+
+Queries that use the same expression in their predicate benefit automatically:
+
+```sql
+-- Uses idx_lower_name
+SELECT * FROM users WHERE LOWER(name) = 'alice';
+
+-- Uses idx_payload_uid
+SELECT * FROM events WHERE payload ->> 'uid' = '42';
+```
+
+---
+
+## Covering indexes (index-only scans)
+
+When all columns referenced by a query are present in the index, MiniSQL performs an **index-only scan** — it reads only the index pages and skips main-table pages entirely.
+
+```sql
+-- Include extra columns in the index for covering queries
+CREATE INDEX idx_orders_user_amount ON orders (user_id, amount);
+
+-- Index-only scan: only user_id and amount are needed
+SELECT user_id, SUM(amount) FROM orders GROUP BY user_id;
+```
+
+Use `EXPLAIN` to verify:
+
+```sql
+EXPLAIN SELECT user_id, SUM(amount) FROM orders GROUP BY user_id;
+-- op: IndexOnlyScan  index: idx_orders_user_amount
+```
+
+---
+
+## Dropping B-tree indexes
+
+```sql
+DROP INDEX idx_users_created;
+DROP INDEX idx_orders_user_status;
+```
+
+Dropping a primary key index requires dropping the table.
+
+---
+
+## Notes
+
+- B-tree indexes are stored as independent B+ trees with doubly-linked leaf pages.
+- `VARCHAR(n)` and `UUID` columns can be indexed; `TEXT` columns can be indexed only via expression indexes.
+- The planner uses table statistics from `ANALYZE` to choose between indexes.
+- `CREATE UNIQUE INDEX` enforces uniqueness at the storage level.
+- Composite primary keys (`PRIMARY KEY (col1, col2)`) use a composite B-tree key.

--- a/docs/indexes/fulltext.md
+++ b/docs/indexes/fulltext.md
@@ -1,0 +1,104 @@
+# Full-text Search
+
+Full-text search lets you find rows where a text column contains specific words or phrases, using an efficient inverted index instead of a slow `LIKE '%…%'` scan.
+
+---
+
+## Creating a full-text index
+
+```sql
+CREATE FULLTEXT INDEX idx_articles_body ON articles (body)
+    WITH (tokenizer = 'simple');
+```
+
+The only supported tokenizer is `simple`:
+
+- Lowercases the input.
+- Splits on whitespace and punctuation.
+- Does not apply stemming or stop-word removal.
+
+!!! note
+    A full-text index can only be created on `TEXT` or `VARCHAR` columns.
+
+---
+
+## Querying with MATCH
+
+`MATCH(column, query)` returns `true` if the column's text contains all query tokens:
+
+```sql
+SELECT id, body
+FROM articles
+WHERE MATCH(body, 'database storage');
+```
+
+The query string is tokenized the same way as the indexed documents. All tokens must be present for a row to match.
+
+---
+
+## Ranking with TS_RANK
+
+`TS_RANK(column, query)` returns a relevance score as `DOUBLE`:
+
+```sql
+SELECT id, TS_RANK(body, 'database storage') AS score
+FROM articles
+WHERE MATCH(body, 'database storage')
+ORDER BY score DESC
+LIMIT 10;
+```
+
+The ranking considers:
+
+- Term frequency — how often each query token appears in the document.
+- Proximity — tokens that appear close together score higher.
+
+---
+
+## Index-accelerated search
+
+When the query planner detects a `MATCH(col, query)` predicate and a full-text index exists on `col`, it uses the inverted index to find matching row IDs without scanning the table:
+
+```sql
+EXPLAIN SELECT * FROM articles WHERE MATCH(body, 'database storage');
+-- op: FullTextIndexScan  index: idx_articles_body
+```
+
+Without a full-text index, `MATCH` falls back to a full table scan.
+
+---
+
+## Full example
+
+```sql
+-- Create table and index
+CREATE TABLE articles (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    title VARCHAR(255) NOT NULL,
+    body  TEXT NOT NULL
+);
+
+CREATE FULLTEXT INDEX idx_articles_body ON articles (body)
+    WITH (tokenizer = 'simple');
+
+-- Insert rows
+INSERT INTO articles (title, body) VALUES
+    ('Intro to SQL',      'SQL is a language for managing relational databases'),
+    ('Storage Engines',   'Database storage engines manage how data is persisted'),
+    ('Query Optimisation','The query planner selects the best index for each query');
+
+-- Search
+SELECT id, title, TS_RANK(body, 'database storage') AS score
+FROM articles
+WHERE MATCH(body, 'database storage')
+ORDER BY score DESC;
+```
+
+---
+
+## Notes
+
+- `MATCH` and `TS_RANK` can be used without a full-text index — they will scan all rows in that case.
+- The full-text index is updated automatically on every `INSERT`, `UPDATE`, and `DELETE`.
+- Drop the index with `DROP INDEX idx_articles_body`.
+- `PRAGMA integrity_check` verifies the consistency of full-text index entries.

--- a/docs/indexes/hnsw.md
+++ b/docs/indexes/hnsw.md
@@ -1,0 +1,132 @@
+# HNSW Vector Index
+
+HNSW (Hierarchical Navigable Small World) is a graph-based algorithm for approximate nearest-neighbour (ANN) search on high-dimensional vectors. It enables sub-linear similarity search over `VECTOR(n)` columns.
+
+---
+
+## Creating an HNSW index
+
+```sql
+CREATE HNSW INDEX idx_embedding ON documents (embedding)
+    WITH (m = 16, ef_construction = 200);
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `m` | 16 | Maximum bidirectional links per node. Higher values improve recall but increase build time and memory. |
+| `ef_construction` | 200 | Beam width during graph construction. Higher values improve graph quality but slow down builds. |
+
+The index can only be created on a `VECTOR(n)` column.
+
+---
+
+## Querying with vector distance
+
+### L2 (Euclidean) distance
+
+```sql
+SELECT id, body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
+
+### Cosine distance
+
+```sql
+SELECT id, body, VEC_COSINE(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
+
+When the query planner detects `ORDER BY VEC_L2(col, ?) LIMIT n` or `ORDER BY VEC_COSINE(col, ?) LIMIT n` and an HNSW index exists on `col`, it performs an ANN search through the HNSW graph instead of scanning all rows:
+
+```sql
+EXPLAIN
+SELECT id, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist LIMIT 5;
+-- op: HNSWSearch  index: idx_embedding
+```
+
+---
+
+## Full example
+
+```sql
+-- Create table
+CREATE TABLE documents (
+    id        INT8       PRIMARY KEY AUTOINCREMENT,
+    body      TEXT       NOT NULL,
+    embedding VECTOR(3)  NOT NULL
+);
+
+-- Create HNSW index
+CREATE HNSW INDEX idx_docs_embedding ON documents (embedding)
+    WITH (m = 16, ef_construction = 200);
+
+-- Insert rows
+INSERT INTO documents (body, embedding) VALUES
+    ('hello world',     '[0.1, 0.2, 0.3]'),
+    ('foo bar baz',     '[0.4, 0.5, 0.6]'),
+    ('database engine', '[0.7, 0.8, 0.9]');
+
+-- Find 2 nearest neighbours by L2 distance
+SELECT id, body, VEC_L2(embedding, '[0.15, 0.25, 0.35]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 2;
+```
+
+---
+
+## Inserting vectors
+
+Vectors are passed as bracket-delimited strings or `[]float32` bind parameters:
+
+```go
+// String literal
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", "[0.1, 0.2, 0.3]",
+)
+
+// []float32 bind parameter
+vec := []float32{0.1, 0.2, 0.3}
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", vec,
+)
+```
+
+---
+
+## Online DML maintenance
+
+The HNSW index is kept up to date automatically:
+
+- **INSERT** — new vectors are added as nodes in the graph.
+- **DELETE** — deleted nodes are marked as tombstoned; they are excluded from search results and lazily reclaimed during compaction.
+- **UPDATE** — treated as delete + insert.
+
+---
+
+## Dropping an HNSW index
+
+```sql
+DROP INDEX idx_docs_embedding;
+```
+
+---
+
+## Notes
+
+- The vector dimension `n` is fixed at table creation time. All inserted vectors must have exactly `n` components.
+- HNSW search is *approximate* — it may miss some true nearest neighbours in exchange for speed. Increasing `ef_construction` and `m` improves recall at the cost of build time and memory.
+- `PRAGMA integrity_check` verifies HNSW page structure and overflow page chains.
+- The HNSW graph is persisted across restarts and carried through `VACUUM` and encryption.
+
+See [Vector Search](../vector-search.md) for the complete vector type and distance function reference.

--- a/docs/indexes/json-inverted.md
+++ b/docs/indexes/json-inverted.md
@@ -1,0 +1,103 @@
+# JSON Inverted Index
+
+A JSON inverted index accelerates containment queries on `JSON` columns. Instead of deserialising every row to check a JSON predicate, the index maps JSON values to the row IDs that contain them.
+
+---
+
+## Creating an inverted index
+
+```sql
+CREATE INVERTED INDEX idx_events_payload ON events (payload);
+```
+
+The index is built on a `JSON` column. No additional options are required.
+
+---
+
+## Querying with JSON_CONTAINS
+
+`JSON_CONTAINS(column, value)` returns `true` if the JSON column contains the given value as a sub-document or array element:
+
+```sql
+-- Object containment
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '{"action": "login"}');
+
+-- Scalar value in any position
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '"go"');
+
+-- Nested object
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '{"user": {"role": "admin"}}');
+```
+
+---
+
+## Index-accelerated queries
+
+When the query planner detects a `JSON_CONTAINS(col, val)` predicate and an inverted index exists on `col`, it uses the index to look up matching row IDs directly:
+
+```sql
+EXPLAIN SELECT * FROM events WHERE JSON_CONTAINS(payload, '{"action": "login"}');
+-- op: InvertedIndexScan  index: idx_events_payload
+```
+
+Without an inverted index, `JSON_CONTAINS` falls back to a full table scan with per-row JSON deserialization.
+
+---
+
+## Combining with other predicates
+
+```sql
+-- Inverted index for the JSON filter; B-tree index for created_at range
+SELECT * FROM events
+WHERE JSON_CONTAINS(payload, '{"type": "purchase"}')
+  AND created_at > '2024-01-01 00:00:00';
+
+-- With ORDER BY and LIMIT
+SELECT id, payload ->> 'user' AS user
+FROM events
+WHERE JSON_CONTAINS(payload, '{"action": "signup"}')
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+---
+
+## Full example
+
+```sql
+-- Create table and index
+CREATE TABLE events (
+    id         INT8 PRIMARY KEY AUTOINCREMENT,
+    created_at TIMESTAMP DEFAULT NOW(),
+    payload    JSON NOT NULL
+);
+
+CREATE INVERTED INDEX idx_events_payload ON events (payload);
+
+-- Insert events
+INSERT INTO events (payload) VALUES
+    ('{"action": "login",  "user": "alice", "ip": "1.2.3.4"}'),
+    ('{"action": "signup", "user": "bob",   "plan": "free"}'),
+    ('{"action": "login",  "user": "carol", "ip": "5.6.7.8"}'),
+    ('{"tags": ["go", "sql", "database"]}');
+
+-- Find all login events
+SELECT id, payload ->> 'user' AS user
+FROM events
+WHERE JSON_CONTAINS(payload, '{"action": "login"}');
+
+-- Find events tagged "go"
+SELECT id FROM events
+WHERE JSON_CONTAINS(payload, '"go"');
+```
+
+---
+
+## Notes
+
+- The inverted index is updated automatically on every `INSERT`, `UPDATE`, and `DELETE`.
+- `JSON_CONTAINS` can be used without an inverted index — it will scan all rows in that case.
+- The index handles both JSON objects and JSON arrays.
+- Drop the index with `DROP INDEX idx_events_payload`.
+
+See [JSON](../json.md) for the full JSON type and operator reference, including `->`, `->>`, `JSON_EXTRACT`, `JSON_TYPE`, and `JSON_ARRAY_LENGTH`.

--- a/docs/indexes/overview.md
+++ b/docs/indexes/overview.md
@@ -1,0 +1,77 @@
+# Index Overview
+
+MiniSQL supports four index types. The query planner automatically selects the best index for each query.
+
+## Index types
+
+| Type | Best for | SQL |
+|------|----------|-----|
+| [B-tree](btree.md) | Equality, range, ORDER BY, covering | `CREATE INDEX` |
+| [Full-text](fulltext.md) | Token search in TEXT columns | `CREATE FULLTEXT INDEX` |
+| [JSON inverted](json-inverted.md) | Containment queries on JSON columns | `CREATE INVERTED INDEX` |
+| [HNSW vector](hnsw.md) | Approximate nearest-neighbour on VECTOR columns | `CREATE HNSW INDEX` |
+
+---
+
+## Creating indexes
+
+```sql
+-- B-tree secondary index
+CREATE INDEX idx_users_email ON users (email);
+
+-- Unique B-tree index
+CREATE UNIQUE INDEX idx_users_email ON users (email);
+
+-- Composite B-tree index
+CREATE INDEX idx_orders_user_created ON orders (user_id, created_at);
+
+-- Partial index (only indexes matching rows)
+CREATE INDEX idx_active_users ON users (email) WHERE active = true;
+
+-- Expression index
+CREATE INDEX idx_lower_name ON users (LOWER(name));
+
+-- Full-text index
+CREATE FULLTEXT INDEX idx_articles_body ON articles (body)
+    WITH (tokenizer = 'simple');
+
+-- JSON inverted index
+CREATE INVERTED INDEX idx_events_payload ON events (payload);
+
+-- HNSW vector index
+CREATE HNSW INDEX idx_embedding ON documents (embedding)
+    WITH (m = 16, ef_construction = 200);
+```
+
+---
+
+## Dropping indexes
+
+```sql
+DROP INDEX index_name;
+```
+
+---
+
+## Index selection by the planner
+
+The planner chooses among all available indexes based on cost estimates:
+
+- **Equality predicate** (`col = ?`) → B-tree index on `col`
+- **Range predicate** (`col > ?`, `BETWEEN`) → B-tree range scan
+- **Leading column of composite index** → B-tree index scan with trailing filter
+- **Covering index** (all needed columns in the index) → index-only scan, no main-table page reads
+- **MATCH(col, query)** → fulltext index on `col`
+- **JSON_CONTAINS(col, val)** → inverted index on `col`
+- **ORDER BY dist LIMIT n** where `dist = VEC_L2(col, ?)` → HNSW ANN search
+
+Use `EXPLAIN` to inspect the chosen plan. Use `ANALYZE table_name` to refresh statistics.
+
+---
+
+## Index maintenance
+
+- Indexes are updated automatically on every `INSERT`, `UPDATE`, and `DELETE`.
+- HNSW indexes support online DML — inserts add new nodes; deletes mark nodes as deleted and are lazily reclaimed.
+- `DROP INDEX` removes the index immediately; space is reclaimed by `VACUUM`.
+- `PRAGMA integrity_check` verifies that every index entry matches the corresponding table row.

--- a/docs/json.md
+++ b/docs/json.md
@@ -1,0 +1,148 @@
+# JSON
+
+MiniSQL has a native `JSON` column type that validates and stores JSON data. JSON columns support path navigation with `->` / `->>` operators, containment queries with `JSON_CONTAINS`, and optional inverted index acceleration.
+
+---
+
+## The JSON type
+
+```sql
+CREATE TABLE events (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    created TIMESTAMP DEFAULT NOW(),
+    payload JSON NOT NULL
+);
+```
+
+- Values must be valid JSON; invalid JSON is rejected on insert and update.
+- Stored as compact UTF-8 text (whitespace is not preserved).
+- Size is unlimited (large values use overflow pages).
+- Validated automatically — no application-level validation needed.
+
+---
+
+## Inserting JSON
+
+```sql
+-- JSON object
+INSERT INTO events (payload) VALUES ('{"action": "login", "user": "alice", "uid": 42}');
+
+-- JSON array
+INSERT INTO events (payload) VALUES ('["go", "sql", "database"]');
+
+-- Nested
+INSERT INTO events (payload) VALUES ('{"meta": {"version": 2}, "tags": ["a", "b"]}');
+```
+
+In Go:
+
+```go
+_, err = db.Exec(
+    `INSERT INTO events (payload) VALUES (?)`,
+    `{"action": "purchase", "amount": 99.99}`,
+)
+```
+
+---
+
+## Path operators
+
+### `->` — JSON fragment
+
+Returns the value at a key or array index as a JSON string.
+
+```sql
+SELECT payload -> 'action'  FROM events;   -- '"login"'
+SELECT payload -> 'user'    FROM events;   -- '"alice"'
+SELECT payload -> 0         FROM events;   -- first element as JSON
+```
+
+### `->>` — SQL scalar
+
+Returns the value as a SQL string or number.
+
+```sql
+SELECT payload ->> 'action' FROM events;   -- 'login'
+SELECT payload ->> 'uid'    FROM events;   -- '42'
+SELECT payload ->> 0        FROM events;   -- first element as string
+```
+
+### Chaining
+
+```sql
+SELECT payload -> 'meta' -> 'version' FROM events;   -- '2' (JSON)
+SELECT payload -> 'meta' ->> 'version' FROM events;  -- '2' (scalar)
+```
+
+---
+
+## Filtering on JSON fields
+
+```sql
+-- Equality on extracted scalar
+SELECT * FROM events WHERE payload ->> 'action' = 'login';
+
+-- Numeric comparison (cast to INT8 first)
+SELECT * FROM events WHERE CAST(payload ->> 'uid' AS INT8) > 100;
+
+-- Nested field
+SELECT * FROM events WHERE payload -> 'meta' ->> 'version' = '2';
+
+-- Array element
+SELECT * FROM events WHERE payload ->> 0 = 'go';
+```
+
+---
+
+## JSON functions
+
+| Function | Description |
+|----------|-------------|
+| `JSON_CONTAINS(json, val)` | True if json contains val as a sub-document or element |
+| `JSON_EXTRACT(json, path)` | Extract scalar at path |
+| `JSON_TYPE(json [, path])` | Type of the JSON value: `'object'`, `'array'`, `'string'`, `'number'`, `'boolean'`, `'null'` |
+| `JSON_ARRAY_LENGTH(json [, path])` | Number of elements in a JSON array |
+| `JSON_VALID(json)` | 1 if valid JSON, 0 otherwise |
+
+See [JSON Functions](functions/json.md) for full examples.
+
+---
+
+## JSON inverted index
+
+For fast containment queries, create an inverted index on a JSON column:
+
+```sql
+CREATE INVERTED INDEX idx_events_payload ON events (payload);
+
+-- Index-accelerated containment query
+SELECT * FROM events WHERE JSON_CONTAINS(payload, '{"action": "login"}');
+```
+
+See [JSON Inverted Index](indexes/json-inverted.md) for details.
+
+---
+
+## Examples
+
+```sql
+-- Create table with JSON column
+CREATE TABLE sessions (
+    id      UUID      PRIMARY KEY,
+    user_id INT8      NOT NULL,
+    meta    JSON
+);
+
+INSERT INTO sessions (id, user_id, meta) VALUES
+    ('550e8400-e29b-41d4-a716-446655440001', 1, '{"ip": "1.2.3.4", "ua": "Firefox"}'),
+    ('550e8400-e29b-41d4-a716-446655440002', 2, '{"ip": "5.6.7.8", "ua": "Chrome"}');
+
+-- Find sessions from a specific IP
+SELECT user_id FROM sessions WHERE meta ->> 'ip' = '1.2.3.4';
+
+-- Aggregate by user-agent family
+SELECT meta ->> 'ua' AS browser, COUNT(*) AS cnt
+FROM sessions
+GROUP BY meta ->> 'ua'
+ORDER BY cnt DESC;
+```

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,80 @@
+# Limitations
+
+MiniSQL is a research and learning project, not yet production-ready. This page lists known limitations and workarounds.
+
+---
+
+## SQL features not yet implemented
+
+| Feature | Notes |
+|---------|-------|
+| Recursive CTEs (`WITH RECURSIVE`) | Non-recursive CTEs are fully supported |
+| Savepoints (`SAVEPOINT`, `RELEASE`, `ROLLBACK TO`) | Full transaction rollback is supported |
+| `TRUNCATE TABLE` | Use `DELETE FROM table_name WHERE true` instead |
+| `CREATE TABLE AS SELECT` | Use a regular `CREATE TABLE` followed by `INSERT INTO … SELECT` |
+| `INSERT INTO … SELECT` | Not yet supported |
+| `MERGE` / `UPSERT` by conflict target | `ON CONFLICT DO NOTHING / DO UPDATE` is supported but without explicit conflict-column targeting |
+| `FULL OUTER JOIN` | INNER, LEFT, and RIGHT JOINs are supported |
+| `CROSS JOIN` | Not supported |
+| Lateral joins | Not supported |
+
+---
+
+## Parser limitations
+
+| Limitation | Workaround |
+|-----------|------------|
+| Negative integer literals rejected | Use `?` bind parameter with a negative `int64` value: `db.Exec("… WHERE n > ?", int64(-1))` |
+| `FROM table alias` (bare alias) | Use `FROM table AS alias` |
+| `HAVING` does not accept `?` placeholders | Use literal values in HAVING conditions |
+| `DELETE` always requires `WHERE` | Use `DELETE FROM t WHERE true` to delete all rows |
+
+---
+
+## Type system limitations
+
+| Limitation | Notes |
+|-----------|-------|
+| Maximum 64 columns per table | Enforced by the 64-bit NULL bitmask per row |
+| No `INTERVAL` column type | `INTERVAL` literals are supported in arithmetic expressions only |
+| No `DECIMAL` / `NUMERIC` types | Use `INT8` for fixed-precision integers or `DOUBLE` for approximation |
+| `TEXT` columns cannot be primary keys or unique-index keys | Use `VARCHAR(n)` for indexed string columns |
+| No multi-value `IN` bind parameter | List values individually or use a subquery |
+
+---
+
+## Concurrency limitations
+
+| Limitation | Notes |
+|-----------|-------|
+| Single connection recommended | MiniSQL's OCC write lock and shared pager are not safe with multiple concurrent connections from different `sql.DB` pools. Set `MaxOpenConns(1)`. |
+| No WAL group commit | Each write transaction flushes to the WAL individually |
+| Checkpoint blocked by active readers | `PRAGMA wal_checkpoint` waits until all snapshot readers finish |
+
+---
+
+## Storage limitations
+
+| Limitation | Notes |
+|-----------|-------|
+| No connection pooling | `db.SetMaxOpenConns(1)` is required |
+| No online backup API | Use `VACUUM` to compact; copy the file while no writes are active |
+| No key rotation for encryption | Re-encrypt by opening with old key, then VACUUM (planned feature) |
+| `VACUUM` requires exclusive access | Blocks all other connections for its duration |
+
+---
+
+## Not yet implemented
+
+- Metrics / observability API (`db.Stats()` equivalent beyond the standard `database/sql` pool stats)
+- `CREATE VIEW`
+- `CREATE TRIGGER`
+- `ALTER TABLE … MODIFY COLUMN` (type changes)
+- `ALTER TABLE … ADD CONSTRAINT` after table creation
+- `RETURNING` on `UPDATE` and `DELETE` with subquery targets
+
+---
+
+## Reporting issues
+
+If you encounter a bug or unexpected behaviour, please open an issue at [github.com/RichardKnop/minisql](https://github.com/RichardKnop/minisql/issues).

--- a/docs/sql/create-table.md
+++ b/docs/sql/create-table.md
@@ -1,0 +1,207 @@
+# CREATE / ALTER / DROP
+
+## CREATE TABLE
+
+```sql
+CREATE TABLE table_name (
+    column_name data_type [column_constraint ...],
+    ...
+    [table_constraint, ...]
+);
+```
+
+### Column constraints
+
+| Constraint | Description |
+|-----------|-------------|
+| `PRIMARY KEY` | Unique B-tree key for the table. One per table. |
+| `PRIMARY KEY AUTOINCREMENT` | Auto-incrementing primary key. Requires `INT8`. |
+| `NOT NULL` | Rejects NULL on insert/update. |
+| `NULL` | Explicitly marks column as nullable (default). |
+| `UNIQUE` | Creates a unique index on this column. |
+| `DEFAULT value` | Default value when column is omitted from INSERT. |
+| `DEFAULT NOW()` | Default current UTC timestamp for TIMESTAMP columns. |
+| `CHECK (expr)` | Rejects rows where expression is false. |
+| `REFERENCES table (col)` | Inline foreign key. |
+
+### Table constraints
+
+| Constraint | Description |
+|-----------|-------------|
+| `PRIMARY KEY (col, ...)` | Composite primary key. |
+| `UNIQUE (col, ...)` | Composite unique constraint. |
+| `FOREIGN KEY (col) REFERENCES table (col)` | Table-level foreign key. |
+| `CONSTRAINT name FOREIGN KEY ...` | Named foreign key. |
+
+### Examples
+
+**Simple table with autoincrement primary key:**
+
+```sql
+CREATE TABLE users (
+    id      INT8         PRIMARY KEY AUTOINCREMENT,
+    email   VARCHAR(255) NOT NULL UNIQUE,
+    name    TEXT,
+    active  BOOLEAN      NOT NULL DEFAULT true,
+    created TIMESTAMP    DEFAULT NOW()
+);
+```
+
+**Table with CHECK constraint:**
+
+```sql
+CREATE TABLE products (
+    id    INT8 PRIMARY KEY AUTOINCREMENT,
+    name  TEXT NOT NULL,
+    price INT8 NOT NULL CHECK (price > 0),
+    qty   INT8 NOT NULL DEFAULT 0 CHECK (qty >= 0)
+);
+```
+
+**Table with composite primary key:**
+
+```sql
+CREATE TABLE memberships (
+    user_id   INT8 NOT NULL,
+    org_id    INT8 NOT NULL,
+    role      VARCHAR(50),
+    joined_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (user_id, org_id)
+);
+```
+
+**Table with composite UNIQUE constraint:**
+
+```sql
+CREATE TABLE tags (
+    id       INT8         PRIMARY KEY AUTOINCREMENT,
+    post_id  INT8         NOT NULL,
+    tag_name VARCHAR(100) NOT NULL,
+    UNIQUE (post_id, tag_name)
+);
+```
+
+**Table with foreign key:**
+
+```sql
+CREATE TABLE orders (
+    id         INT8 PRIMARY KEY AUTOINCREMENT,
+    user_id    INT8 NOT NULL REFERENCES users (id),
+    product_id INT8 NOT NULL,
+    amount     INT8 NOT NULL CHECK (amount > 0),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+**Table-level named foreign key:**
+
+```sql
+CREATE TABLE orders (
+    id      INT8 PRIMARY KEY AUTOINCREMENT,
+    user_id INT8 NOT NULL,
+    amount  INT8 NOT NULL,
+    CONSTRAINT fk_orders_users FOREIGN KEY (user_id) REFERENCES users (id)
+);
+```
+
+**Table with JSON, UUID, and VECTOR columns:**
+
+```sql
+CREATE TABLE documents (
+    id        INT8      PRIMARY KEY AUTOINCREMENT,
+    ref_id    UUID,
+    metadata  JSON,
+    body      TEXT      NOT NULL,
+    embedding VECTOR(768) NOT NULL
+);
+```
+
+## CREATE TABLE IF NOT EXISTS
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+    id    INT8         PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) UNIQUE,
+    name  TEXT,
+    created TIMESTAMP DEFAULT NOW()
+);
+```
+
+Silently does nothing if the table already exists. Useful for idempotent schema initialisation.
+
+---
+
+## DROP TABLE
+
+```sql
+DROP TABLE table_name;
+```
+
+Removes the table and all its indexes. Fails if the table has child rows referencing it via a foreign key (when `PRAGMA foreign_keys = on`, which is the default).
+
+---
+
+## ALTER TABLE
+
+### ADD COLUMN
+
+```sql
+ALTER TABLE users ADD COLUMN score INT4;
+ALTER TABLE users ADD COLUMN nickname VARCHAR(64);
+ALTER TABLE users ADD COLUMN active BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE users ADD COLUMN metadata JSON;
+```
+
+!!! note
+    The new column is added as nullable or with the specified DEFAULT. Existing rows get the DEFAULT value (or NULL if no default).
+
+### DROP COLUMN
+
+```sql
+ALTER TABLE users DROP COLUMN internal_note;
+```
+
+Marks the column as **dropped** in the DDL (tombstone). Existing rows retain the bytes on disk but the column is invisible to SQL. The space is reclaimed by `VACUUM`.
+
+### RENAME COLUMN
+
+```sql
+ALTER TABLE users RENAME COLUMN nm TO full_name;
+ALTER TABLE users RENAME COLUMN ts TO created_at;
+```
+
+### RENAME TABLE
+
+```sql
+ALTER TABLE users RENAME TO members;
+```
+
+Renames the table and updates all schema references. Indexes are updated automatically.
+
+---
+
+## CREATE INDEX
+
+See [Indexes](../indexes/overview.md) for the full index reference.
+
+```sql
+-- B-tree secondary index
+CREATE INDEX idx_users_created ON users (created);
+
+-- Fulltext index
+CREATE FULLTEXT INDEX idx_articles_body ON articles (body)
+    WITH (tokenizer = 'simple');
+
+-- JSON inverted index
+CREATE INVERTED INDEX idx_events_payload ON events (payload);
+
+-- HNSW vector index
+CREATE HNSW INDEX idx_embedding ON documents (embedding)
+    WITH (m = 16, ef_construction = 200);
+```
+
+## DROP INDEX
+
+```sql
+DROP INDEX index_name;
+```

--- a/docs/sql/delete.md
+++ b/docs/sql/delete.md
@@ -1,0 +1,85 @@
+# DELETE
+
+## Basic syntax
+
+```sql
+DELETE FROM table_name
+WHERE condition
+[RETURNING column_list]
+```
+
+!!! warning
+    MiniSQL requires a `WHERE` clause on every `DELETE`. A DELETE without a WHERE clause is a parse error. To remove all rows, use `DELETE FROM table_name WHERE true` or `TRUNCATE` (not yet implemented).
+
+---
+
+## Basic DELETE
+
+```sql
+-- Delete one row by primary key
+DELETE FROM users WHERE id = 1;
+
+-- Delete by condition
+DELETE FROM sessions WHERE expires < '2024-01-01 00:00:00';
+
+-- Delete with multiple conditions
+DELETE FROM orders WHERE user_id = 5 AND status = 'cancelled';
+
+-- Delete with bind parameters
+DELETE FROM tokens WHERE user_id = ? AND token = ?;
+```
+
+---
+
+## DELETE with RETURNING
+
+`RETURNING` makes DELETE behave like a query — it returns the deleted rows.
+
+```sql
+-- Return the deleted row's id
+DELETE FROM users WHERE id = 1 RETURNING id;
+
+-- Return multiple columns
+DELETE FROM sessions WHERE expires < NOW() RETURNING id, user_id;
+```
+
+In Go:
+
+```go
+rows, err := db.Query(
+    `DELETE FROM sessions WHERE expires < ? RETURNING id, user_id`,
+    time.Now(),
+)
+defer rows.Close()
+for rows.Next() {
+    var id, userID int64
+    rows.Scan(&id, &userID)
+    // handle deleted session
+}
+```
+
+---
+
+## DELETE with subquery
+
+```sql
+-- Delete orders for banned users
+DELETE FROM orders
+WHERE user_id IN (SELECT id FROM users WHERE banned = true);
+
+-- Delete the oldest sessions, keeping only the 10 most recent per user
+DELETE FROM sessions
+WHERE id NOT IN (
+    SELECT id FROM sessions
+    ORDER BY created_at DESC
+    LIMIT 10
+);
+```
+
+---
+
+## Notes
+
+- Foreign-key constraints are checked on delete when `PRAGMA foreign_keys = on` (the default). Deleting a parent row that has child rows referencing it returns an error.
+- `RETURNING` returns the row values *before* deletion — useful for audit logging or cascading application logic.
+- To delete all rows efficiently, use `DELETE FROM table_name WHERE true`.

--- a/docs/sql/explain.md
+++ b/docs/sql/explain.md
@@ -1,0 +1,158 @@
+# EXPLAIN, ANALYZE, VACUUM & PRAGMA
+
+## EXPLAIN
+
+`EXPLAIN` shows the query plan the engine will use without executing the query:
+
+```sql
+EXPLAIN SELECT * FROM users WHERE id = 1;
+EXPLAIN SELECT * FROM users WHERE email = 'alice@example.com';
+EXPLAIN SELECT u.name, COUNT(*) FROM users u JOIN orders o ON u.id = o.user_id GROUP BY u.name;
+```
+
+The output includes:
+
+| Column | Description |
+|--------|-------------|
+| `op` | Operator name (e.g., `SeqScan`, `IndexScan`, `HashJoin`) |
+| `table` | Table being accessed |
+| `index` | Index used, if any |
+| `filter` | Predicate applied at this node |
+| `est_rows` | Estimated output row count |
+| `est_cost` | Estimated cost |
+
+---
+
+## EXPLAIN ANALYZE
+
+`EXPLAIN ANALYZE` executes the query and augments the plan with actual runtime statistics:
+
+```sql
+EXPLAIN ANALYZE SELECT * FROM users WHERE id = 1;
+EXPLAIN ANALYZE SELECT * FROM articles WHERE MATCH(body, 'database storage');
+```
+
+Additional columns in the output:
+
+| Column | Description |
+|--------|-------------|
+| `actual_rows` | Rows actually produced |
+| `actual_time_ms` | Time spent in this node (milliseconds) |
+| `loops` | Number of times this node was invoked |
+
+---
+
+## ANALYZE
+
+`ANALYZE` collects table statistics that the query planner uses to estimate row counts, select indexes, and order joins:
+
+```sql
+-- Analyze one table
+ANALYZE users;
+
+-- Analyze multiple tables
+ANALYZE users, orders, products;
+```
+
+Statistics collected:
+
+- Row count
+- Column cardinality (distinct value count)
+- Histograms of value distribution
+- Most-common values (MCV) per column
+
+Run `ANALYZE` after large bulk inserts or updates to keep the planner's estimates accurate.
+
+---
+
+## VACUUM
+
+`VACUUM` compacts the database file by rewriting all live data into a fresh file, reclaiming space from deleted rows, dropped columns, and freed pages:
+
+```sql
+VACUUM;
+```
+
+What VACUUM does:
+
+1. Creates a new database file alongside the original.
+2. Copies all live B-tree pages (tables and indexes) into the new file.
+3. Resets the free-page list.
+4. Replaces the original file with the compacted copy.
+5. Carries encryption through — if the database is encrypted, the new file is encrypted with the same key.
+
+!!! note
+    VACUUM requires exclusive access and blocks other connections for its duration. It is safe to run at any time and is fully crash-safe; an interrupted VACUUM leaves the original file intact.
+
+---
+
+## PRAGMA
+
+PRAGMAs control database engine settings at runtime.
+
+### `PRAGMA synchronous`
+
+Controls WAL fsync behaviour:
+
+```sql
+PRAGMA synchronous;           -- read current mode (returns 0, 1, or 2)
+PRAGMA synchronous = off;     -- no fsync (0) — fastest, least durable
+PRAGMA synchronous = normal;  -- periodic fsync (1) — default
+PRAGMA synchronous = full;    -- fsync on every commit (2) — safest
+```
+
+| Mode | Value | Behaviour |
+|------|-------|-----------|
+| `off` | 0 | No `fsync` calls. Best throughput; data may be lost on power failure. |
+| `normal` | 1 | `fsync` during checkpoint. Default. Safe under most failure scenarios. |
+| `full` | 2 | `fsync` after every commit. Maximum durability, lowest throughput. |
+
+### `PRAGMA foreign_keys`
+
+Enable or disable foreign-key constraint enforcement (enabled by default):
+
+```sql
+PRAGMA foreign_keys;          -- read current state (1 = on, 0 = off)
+PRAGMA foreign_keys = on;
+PRAGMA foreign_keys = off;
+```
+
+### `PRAGMA parallel_scan`
+
+Enable parallel table scans using multiple goroutines:
+
+```sql
+PRAGMA parallel_scan;         -- read current state (1 = on, 0 = off)
+PRAGMA parallel_scan = on;
+PRAGMA parallel_scan = off;   -- default
+```
+
+Parallel scan uses a goroutine pool to read pages concurrently. Beneficial for large full-table scans on multi-core machines. Can also be set via the DSN connection string parameter `parallel_scan=true`.
+
+### `PRAGMA wal_checkpoint`
+
+Flush all WAL frames to the main database file and truncate the WAL:
+
+```sql
+PRAGMA wal_checkpoint;
+```
+
+Checkpoint blocks if any read-only snapshot transaction is active; it resumes automatically once all readers finish. See [Architecture](../architecture.md) for WAL details.
+
+### `PRAGMA integrity_check`
+
+Full integrity check of all B-tree pages, CRC32 checksums, cell ordering, overflow page chains, and index consistency:
+
+```sql
+PRAGMA integrity_check;
+```
+
+Returns one row per issue found, or a single `ok` row if the database is healthy.
+
+### `PRAGMA quick_check`
+
+Faster subset of `integrity_check` — checks page structure and checksums but skips cross-index consistency:
+
+```sql
+PRAGMA quick_check;
+```

--- a/docs/sql/insert.md
+++ b/docs/sql/insert.md
@@ -1,0 +1,201 @@
+# INSERT
+
+## Basic INSERT
+
+```sql
+INSERT INTO table_name (col1, col2, ...) VALUES (val1, val2, ...);
+```
+
+### Single row
+
+```sql
+INSERT INTO users (email, name) VALUES ('alice@example.com', 'Alice');
+```
+
+### Multi-row
+
+```sql
+INSERT INTO users (email, name) VALUES
+    ('bob@example.com', 'Bob'),
+    ('carol@example.com', 'Carol'),
+    ('dave@example.com', 'Dave');
+```
+
+### Using DEFAULT values
+
+Omit columns that have defaults — they are filled in automatically:
+
+```sql
+-- active defaults to true, created defaults to NOW()
+INSERT INTO users (email, name) VALUES ('eve@example.com', 'Eve');
+
+-- Explicit NOW()
+INSERT INTO events (name, created) VALUES ('login', NOW());
+```
+
+### Bind parameters
+
+Always use `?` placeholders for user-supplied values:
+
+```go
+_, err = db.Exec(
+    `INSERT INTO users (email, name) VALUES (?, ?)`,
+    "frank@example.com", "Frank",
+)
+```
+
+### Prepared statements
+
+```go
+stmt, err := db.Prepare(`INSERT INTO users (email, name) VALUES (?, ?)`)
+defer stmt.Close()
+
+for _, u := range users {
+    _, err = stmt.Exec(u.Email, u.Name)
+}
+```
+
+---
+
+## ON CONFLICT
+
+### DO NOTHING
+
+Silently skip the row if a unique or primary-key constraint is violated:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice Duplicate')
+ON CONFLICT DO NOTHING;
+```
+
+### DO UPDATE (upsert)
+
+Update the existing row when there is a conflict:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice Updated')
+ON CONFLICT DO UPDATE SET name = 'Alice Updated';
+```
+
+Use the `EXCLUDED` pseudo-table to reference the values that were proposed for insertion:
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice V2')
+ON CONFLICT DO UPDATE SET name = EXCLUDED.name;
+```
+
+Multi-row upsert with `EXCLUDED`:
+
+```sql
+INSERT INTO users (email, name) VALUES
+    ('alice@example.com', 'Alice V3'),
+    ('bob@example.com',   'Bob V3')
+ON CONFLICT DO UPDATE SET name = EXCLUDED.name;
+```
+
+Update multiple columns:
+
+```sql
+INSERT INTO products (sku, name, price, stock)
+VALUES ('ABC-1', 'Widget', 999, 100)
+ON CONFLICT DO UPDATE
+    SET name  = EXCLUDED.name,
+        price = EXCLUDED.price,
+        stock = stock + EXCLUDED.stock;
+```
+
+---
+
+## RETURNING
+
+`RETURNING` makes INSERT behave like a query — it returns rows from the newly inserted data.
+
+### Return the generated primary key
+
+```go
+var newID int64
+err = db.QueryRow(
+    `INSERT INTO users (email, name) VALUES (?, ?) RETURNING id`,
+    "alice@example.com", "Alice",
+).Scan(&newID)
+```
+
+### Return multiple columns
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('bob@example.com', 'Bob')
+RETURNING id, name, email, created;
+```
+
+### Multi-row RETURNING
+
+```go
+rows, err := db.Query(`
+    INSERT INTO users (email, name) VALUES
+        ('carol@example.com', 'Carol'),
+        ('dave@example.com',  'Dave')
+    RETURNING id, name
+`)
+defer rows.Close()
+for rows.Next() {
+    var id int64
+    var name string
+    rows.Scan(&id, &name)
+}
+```
+
+### ON CONFLICT … RETURNING
+
+```sql
+INSERT INTO users (email, name)
+VALUES ('alice@example.com', 'Alice')
+ON CONFLICT DO UPDATE SET name = EXCLUDED.name
+RETURNING id, name;
+```
+
+---
+
+## Inserting JSON
+
+```sql
+INSERT INTO events (name, payload)
+VALUES ('login', '{"user":"alice","uid":42}');
+
+INSERT INTO events (name, payload)
+VALUES ('tags', '["go","sql","json"]');
+```
+
+## Inserting VECTOR data
+
+```go
+// String literal
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", "[0.1, 0.2, 0.3]",
+)
+
+// []float32 bind parameter
+vec := []float32{0.1, 0.2, 0.3}
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", vec,
+)
+```
+
+## Inserting UUID
+
+```sql
+INSERT INTO sessions (id, user_id)
+VALUES ('550e8400-e29b-41d4-a716-446655440000', 1);
+```
+
+Or use `CAST`:
+
+```sql
+INSERT INTO sessions (id, user_id)
+VALUES (CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID), 1);
+```

--- a/docs/sql/operators.md
+++ b/docs/sql/operators.md
@@ -1,0 +1,184 @@
+# Operators & WHERE
+
+## Comparison operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `=` | Equal | `WHERE id = 1` |
+| `<>` / `!=` | Not equal | `WHERE status <> 'active'` |
+| `<` | Less than | `WHERE price < 100` |
+| `<=` | Less than or equal | `WHERE age <= 18` |
+| `>` | Greater than | `WHERE score > 80` |
+| `>=` | Greater than or equal | `WHERE score >= 90` |
+
+---
+
+## Logical operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `AND` | Both conditions true | `WHERE active = true AND age >= 18` |
+| `OR` | Either condition true | `WHERE role = 'admin' OR role = 'owner'` |
+| `NOT` | Negates a condition | `WHERE NOT active` |
+
+`AND` binds more tightly than `OR`. Use parentheses to control grouping:
+
+```sql
+WHERE (status = 'pending' OR status = 'review') AND created > '2024-01-01 00:00:00'
+```
+
+---
+
+## Arithmetic operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `+` | Addition | `price + tax` |
+| `-` | Subtraction | `balance - amount` |
+| `*` | Multiplication | `price * quantity` |
+| `/` | Division | `total / count` |
+| `%` | Modulo | `id % 2` |
+
+```sql
+SELECT id, price * quantity AS total FROM order_lines;
+SELECT * FROM orders WHERE amount * 1.2 > 1000;
+```
+
+!!! warning "No negative integer literals"
+    The parser does not accept negative integer literals directly. Use a bind parameter instead:
+
+    ```go
+    db.Exec("SELECT * FROM t WHERE n > ?", int64(-1)) // ✅
+    // db.Exec("SELECT * FROM t WHERE n > -1")        // ❌ parse error
+    ```
+
+---
+
+## LIKE and ILIKE
+
+Pattern matching with `%` (any sequence) and `_` (single character):
+
+```sql
+SELECT * FROM users WHERE email LIKE '%@example.com';
+SELECT * FROM users WHERE name  LIKE 'Al%';
+SELECT * FROM users WHERE code  LIKE 'A_C';
+```
+
+`ILIKE` is case-insensitive:
+
+```sql
+SELECT * FROM users WHERE name ILIKE 'alice%';
+```
+
+---
+
+## BETWEEN … AND
+
+```sql
+SELECT * FROM users  WHERE score BETWEEN 80 AND 100;
+SELECT * FROM events WHERE created BETWEEN '2024-01-01 00:00:00' AND '2024-12-31 23:59:59';
+```
+
+`BETWEEN` is inclusive on both ends (equivalent to `>= low AND <= high`).
+
+---
+
+## IN and NOT IN
+
+Match against a literal list:
+
+```sql
+SELECT * FROM users WHERE id IN (1, 2, 3);
+SELECT * FROM orders WHERE status NOT IN ('cancelled', 'refunded');
+```
+
+Match against a subquery:
+
+```sql
+SELECT * FROM users WHERE id IN (SELECT user_id FROM orders WHERE amount > 100);
+SELECT * FROM users WHERE id NOT IN (SELECT user_id FROM banned_users);
+```
+
+---
+
+## IS NULL and IS NOT NULL
+
+```sql
+SELECT * FROM users WHERE nickname IS NULL;
+SELECT * FROM users WHERE email   IS NOT NULL;
+```
+
+---
+
+## String concatenation: `||`
+
+```sql
+SELECT first_name || ' ' || last_name AS full_name FROM users;
+```
+
+---
+
+## JSON operators
+
+| Operator | Returns | Example |
+|----------|---------|---------|
+| `->` key | JSON fragment (string) | `payload -> 'user'` |
+| `->>` key | SQL scalar (string/number) | `payload ->> 'uid'` |
+| `->` index | JSON array element | `tags -> 0` |
+| `->>` index | Array element as scalar | `tags ->> 0` |
+
+Path navigation:
+
+```sql
+-- Navigate nested object
+SELECT payload -> 'address' -> 'city' FROM users;
+
+-- Extract scalar
+SELECT payload ->> 'name' FROM events;
+
+-- Filter by JSON field
+SELECT * FROM events WHERE payload ->> 'type' = 'login';
+SELECT * FROM events WHERE (payload -> 'score')::INT8 > 90;
+```
+
+See [JSON](../json.md) for the full JSON reference.
+
+---
+
+## WHERE clause examples
+
+```sql
+-- Simple equality
+SELECT * FROM users WHERE id = 1;
+
+-- Multiple conditions
+SELECT * FROM users WHERE age >= 18 AND active = true;
+
+-- OR conditions
+SELECT * FROM orders WHERE status = 'pending' OR status = 'processing';
+
+-- LIKE
+SELECT * FROM users WHERE email LIKE '%@example.com';
+
+-- IN list
+SELECT * FROM users WHERE id IN (1, 2, 3);
+
+-- BETWEEN
+SELECT * FROM users WHERE score BETWEEN 80 AND 100;
+
+-- IS NULL
+SELECT * FROM users WHERE nickname IS NULL;
+
+-- Subquery
+SELECT * FROM users WHERE id IN (SELECT user_id FROM orders WHERE amount > 100);
+
+-- JSON field filter
+SELECT * FROM events WHERE payload ->> 'action' = 'signup';
+
+-- Combined
+SELECT * FROM products
+WHERE category = 'electronics'
+  AND price BETWEEN 100 AND 500
+  AND stock > 0
+  AND name LIKE '%phone%';
+```

--- a/docs/sql/select.md
+++ b/docs/sql/select.md
@@ -1,0 +1,358 @@
+# SELECT
+
+## Basic syntax
+
+```sql
+SELECT [DISTINCT] column_list
+FROM   table_name [AS alias]
+[JOIN  ...]
+[WHERE condition]
+[GROUP BY column_list]
+[HAVING condition]
+[ORDER BY column_list [ASC|DESC]]
+[LIMIT n]
+[OFFSET m]
+```
+
+---
+
+## Column selection
+
+```sql
+-- All columns
+SELECT * FROM users;
+
+-- Named columns
+SELECT id, name, email FROM users;
+
+-- Aliases
+SELECT id, UPPER(name) AS display_name FROM users;
+
+-- Expressions
+SELECT id, price * quantity AS total FROM order_lines;
+```
+
+---
+
+## WHERE
+
+See [Operators & WHERE](operators.md) for the full operator reference.
+
+```sql
+SELECT * FROM users WHERE id = 1;
+SELECT * FROM users WHERE age >= 18 AND active = true;
+SELECT * FROM users WHERE email LIKE '%@example.com';
+SELECT * FROM users WHERE id IN (1, 2, 3);
+SELECT * FROM users WHERE score BETWEEN 80 AND 100;
+SELECT * FROM users WHERE name IS NOT NULL;
+```
+
+---
+
+## DISTINCT
+
+Remove duplicate rows from the result:
+
+```sql
+SELECT DISTINCT department FROM employees;
+SELECT DISTINCT user_id, product_id FROM orders;
+```
+
+---
+
+## ORDER BY
+
+```sql
+-- Single column ascending (default)
+SELECT * FROM users ORDER BY created;
+
+-- Descending
+SELECT * FROM users ORDER BY created DESC;
+
+-- Multiple columns
+SELECT * FROM users ORDER BY department ASC, salary DESC;
+```
+
+---
+
+## LIMIT and OFFSET
+
+```sql
+-- First 10 rows
+SELECT * FROM users LIMIT 10;
+
+-- Pagination: rows 21–30
+SELECT * FROM users ORDER BY id LIMIT 10 OFFSET 20;
+```
+
+---
+
+## GROUP BY and HAVING
+
+```sql
+-- Count per department
+SELECT department, COUNT(*) AS cnt
+FROM employees
+GROUP BY department;
+
+-- Only departments with more than 5 members
+SELECT department, COUNT(*) AS cnt, AVG(salary) AS avg_sal
+FROM employees
+GROUP BY department
+HAVING COUNT(*) > 5;
+
+-- Sum per user with filter
+SELECT user_id, SUM(amount) AS total
+FROM orders
+GROUP BY user_id
+HAVING SUM(amount) > 1000;
+```
+
+---
+
+## Aggregate functions
+
+```sql
+SELECT COUNT(*)                    FROM orders;
+SELECT COUNT(DISTINCT user_id)     FROM orders;
+SELECT SUM(amount)                 FROM orders;
+SELECT AVG(amount)                 FROM orders;
+SELECT MIN(amount), MAX(amount)    FROM orders;
+```
+
+See [Aggregate Functions](../functions/aggregate.md).
+
+---
+
+## JOINs
+
+### INNER JOIN
+
+Returns rows matching in both tables:
+
+```sql
+SELECT u.id, u.name, o.amount
+FROM users u
+INNER JOIN orders o ON u.id = o.user_id;
+```
+
+### LEFT JOIN
+
+All rows from the left table; NULL for unmatched right rows:
+
+```sql
+SELECT u.id, u.name, COALESCE(o.amount, 0) AS total
+FROM users u
+LEFT JOIN orders o ON u.id = o.user_id;
+```
+
+### RIGHT JOIN
+
+All rows from the right table; NULL for unmatched left rows:
+
+```sql
+SELECT u.id, u.name, o.amount
+FROM users u
+RIGHT JOIN orders o ON u.id = o.user_id;
+```
+
+### Multi-table chain
+
+```sql
+SELECT u.name, p.name AS product, o.amount
+FROM users u
+INNER JOIN orders o   ON u.id = o.user_id
+INNER JOIN products p ON o.product_id = p.id
+LEFT JOIN  reviews r  ON p.id = r.product_id;
+```
+
+---
+
+## Subqueries
+
+### Scalar subquery in SELECT
+
+```sql
+SELECT id, name,
+       (SELECT COUNT(*) FROM orders WHERE user_id = users.id) AS order_count
+FROM users;
+```
+
+### IN with subquery
+
+```sql
+SELECT * FROM users
+WHERE id IN (SELECT user_id FROM orders WHERE amount > 100);
+
+SELECT * FROM users
+WHERE id NOT IN (SELECT user_id FROM banned_users);
+```
+
+### Derived table in FROM
+
+```sql
+SELECT * FROM (
+    SELECT id, name FROM users WHERE score > 80
+) AS active_users;
+```
+
+---
+
+## Common Table Expressions (CTEs)
+
+```sql
+-- Single CTE
+WITH active_users AS (
+    SELECT id, name FROM users WHERE score > 80
+)
+SELECT * FROM active_users;
+
+-- Multiple CTEs
+WITH
+    high_scorers AS (SELECT id FROM users WHERE score > 80),
+    user_orders  AS (SELECT user_id, amount FROM orders)
+SELECT uo.amount
+FROM user_orders uo
+WHERE uo.user_id IN (SELECT id FROM high_scorers);
+
+-- CTE joined with real table
+WITH active AS (SELECT id FROM users WHERE score > 80)
+SELECT u.name
+FROM users AS u
+INNER JOIN active AS a ON u.id = a.id;
+
+-- CTE with aggregation
+WITH totals AS (
+    SELECT user_id, COUNT(*) AS cnt, SUM(amount) AS total
+    FROM orders
+    GROUP BY user_id
+)
+SELECT * FROM totals WHERE total > 500;
+```
+
+!!! note
+    Recursive CTEs (`WITH RECURSIVE`) are not yet implemented.
+
+---
+
+## UNION and UNION ALL
+
+```sql
+-- UNION deduplicates rows
+SELECT id, name FROM active_users
+UNION
+SELECT id, name FROM archived_users;
+
+-- UNION ALL keeps duplicates (faster)
+SELECT id, name FROM users
+UNION ALL
+SELECT id, name FROM former_users;
+
+-- Chain of three
+SELECT id FROM users
+UNION ALL
+SELECT id FROM archived_users
+UNION
+SELECT id FROM deleted_users;
+```
+
+---
+
+## CASE WHEN
+
+Searched form (arbitrary conditions):
+
+```sql
+SELECT id, name,
+    CASE
+        WHEN score >= 90 THEN 'A'
+        WHEN score >= 80 THEN 'B'
+        WHEN score >= 70 THEN 'C'
+        ELSE 'F'
+    END AS grade
+FROM students;
+```
+
+Simple form (equality on one expression):
+
+```sql
+SELECT id,
+    CASE status
+        WHEN 'active'   THEN 'Active'
+        WHEN 'inactive' THEN 'Inactive'
+        ELSE 'Unknown'
+    END AS status_label
+FROM accounts;
+```
+
+---
+
+## CAST
+
+```sql
+SELECT CAST(price AS INT8)   FROM products;
+SELECT CAST(id AS TEXT)      FROM users;
+SELECT CAST(n AS DOUBLE)     FROM numbers;
+SELECT CAST(name AS VARCHAR(50)) FROM users;
+SELECT CAST('2024-01-01 00:00:00' AS TIMESTAMP);
+SELECT CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID);
+SELECT CAST('{"a": 1}' AS JSON);
+```
+
+---
+
+## Window functions
+
+```sql
+-- Row number
+SELECT name, ROW_NUMBER() OVER (ORDER BY score DESC) AS rn
+FROM students;
+
+-- Partition by department
+SELECT name, dept,
+       ROW_NUMBER()  OVER (PARTITION BY dept ORDER BY score DESC) AS dept_rank,
+       DENSE_RANK()  OVER (PARTITION BY dept ORDER BY score DESC) AS dense_rk,
+       SUM(score)    OVER (PARTITION BY dept) AS dept_total,
+       AVG(score)    OVER (PARTITION BY dept) AS dept_avg
+FROM employees;
+
+-- Running total
+SELECT name, score,
+       SUM(score) OVER (ORDER BY score) AS running_sum
+FROM students;
+
+-- LAG / LEAD
+SELECT name, score,
+       LAG(score,  1) OVER (ORDER BY score) AS prev_score,
+       LEAD(score, 1) OVER (ORDER BY score) AS next_score
+FROM students;
+```
+
+See [Window Functions](../functions/window.md).
+
+---
+
+## Full-text search
+
+```sql
+SELECT id, TS_RANK(body, 'database storage') AS score
+FROM articles
+WHERE MATCH(body, 'database storage')
+ORDER BY score DESC
+LIMIT 10;
+```
+
+See [Full-text Search](../indexes/fulltext.md).
+
+---
+
+## Vector nearest-neighbour search
+
+```sql
+SELECT id, body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
+
+See [Vector Search](../vector-search.md).

--- a/docs/sql/transactions.md
+++ b/docs/sql/transactions.md
@@ -1,0 +1,167 @@
+# Transactions
+
+## Overview
+
+MiniSQL uses two concurrency models:
+
+- **Write transactions** — Optimistic Concurrency Control (OCC). One writer at a time; conflicts detected at commit.
+- **Read-only transactions** — MVCC snapshot isolation. Multiple concurrent readers; always see a consistent point-in-time snapshot.
+
+---
+
+## Explicit transactions
+
+```sql
+BEGIN;
+
+INSERT INTO accounts (id, balance) VALUES (1, 1000);
+UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+
+COMMIT;
+```
+
+Roll back if something goes wrong:
+
+```sql
+BEGIN;
+
+UPDATE accounts SET balance = balance - 100 WHERE id = 1;
+
+-- Something failed — undo everything
+ROLLBACK;
+```
+
+---
+
+## Transactions in Go
+
+### Basic transaction
+
+```go
+tx, err := db.Begin()
+if err != nil {
+    return err
+}
+defer tx.Rollback() // safe to call even after Commit
+
+_, err = tx.Exec(
+    `UPDATE accounts SET balance = balance - ? WHERE id = ?`,
+    100, fromID,
+)
+if err != nil {
+    return err
+}
+
+_, err = tx.Exec(
+    `UPDATE accounts SET balance = balance + ? WHERE id = ?`,
+    100, toID,
+)
+if err != nil {
+    return err
+}
+
+return tx.Commit()
+```
+
+### Retry on OCC conflict
+
+Write transactions use optimistic concurrency control. When two concurrent writers modify the same pages, one receives `ErrTxConflict` at commit time and must retry:
+
+```go
+import minisqlErrors "github.com/RichardKnop/minisql/errors"
+
+for {
+    tx, err := db.Begin()
+    if err != nil {
+        return err
+    }
+
+    _, err = tx.Exec(
+        `UPDATE accounts SET balance = balance - 100 WHERE id = 1`,
+    )
+    if err != nil {
+        tx.Rollback()
+        return err
+    }
+
+    if err := tx.Commit(); err != nil {
+        tx.Rollback()
+        if errors.Is(err, minisqlErrors.ErrTxConflict) {
+            continue // retry
+        }
+        return err
+    }
+    break
+}
+```
+
+### Read-only transaction
+
+Every `SELECT` runs automatically in a snapshot-isolated read-only transaction. To run multiple SELECTs against the same snapshot, use `db.BeginTx` with `ReadOnly: true`:
+
+```go
+tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+if err != nil {
+    return err
+}
+defer tx.Rollback()
+
+var balance1, balance2 int64
+tx.QueryRow(`SELECT balance FROM accounts WHERE id = 1`).Scan(&balance1)
+tx.QueryRow(`SELECT balance FROM accounts WHERE id = 2`).Scan(&balance2)
+
+// balance1 + balance2 is consistent — both rows come from the same snapshot
+tx.Commit()
+```
+
+---
+
+## Isolation guarantees
+
+### Readers
+
+Read-only transactions provide **snapshot isolation**:
+
+- No dirty reads — a reader never sees uncommitted data.
+- No non-repeatable reads — re-reading the same row within a snapshot returns the same value.
+- No phantom reads — the set of rows matching a query is stable within a snapshot.
+- Readers never block writers; writers never block readers.
+
+### Writers
+
+Write transactions provide **serialisability** via OCC:
+
+- Only one write transaction commits at a time.
+- Page versions are recorded in a read-set when first accessed.
+- At commit, the engine checks that none of those pages were modified by a concurrent transaction.
+- Conflict → `ErrTxConflict` → retry.
+- Early conflict detection also happens in `ModifyPage` to fail fast.
+
+---
+
+## Autocommit
+
+When you call `db.Exec` or `db.Query` outside a transaction, each statement runs in its own implicit transaction with autocommit. This is fine for single-statement operations:
+
+```go
+// Each of these runs in its own implicit transaction
+db.Exec(`INSERT INTO users (email) VALUES (?)`, email)
+db.Query(`SELECT * FROM users`)
+```
+
+For multi-statement operations that must be atomic, always use an explicit transaction.
+
+---
+
+## WAL durability
+
+Transactions are written to the WAL file before the commit returns. Durability can be tuned with `PRAGMA synchronous`:
+
+```sql
+PRAGMA synchronous = full;   -- fsync WAL on every commit (safest)
+PRAGMA synchronous = normal; -- fsync WAL periodically (default)
+PRAGMA synchronous = off;    -- no fsync (fastest, least durable)
+```
+
+See [PRAGMA](explain.md#pragma) for full details.

--- a/docs/sql/update.md
+++ b/docs/sql/update.md
@@ -1,0 +1,119 @@
+# UPDATE
+
+## Basic syntax
+
+```sql
+UPDATE table_name
+SET col1 = expr1 [, col2 = expr2 ...]
+[FROM other_table]
+[WHERE condition]
+[RETURNING column_list]
+```
+
+---
+
+## Simple UPDATE
+
+```sql
+-- Update one column
+UPDATE users SET name = 'Alice Smith' WHERE id = 1;
+
+-- Update multiple columns
+UPDATE users
+SET name = 'Bob', active = false
+WHERE id = 2;
+
+-- Update with expression
+UPDATE products SET price = price * 2 WHERE category = 'rare';
+
+-- Update with bind parameters
+UPDATE users SET email = ? WHERE id = ?;
+```
+
+---
+
+## UPDATE with RETURNING
+
+`RETURNING` makes UPDATE behave like a query — it returns the modified rows after the update is applied.
+
+```sql
+-- Return updated row
+UPDATE users SET name = 'Carol' WHERE id = 3 RETURNING id, name;
+
+-- Return all columns
+UPDATE accounts SET balance = balance - 100 WHERE id = 1 RETURNING *;
+```
+
+In Go:
+
+```go
+var newBalance int64
+err = db.QueryRow(
+    `UPDATE accounts SET balance = balance - ? WHERE id = ? RETURNING balance`,
+    100, accountID,
+).Scan(&newBalance)
+```
+
+---
+
+## UPDATE FROM
+
+`UPDATE … FROM` joins a second table to compute the new values:
+
+```sql
+-- Apply a discount from the discount table
+UPDATE products p
+SET price = p.price * (1 - d.pct)
+FROM discounts d
+WHERE d.product_id = p.id AND d.active = true;
+
+-- Copy a field from another table
+UPDATE orders o
+SET status = s.state
+FROM order_states s
+WHERE s.order_id = o.id;
+```
+
+---
+
+## UPDATE all rows
+
+Omit `WHERE` to update every row in the table:
+
+```sql
+UPDATE settings SET value = 'default';
+```
+
+!!! warning
+    There is no confirmation prompt. An UPDATE without a WHERE clause modifies all rows immediately and cannot be undone without a rollback.
+
+---
+
+## CASE WHEN in SET
+
+```sql
+UPDATE employees
+SET salary = CASE
+    WHEN department = 'eng'   THEN salary * 1.10
+    WHEN department = 'sales' THEN salary * 1.05
+    ELSE salary
+END;
+```
+
+---
+
+## Subquery in SET
+
+```sql
+UPDATE orders o
+SET amount = (SELECT SUM(price * qty) FROM order_lines WHERE order_id = o.id);
+```
+
+---
+
+## Notes
+
+- `UPDATE` without a `WHERE` clause affects every row in the table.
+- Expressions in `SET` are evaluated against the *original* row values, not intermediate results; updating column `a` and using `a` in a second `SET` clause sees the old value of `a`.
+- Foreign-key constraints are checked after every update when `PRAGMA foreign_keys = on` (the default).
+- CHECK constraints are re-evaluated on the updated values.

--- a/docs/system-table.md
+++ b/docs/system-table.md
@@ -1,0 +1,82 @@
+# System Tables
+
+MiniSQL maintains internal tables that store schema metadata and query planner statistics. These tables are read-only from SQL and are automatically maintained by the engine.
+
+---
+
+## minisql_schema
+
+`minisql_schema` stores the schema definition for every user table and index. It is the single source of truth for the database schema — analogous to `sqlite_schema` in SQLite or `information_schema` in PostgreSQL.
+
+### Structure
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `type` | `INT4` | Object kind: `1` = table, `2` = primary key, `3` = unique index, `4` = secondary index, `5` = foreign key |
+| `name` | `VARCHAR(255)` | Object name (table name, index name, or FK constraint name) |
+| `tbl_name` | `VARCHAR(255)` | Parent table name (for indexes and foreign keys); NULL for tables |
+| `root_page` | `INT4` | B-tree root page number for this object |
+| `sql` | `TEXT` | DDL statement that created this object |
+
+### Querying the schema
+
+```sql
+-- List all user tables
+SELECT name, sql FROM minisql_schema WHERE type = 1;
+
+-- List all indexes on a specific table
+SELECT name, type, sql
+FROM minisql_schema
+WHERE tbl_name = 'users' AND type IN (2, 3, 4);
+
+-- List all foreign keys
+SELECT name, tbl_name, sql FROM minisql_schema WHERE type = 5;
+
+-- Show DDL for a specific table
+SELECT sql FROM minisql_schema WHERE type = 1 AND name = 'users';
+```
+
+### Type values
+
+| Value | Constant | Meaning |
+|-------|----------|---------|
+| 1 | `SchemaTable` | User table |
+| 2 | `SchemaPrimaryKey` | Primary key index |
+| 3 | `SchemaUniqueIndex` | Unique index |
+| 4 | `SchemaSecondaryIndex` | Secondary / fulltext / inverted / HNSW index |
+| 5 | `SchemaForeignKey` | Foreign key constraint |
+
+---
+
+## minisql_stats
+
+`minisql_stats` stores column statistics collected by the `ANALYZE` command. The query planner reads these statistics to estimate row counts, choose indexes, and order joins.
+
+Statistics are populated by:
+
+```sql
+ANALYZE table_name;
+```
+
+### What ANALYZE collects
+
+- Row count per table
+- Distinct value count (cardinality) per column
+- Value distribution histograms per column
+- Most-common values (MCV) per column
+
+### Usage
+
+```sql
+-- Check that stats exist for a table
+SELECT * FROM minisql_stats WHERE tbl_name = 'orders';
+```
+
+---
+
+## Notes
+
+- Both system tables are read-only from SQL — writing to them directly is rejected.
+- `minisql_schema` is always consistent with the current schema; DDL operations (CREATE TABLE, DROP TABLE, CREATE INDEX, etc.) update it atomically within the same transaction.
+- `minisql_stats` is stale until `ANALYZE` is run; the planner falls back to default estimates for tables without statistics.
+- System tables do not appear in `SELECT * FROM minisql_schema WHERE type = 1` because the filter on `type = 1` (user tables) excludes them. They are visible if you query without a type filter.

--- a/docs/vector-search.md
+++ b/docs/vector-search.md
@@ -1,0 +1,177 @@
+# Vector Search
+
+MiniSQL supports high-dimensional vector storage and approximate nearest-neighbour (ANN) search via the `VECTOR(n)` column type and the HNSW index.
+
+---
+
+## The VECTOR type
+
+```sql
+CREATE TABLE documents (
+    id        INT8       PRIMARY KEY AUTOINCREMENT,
+    body      TEXT       NOT NULL,
+    embedding VECTOR(3)  NOT NULL
+);
+```
+
+- `n` is the vector dimension — fixed at column creation time.
+- All inserted vectors must have exactly `n` components.
+- Components are `float32` (IEEE 754 single-precision).
+- Data is stored on overflow pages; the inline cell holds only the dimension and first overflow page pointer.
+
+---
+
+## Inserting vectors
+
+As a bracket-delimited string:
+
+```sql
+INSERT INTO documents (body, embedding)
+VALUES ('hello world', '[0.1, 0.2, 0.3]');
+```
+
+In Go — string or `[]float32`:
+
+```go
+// String literal
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", "[0.1, 0.2, 0.3]",
+)
+
+// []float32 bind parameter
+vec := []float32{0.1, 0.2, 0.3}
+_, err = db.Exec(
+    `INSERT INTO documents (body, embedding) VALUES (?, ?)`,
+    "hello world", vec,
+)
+```
+
+---
+
+## Distance functions
+
+### VEC_L2(a, b) — Euclidean (L2) distance
+
+Returns the L2 distance between two vectors. Smaller = more similar.
+
+```sql
+SELECT id, body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
+
+### VEC_COSINE(a, b) — Cosine distance
+
+Returns the cosine distance (1 − cosine similarity). Smaller = more similar. Best for comparing direction, independent of magnitude.
+
+```sql
+SELECT id, body, VEC_COSINE(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 5;
+```
+
+Both functions accept vectors as column references, string literals `'[…]'`, or `[]float32` bind parameters.
+
+---
+
+## HNSW index for fast ANN search
+
+Without an index, every distance query scans all rows. For large tables, create an HNSW (Hierarchical Navigable Small World) index:
+
+```sql
+CREATE HNSW INDEX idx_docs_embedding ON documents (embedding)
+    WITH (m = 16, ef_construction = 200);
+```
+
+The query planner automatically uses the HNSW index for `ORDER BY VEC_L2(col, ?) LIMIT n` and `ORDER BY VEC_COSINE(col, ?) LIMIT n` patterns:
+
+```sql
+-- Uses HNSW ANN search
+SELECT id, body, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist
+LIMIT 10;
+```
+
+Verify with `EXPLAIN`:
+
+```sql
+EXPLAIN
+SELECT id, VEC_L2(embedding, '[0.1, 0.2, 0.3]') AS dist
+FROM documents
+ORDER BY dist LIMIT 10;
+-- op: HNSWSearch  index: idx_docs_embedding
+```
+
+See [HNSW Index](indexes/hnsw.md) for parameter reference and full details.
+
+---
+
+## Full example
+
+```go
+package main
+
+import (
+    "database/sql"
+    "fmt"
+    _ "github.com/RichardKnop/minisql"
+)
+
+func main() {
+    db, _ := sql.Open("minisql", "/tmp/vectors.db")
+    defer db.Close()
+    db.SetMaxOpenConns(1)
+
+    db.Exec(`CREATE TABLE IF NOT EXISTS documents (
+        id        INT8      PRIMARY KEY AUTOINCREMENT,
+        body      TEXT      NOT NULL,
+        embedding VECTOR(3) NOT NULL
+    )`)
+
+    db.Exec(`CREATE HNSW INDEX IF NOT EXISTS idx_embedding
+        ON documents (embedding)
+        WITH (m = 16, ef_construction = 200)`)
+
+    vecs := []struct {
+        body string
+        vec  []float32
+    }{
+        {"hello world",     {0.1, 0.2, 0.3}},
+        {"foo bar",         {0.4, 0.5, 0.6}},
+        {"database engine", {0.7, 0.8, 0.9}},
+    }
+    for _, v := range vecs {
+        db.Exec(`INSERT INTO documents (body, embedding) VALUES (?, ?)`, v.body, v.vec)
+    }
+
+    query := []float32{0.15, 0.25, 0.35}
+    rows, _ := db.Query(
+        `SELECT id, body, VEC_L2(embedding, ?) AS dist
+         FROM documents
+         ORDER BY dist
+         LIMIT 3`,
+        query,
+    )
+    defer rows.Close()
+    for rows.Next() {
+        var id int64
+        var body string
+        var dist float64
+        rows.Scan(&id, &body, &dist)
+        fmt.Printf("id=%d body=%q dist=%.4f\n", id, body, dist)
+    }
+}
+```
+
+---
+
+## Notes
+
+- `VECTOR(n)` columns cannot be primary keys.
+- Dimension count is validated on every insert — mismatched dimensions return an error.
+- `VEC_L2` and `VEC_COSINE` return `NULL` if either argument is `NULL`.
+- The HNSW index is *approximate* — for exact results (all rows), use the distance functions without an index (smaller tables) or increase `ef_construction`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,106 @@
+site_name: MiniSQL
+site_description: Embedded single-file SQL database written in Go
+site_url: https://richardknop.github.io/minisql/
+repo_url: https://github.com/RichardKnop/minisql
+repo_name: RichardKnop/minisql
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.tabs.link
+    - content.code.copy
+    - content.code.annotate
+    - content.tooltips
+    - toc.follow
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Connection: connection.md
+  - Architecture: architecture.md
+  - Data Types: data-types.md
+  - SQL Reference:
+    - CREATE / ALTER / DROP: sql/create-table.md
+    - INSERT: sql/insert.md
+    - SELECT: sql/select.md
+    - UPDATE: sql/update.md
+    - DELETE: sql/delete.md
+    - Operators & WHERE: sql/operators.md
+    - Transactions: sql/transactions.md
+    - EXPLAIN / ANALYZE / VACUUM / PRAGMA: sql/explain.md
+  - Indexes:
+    - Overview: indexes/overview.md
+    - B-tree Indexes: indexes/btree.md
+    - Full-text Search: indexes/fulltext.md
+    - JSON Inverted Index: indexes/json-inverted.md
+    - HNSW Vector Index: indexes/hnsw.md
+  - Functions:
+    - String: functions/string.md
+    - Numeric: functions/numeric.md
+    - Date & Time: functions/datetime.md
+    - Aggregate: functions/aggregate.md
+    - Window: functions/window.md
+    - JSON: functions/json.md
+    - Conditional: functions/conditional.md
+  - JSON: json.md
+  - Vector Search: vector-search.md
+  - Encryption: encryption.md
+  - Constraints: constraints.md
+  - System Table: system-table.md
+  - Limitations: limitations.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/RichardKnop/minisql


### PR DESCRIPTION
…oyment

Adds comprehensive MkDocs Material documentation covering all SQL features, data types, indexes, functions, architecture, encryption, and limitations. Deploys automatically to GitHub Pages on every push/merge to main.