### PR TITLE
feat: implement INSERT INTO … SELECT

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -12,7 +12,6 @@ MiniSQL is a research and learning project, not yet production-ready. This page 
 | Savepoints (`SAVEPOINT`, `RELEASE`, `ROLLBACK TO`) | Full transaction rollback is supported |
 | `TRUNCATE TABLE` | Use `DELETE FROM table_name WHERE true` instead |
 | `CREATE TABLE AS SELECT` | Use a regular `CREATE TABLE` followed by `INSERT INTO … SELECT` |
-| `INSERT INTO … SELECT` | Not yet supported |
 | `MERGE` / `UPSERT` by conflict target | `ON CONFLICT DO NOTHING / DO UPDATE` is supported but without explicit conflict-column targeting |
 | `FULL OUTER JOIN` | INNER, LEFT, and RIGHT JOINs are supported |
 | `CROSS JOIN` | Not supported |

--- a/docs/sql/insert.md
+++ b/docs/sql/insert.md
@@ -57,6 +57,86 @@ for _, u := range users {
 
 ---
 
+## INSERT INTO … SELECT
+
+Populate a table from a query result instead of a literal `VALUES` list.
+
+```sql
+INSERT INTO table_name (col1, col2, ...)
+SELECT expr1, expr2, ...
+FROM source_table
+[WHERE condition];
+```
+
+The column list is required. The number of SELECT output columns must match the number of target columns.
+
+### Copy all rows
+
+```sql
+INSERT INTO archived_users (email, name)
+SELECT email, name FROM users;
+```
+
+### Copy a filtered subset
+
+```sql
+INSERT INTO archived_users (email, name)
+SELECT email, name FROM users
+WHERE created < '2024-01-01';
+```
+
+### Copy a transformed subset
+
+```sql
+INSERT INTO audit_log (user_id, action, ts)
+SELECT id, 'signup', created FROM users
+WHERE created > '2025-01-01';
+```
+
+### Bulk move between tables
+
+```sql
+INSERT INTO orders_archive (order_id, user_id, total_paid)
+SELECT order_id, user_id, total_paid FROM orders
+WHERE created < '2024-01-01';
+
+DELETE FROM orders WHERE created < '2024-01-01';
+```
+
+### With ON CONFLICT
+
+```sql
+INSERT INTO archived_users (email, name)
+SELECT email, name FROM users
+ON CONFLICT DO NOTHING;
+```
+
+### With RETURNING
+
+```go
+rows, err := db.Query(`
+    INSERT INTO archived_users (email, name)
+    SELECT email, name FROM users WHERE id = ?
+    RETURNING id, email
+`, userID)
+defer rows.Close()
+for rows.Next() {
+    var id int64
+    var email string
+    rows.Scan(&id, &email)
+}
+```
+
+### Seeding from a subquery
+
+```sql
+INSERT INTO product_stats (product_id, total_orders)
+SELECT product_id, COUNT(*) FROM orders
+GROUP BY product_id;
+```
+
+---
+
 ## ON CONFLICT
 
 ### DO NOTHING

--- a/e2e_tests/insert_select_test.go
+++ b/e2e_tests/insert_select_test.go
@@ -1,0 +1,161 @@
+package e2etests
+
+import (
+	"context"
+	"database/sql"
+)
+
+func (s *TestSuite) TestInsertSelect() {
+	_, err := s.db.Exec(createUsersTableSQL)
+	s.Require().NoError(err)
+
+	var createArchivedUsersTableSQL = `create table "archived_users" (
+		id int8 primary key autoincrement,
+		email varchar(255),
+		name text
+	);`
+	_, err = s.db.Exec(createArchivedUsersTableSQL)
+	s.Require().NoError(err)
+
+	// Seed some users.
+	s.execQuery(`insert into users("email", "name") values('alice@example.com', 'Alice');`, 1)
+	s.execQuery(`insert into users("email", "name") values('bob@example.com', 'Bob');`, 1)
+	s.execQuery(`insert into users("email", "name") values('carol@example.com', 'Carol');`, 1)
+
+	s.Run("basic INSERT SELECT copies rows", func() {
+		result, err := s.db.ExecContext(
+			context.Background(),
+			`insert into archived_users("email", "name") select email, name from users;`,
+		)
+		s.Require().NoError(err)
+		rowsAffected, err := result.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(3), rowsAffected)
+
+		rows, err := s.db.QueryContext(context.Background(), `select id, email, name from archived_users order by id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type archivedUser struct {
+			ID    int64
+			Email sql.NullString
+			Name  sql.NullString
+		}
+		var archived []archivedUser
+		for rows.Next() {
+			var u archivedUser
+			s.Require().NoError(rows.Scan(&u.ID, &u.Email, &u.Name))
+			archived = append(archived, u)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(archived, 3)
+		s.Equal("alice@example.com", archived[0].Email.String)
+		s.Equal("Alice", archived[0].Name.String)
+		s.Equal("bob@example.com", archived[1].Email.String)
+		s.Equal("carol@example.com", archived[2].Email.String)
+	})
+
+	s.Run("INSERT SELECT with WHERE filters rows", func() {
+		// Truncate archived_users first.
+		s.execQuery(`delete from archived_users where id > 0;`, 3)
+
+		result, err := s.db.ExecContext(
+			context.Background(),
+			`insert into archived_users("email", "name") select email, name from users where name = 'Alice';`,
+		)
+		s.Require().NoError(err)
+		rowsAffected, err := result.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(1), rowsAffected)
+
+		rows, err := s.db.QueryContext(context.Background(), `select id, email, name from archived_users;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var id int64
+			var email, name sql.NullString
+			s.Require().NoError(rows.Scan(&id, &email, &name))
+			names = append(names, name.String)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(names, 1)
+		s.Equal("Alice", names[0])
+	})
+
+	s.Run("INSERT SELECT from empty result inserts 0 rows", func() {
+		// Truncate archived_users first.
+		s.execQuery(`delete from archived_users where id > 0;`, 1)
+
+		result, err := s.db.ExecContext(
+			context.Background(),
+			`insert into archived_users("email", "name") select email, name from users where name = 'NoSuchUser';`,
+		)
+		s.Require().NoError(err)
+		rowsAffected, err := result.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(0), rowsAffected)
+
+		rows, err := s.db.QueryContext(context.Background(), `select id, email, name from archived_users;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+		s.False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("INSERT SELECT with ON CONFLICT DO NOTHING skips duplicates", func() {
+		_, err = s.db.Exec(`drop table archived_users;`)
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`create table "archived_users" (
+			id int8 primary key autoincrement,
+			email varchar(255) unique,
+			name text
+		);`)
+		s.Require().NoError(err)
+
+		// Insert Alice first.
+		s.execQuery(`insert into archived_users("email", "name") values('alice@example.com', 'Alice');`, 1)
+
+		// INSERT SELECT all users ON CONFLICT DO NOTHING — Alice should be skipped.
+		result, err := s.db.ExecContext(
+			context.Background(),
+			`insert into archived_users("email", "name") select email, name from users ON CONFLICT DO NOTHING;`,
+		)
+		s.Require().NoError(err)
+		rowsAffected, err := result.RowsAffected()
+		s.Require().NoError(err)
+		// Bob and Carol inserted; Alice skipped.
+		s.Equal(int64(2), rowsAffected)
+	})
+
+	s.Run("INSERT SELECT with RETURNING returns inserted rows", func() {
+		_, err = s.db.Exec(`drop table archived_users;`)
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`create table "archived_users" (
+			id int8 primary key autoincrement,
+			email varchar(255),
+			name text
+		);`)
+		s.Require().NoError(err)
+
+		rows, err := s.db.QueryContext(
+			context.Background(),
+			`insert into archived_users("email", "name") select email, name from users where name = 'Bob' RETURNING id, email, name;`,
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var count int
+		for rows.Next() {
+			var id int64
+			var email, name sql.NullString
+			s.Require().NoError(rows.Scan(&id, &email, &name))
+			s.Equal("bob@example.com", email.String)
+			s.Equal("Bob", name.String)
+			count++
+		}
+		s.Require().NoError(rows.Err())
+		s.Equal(1, count)
+	})
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -206,7 +206,9 @@ func (d *Database) PrepareStatement(ctx context.Context, query string) (Statemen
 	stmt.CacheKey = query
 
 	// Pre-allocate the insert column-order cache so all clones share one object.
-	if stmt.Kind == Insert {
+	// INSERT … SELECT cannot use the cache: column layout comes from the runtime
+	// SELECT result, not from the static statement structure.
+	if stmt.Kind == Insert && stmt.InsertSelectStmt == nil {
 		stmt.insertCache = &insertPrepCache{}
 	}
 
@@ -552,6 +554,16 @@ func (d *Database) ExecuteStatement(ctx context.Context, stmt Statement) (Statem
 		if stmt.Kind == Update {
 			var err error
 			ctx, err = d.resolveSetSubqueries(ctx, &stmt)
+			if err != nil {
+				return StatementResult{}, err
+			}
+		}
+
+		// INSERT INTO … SELECT: execute the SELECT before acquiring the write lock.
+		// This avoids a re-entrant dbLock deadlock (GetTable → RLock inside Lock).
+		if stmt.Kind == Insert && stmt.InsertSelectStmt != nil {
+			var err error
+			stmt, err = d.materialiseInsertSelect(ctx, stmt)
 			if err != nil {
 				return StatementResult{}, err
 			}
@@ -1166,6 +1178,44 @@ func (d *Database) executeTableStatement(ctx context.Context, table *Table, stmt
 	}
 
 	return StatementResult{}, fmt.Errorf("unrecognized table statement type: %v", stmt.Kind)
+}
+
+// materialiseInsertSelect executes the SELECT sub-statement of an INSERT INTO … SELECT
+// and converts the result rows into stmt.Inserts so that the normal INSERT path can proceed.
+// It must be called before the exclusive write lock is acquired to avoid a re-entrant
+// dbLock deadlock (SELECT reads call GetTable → RLock).
+func (d *Database) materialiseInsertSelect(ctx context.Context, stmt Statement) (Statement, error) {
+	result, err := d.ExecuteStatement(ctx, *stmt.InsertSelectStmt)
+	if err != nil {
+		return Statement{}, fmt.Errorf("INSERT INTO … SELECT: %w", err)
+	}
+	rows, err := materializeResultRows(ctx, result)
+	if err != nil {
+		return Statement{}, fmt.Errorf("INSERT INTO … SELECT: materialise: %w", err)
+	}
+
+	// Compute how many of stmt.Fields are INSERT target fields (vs. DO UPDATE SET fields).
+	nInsertFields := len(stmt.Fields)
+	if stmt.ConflictAction == ConflictActionDoUpdate && len(stmt.Updates) > 0 {
+		if n := len(stmt.Fields) - len(stmt.Updates); n >= 0 {
+			nInsertFields = n
+		}
+	}
+
+	inserts := make([][]OptionalValue, 0, len(rows))
+	for _, row := range rows {
+		if len(row.Values) != nInsertFields {
+			return Statement{}, fmt.Errorf(
+				"INSERT INTO … SELECT: SELECT returns %d column(s) but INSERT expects %d",
+				len(row.Values), nInsertFields,
+			)
+		}
+		insertRow := make([]OptionalValue, nInsertFields)
+		copy(insertRow, row.Values)
+		inserts = append(inserts, insertRow)
+	}
+	stmt.Inserts = inserts
+	return stmt, nil
 }
 
 // flattenUnionChain traverses a linked chain of UnionClause nodes (built by the parser)

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -451,6 +451,7 @@ type Statement struct {
 	UpdateFromTable    string     // table name in UPDATE … FROM clause (empty = no UPDATE FROM)
 	UpdateFromAlias    string     // alias for the UPDATE FROM table (e.g. "d" in FROM departments d)
 	UpdateFromSubquery *Statement // non-nil when UPDATE FROM clause is a subquery
+	InsertSelectStmt  *Statement // non-nil for INSERT INTO … SELECT
 	CTEs               []CTE      // non-nil for WITH … SELECT statements
 	// ALTER TABLE fields
 	AlterTableAction AlterTableAction // which ALTER TABLE operation to perform
@@ -1606,7 +1607,7 @@ func canInlinedRowFitInPage(columns []Column) bool {
 }
 
 func (s Statement) validateInsert(table *Table) error {
-	if len(s.Inserts) == 0 {
+	if len(s.Inserts) == 0 && s.InsertSelectStmt == nil {
 		return errors.New("at least one row to insert is required")
 	}
 

--- a/internal/parser/insert.go
+++ b/internal/parser/insert.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/RichardKnop/minisql/internal/minisql"
@@ -12,6 +13,53 @@ var (
 	errInsertFieldValueCountMismatch = errors.New("at INSERT INTO: value count doesn't match field count")
 	errInsertNoFields                = errors.New("at INSERT INTO: expected at least one field to insert")
 )
+
+// insertSelectBoundary returns the byte offset in upperSQL (already normalised,
+// upper-cased) where the SELECT sub-statement ends. It stops at the first
+// occurrence of "ON CONFLICT" or "RETURNING" (INSERT-level keywords) at
+// paren depth 0 and outside string literals, or at the end of the string.
+func insertSelectBoundary(upperSQL string) int {
+	depth := 0
+	i := 0
+	for i < len(upperSQL) {
+		switch upperSQL[i] {
+		case '\'':
+			i++
+			for i < len(upperSQL) && upperSQL[i] != '\'' {
+				i++
+			}
+			if i < len(upperSQL) {
+				i++ // skip closing quote
+			}
+		case '(':
+			depth++
+			i++
+		case ')':
+			depth--
+			i++
+		default:
+			if depth == 0 {
+				rem := upperSQL[i:]
+				if isInsertKeywordAt(rem, "ON CONFLICT") || isInsertKeywordAt(rem, "RETURNING") {
+					return i
+				}
+			}
+			i++
+		}
+	}
+	return i
+}
+
+// isInsertKeywordAt reports whether rem starts with kw followed by a space,
+// semicolon, or end-of-string (i.e. kw is a complete token, not a prefix of
+// a longer identifier).
+func isInsertKeywordAt(rem, kw string) bool {
+	if !strings.HasPrefix(rem, kw) {
+		return false
+	}
+	rest := rem[len(kw):]
+	return rest == "" || rest[0] == ' ' || rest[0] == ';'
+}
 
 func (p *parserItem) doParseInsert() error {
 	switch p.step {
@@ -51,8 +99,38 @@ func (p *parserItem) doParseInsert() error {
 		p.step = stepInsertValuesRWord
 	case stepInsertValuesRWord:
 		valuesRWord := p.peek()
+		if strings.ToUpper(valuesRWord) == "SELECT" {
+			// INSERT INTO … SELECT — parse the SELECT as a sub-statement.
+			//
+			// Limit the sub-parser to the SELECT portion only: stop before any
+			// INSERT-level keyword (ON CONFLICT, RETURNING) at paren depth 0.
+			// This prevents the SELECT parser from consuming those tokens.
+			boundary := insertSelectBoundary(p.upperSQL[p.i:])
+			rest := &parserItem{
+				sql:      p.sql[p.i : p.i+boundary],
+				upperSQL: p.upperSQL[p.i : p.i+boundary],
+				step:     stepBeginning,
+			}
+			selectStmts, err := rest.doParse()
+			if err != nil {
+				return fmt.Errorf("INSERT INTO … SELECT: %w", err)
+			}
+			if len(selectStmts) != 1 {
+				return p.errorf("at INSERT INTO … SELECT: expected exactly one SELECT statement")
+			}
+			if selectStmts[0].Kind != minisql.Select {
+				return p.errorf("at INSERT INTO … SELECT: expected SELECT statement")
+			}
+			selectStmt := selectStmts[0]
+			p.InsertSelectStmt = &selectStmt
+			p.i += rest.i
+			// Transition to stepInsertValuesCommaBeforeOpeningParens so the normal
+			// INSERT post-value handling processes ON CONFLICT / RETURNING / end.
+			p.step = stepInsertValuesCommaBeforeOpeningParens
+			return nil
+		}
 		if strings.ToUpper(valuesRWord) != "VALUES" {
-			return p.errorf("at INSERT INTO: expected VALUES")
+			return p.errorf("at INSERT INTO: expected VALUES or SELECT")
 		}
 		p.pop()
 		p.step = stepInsertValuesOpeningParens

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -776,7 +776,7 @@ func (p *parserItem) validate(stmt minisql.Statement) error {
 			}
 		}
 	}
-	if stmt.Kind == minisql.Insert && len(stmt.Inserts) == 0 {
+	if stmt.Kind == minisql.Insert && len(stmt.Inserts) == 0 && stmt.InsertSelectStmt == nil {
 		return errNoRowsToInsert
 	}
 	if stmt.Kind == minisql.Insert {


### PR DESCRIPTION
Wire SELECT executor output into the INSERT path so rows from any SELECT (including WHERE, GROUP BY, subqueries, CTEs, JOINs) can be bulk-inserted into a target table.

- Parser: detect SELECT after the column list, use insertSelectBoundary to clip the sub-SQL before INSERT-level keywords (ON CONFLICT, RETURNING) at paren depth 0, then parse the SELECT as a sub-statement; transitions to stepInsertValuesCommaBeforeOpeningParens so ON CONFLICT and RETURNING are handled by the existing INSERT state machine
- Executor: materialiseInsertSelect executes the SELECT before acquiring the exclusive write lock (same pattern as UPDATE FROM, avoids dbLock re-entrancy deadlock), maps SELECT output columns positionally to INSERT target fields, then lets the normal INSERT path handle the rows
- ON CONFLICT DO NOTHING / DO UPDATE and RETURNING all work with SELECT
- INSERT … SELECT with 0 result rows succeeds (inserts nothing)
- Docs: add INSERT INTO … SELECT section to insert.md; remove it from limitations.md