### PR TITLE
feat: support negative integer and float literals in SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,7 +666,7 @@ When adding filtering/transformation stages, insert them as goroutines between `
 - JSON functions: `JSON_EXTRACT`, `JSON_VALID`, `JSON_TYPE`, `JSON_ARRAY_LENGTH`.
 - `JSON_CONTAINS(col, '{"key":"val"}')` uses the JSON inverted index when one exists.
 - `CAST(x AS JSON)` and `CAST(uuid AS TEXT)` are supported.
-- Parser does not support negative integer literals in SQL — use `?` placeholder with `int64` arg instead.
+- Negative integer and float literals are supported directly in SQL (e.g., `WHERE n = -1`, `VALUES (-42)`).
 
 ---
 
@@ -780,7 +780,7 @@ Parser files mirror engine files: `parser/select.go` ↔ `internal/minisql/selec
 - **Partial index implication check** — conservative syntactic containment: each condition in the index WHERE must appear verbatim in the query WHERE. Semantically equivalent but textually different conditions are not recognised.
 - **CHECK constraints** — column-level only; table-level CHECK is not yet implemented.
 - **FOREIGN KEY** — single-column only; composite FK is not yet implemented. Actions: RESTRICT, NO ACTION, SET NULL, CASCADE.
-- **Parser negative integer literals** — the parser does not support negative integer literals directly in SQL. Use `?` placeholder with a negative `int64` argument instead.
+- **`FROM table alias`** — bare alias (without `AS`) is not supported; write `FROM t AS alias`.
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -21,7 +21,6 @@ MiniSQL is a research and learning project, not yet production-ready. This page 
 
 | Limitation | Workaround |
 |-----------|------------|
-| Negative integer literals rejected | Use `?` bind parameter with a negative `int64` value: `db.Exec("… WHERE n > ?", int64(-1))` |
 | `FROM table alias` (bare alias) | Use `FROM table AS alias` |
 | `HAVING` does not accept `?` placeholders | Use literal values in HAVING conditions |
 

--- a/e2e_tests/negative_literal_test.go
+++ b/e2e_tests/negative_literal_test.go
@@ -1,0 +1,83 @@
+package e2etests
+
+func (s *TestSuite) TestNegativeLiterals() {
+	_, err := s.db.Exec(`create table "scores" (
+		id    int8 primary key autoincrement,
+		name  text not null,
+		score int8 not null
+	)`)
+	s.Require().NoError(err)
+
+	_, err = s.db.Exec(
+		`insert into "scores" (name, score) values (?, ?), (?, ?), (?, ?)`,
+		"Alice", -50,
+		"Bob", 0,
+		"Carol", 100,
+	)
+	s.Require().NoError(err)
+
+	s.Run("WHERE equality with negative integer literal", func() {
+		var name string
+		err := s.db.QueryRow(`SELECT name FROM "scores" WHERE score = -50`).Scan(&name)
+		s.Require().NoError(err)
+		s.Equal("Alice", name)
+	})
+
+	s.Run("WHERE greater-than with negative integer literal", func() {
+		var count int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM "scores" WHERE score > -1`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(int64(2), count)
+	})
+
+	s.Run("WHERE less-than with negative integer literal", func() {
+		var count int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM "scores" WHERE score < -1`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(int64(1), count)
+	})
+
+	s.Run("WHERE BETWEEN with negative bounds", func() {
+		var count int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM "scores" WHERE score BETWEEN -100 AND -1`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(int64(1), count)
+	})
+
+	s.Run("WHERE IN with negative values", func() {
+		var count int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM "scores" WHERE score IN (-50, 0)`).Scan(&count)
+		s.Require().NoError(err)
+		s.Equal(int64(2), count)
+	})
+
+	s.Run("INSERT with negative literal in VALUES", func() {
+		_, err := s.db.Exec(`INSERT INTO "scores" (name, score) VALUES ('Dave', -999)`)
+		s.Require().NoError(err)
+
+		var score int64
+		err = s.db.QueryRow(`SELECT score FROM "scores" WHERE name = 'Dave'`).Scan(&score)
+		s.Require().NoError(err)
+		s.Equal(int64(-999), score)
+	})
+
+	s.Run("UPDATE SET with negative literal", func() {
+		res, err := s.db.Exec(`UPDATE "scores" SET score = -1 WHERE name = 'Bob'`)
+		s.Require().NoError(err)
+		n, err := res.RowsAffected()
+		s.Require().NoError(err)
+		s.Equal(int64(1), n)
+
+		var score int64
+		err = s.db.QueryRow(`SELECT score FROM "scores" WHERE name = 'Bob'`).Scan(&score)
+		s.Require().NoError(err)
+		s.Equal(int64(-1), score)
+	})
+
+	s.Run("arithmetic still works correctly (positive subtraction)", func() {
+		var result int64
+		err := s.db.QueryRow(`SELECT score - 10 FROM "scores" WHERE name = 'Carol'`).Scan(&result)
+		s.Require().NoError(err)
+		s.Equal(int64(90), result)
+	})
+}

--- a/internal/parser/insert_test.go
+++ b/internal/parser/insert_test.go
@@ -394,6 +394,45 @@ func TestParse_Insert(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"INSERT with negative integer literal works",
+			"INSERT INTO 'a' (b) VALUES (-42);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "a",
+					Fields:    []minisql.Field{{Name: "b"}},
+					Inserts:   [][]minisql.OptionalValue{{{Value: int64(-42), Valid: true}}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT with negative float literal works",
+			"INSERT INTO 'a' (b) VALUES (-3.14);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "a",
+					Fields:    []minisql.Field{{Name: "b"}},
+					Inserts:   [][]minisql.OptionalValue{{{Value: float64(-3.14), Valid: true}}},
+				},
+			},
+			nil,
+		},
+		{
+			"INSERT with mixed positive and negative values works",
+			"INSERT INTO 'a' (b, c) VALUES (-1, 2);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Insert,
+					TableName: "a",
+					Fields:    []minisql.Field{{Name: "b"}, {Name: "c"}},
+					Inserts:   [][]minisql.OptionalValue{{{Value: int64(-1), Valid: true}, {Value: int64(2), Valid: true}}},
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, aTestCase := range testCases {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -622,6 +622,12 @@ func (p *parserItem) peekWithLength() (string, int) {
 			}
 		}
 
+		// Don't consume '-' as an operator when it is immediately followed by a
+		// digit — that is a negative number literal, not binary subtraction.
+		if rWord == "-" && p.i+1 < len(p.sql) && unicode.IsDigit(rune(p.sql[p.i+1])) {
+			continue
+		}
+
 		return p.upperSQL[p.i:end], len(rWord)
 	}
 
@@ -630,12 +636,19 @@ func (p *parserItem) peekWithLength() (string, int) {
 		return p.peekQuotedStringWithLength()
 	}
 
-	// Next for numbers (floats or integers)
+	// Next for numbers (floats or integers), including negative literals ('-' + digit).
 	if unicode.IsDigit(rune(p.sql[p.i])) {
 		_, ln := p.peekNumberWithLength()
 		if ln > 0 {
 			return p.sql[p.i : p.i+ln], ln
 		}
+	}
+	if p.sql[p.i] == '-' && p.i+1 < len(p.sql) && unicode.IsDigit(rune(p.sql[p.i+1])) {
+		end := p.i + 2
+		for end < len(p.sql) && (unicode.IsDigit(rune(p.sql[end])) || p.sql[end] == '.') {
+			end++
+		}
+		return p.sql[p.i:end], end - p.i
 	}
 
 	// And finally for identifiers
@@ -715,6 +728,21 @@ func (p *parserItem) peekValue() (any, int) {
 			return int64(number), ln
 		}
 		return number, ln
+	}
+	// Negative numeric literal: '-' immediately followed by a digit.
+	if p.i+1 < len(p.sql) && p.sql[p.i] == '-' && unicode.IsDigit(rune(p.sql[p.i+1])) {
+		savedI := p.i
+		p.i++
+		number, ln = p.peekNumberWithLength()
+		p.i = savedI
+		if ln > 0 {
+			number = -number
+			totalLen := 1 + ln
+			if float64(int64(number)) == number {
+				return int64(number), totalLen
+			}
+			return number, totalLen
+		}
 	}
 	quotedValue, ln := p.peekQuotedStringWithLength()
 	if ln > 0 {

--- a/internal/parser/where_test.go
+++ b/internal/parser/where_test.go
@@ -422,6 +422,66 @@ func TestParse_Where(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"WHERE with negative integer literal",
+			"WHERE b = -1",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsEqual(minisql.Field{Name: "b"}, minisql.OperandInteger, int64(-1)),
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE with negative integer in greater-than condition",
+			"WHERE score > -100",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsGreater(minisql.Field{Name: "score"}, minisql.OperandInteger, int64(-100)),
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE with negative float literal",
+			"WHERE b = -1.5",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsEqual(minisql.Field{Name: "b"}, minisql.OperandFloat, float64(-1.5)),
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE with negative integer in BETWEEN bounds",
+			"WHERE score BETWEEN -10 AND -1",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsBetween(minisql.Field{Name: "score"}, int64(-10), int64(-1)),
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE with negative integers in IN list",
+			"WHERE b IN (-1, -2, -3)",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsInAny(minisql.Field{Name: "b"}, int64(-1), int64(-2), int64(-3)),
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE with mixed positive and negative integers in IN list",
+			"WHERE b IN (-1, 0, 1)",
+			minisql.OneOrMore{
+				{
+					minisql.FieldIsInAny(minisql.Field{Name: "b"}, int64(-1), int64(0), int64(1)),
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, aTestCase := range testCases {


### PR DESCRIPTION
Teach the tokenizer to recognise '-' immediately followed by a digit as a negative number literal rather than a binary-minus operator. Both peekWithLength (token stream) and peekValue (typed value reader) are updated so they agree on the token boundary, keeping pop() correct.

Negative literals now work anywhere a value is expected: WHERE comparisons, BETWEEN bounds, IN lists, INSERT VALUES, and UPDATE SET. Arithmetic with proper spacing (a - 1) is unaffected.

Adds parser unit tests and an e2e test; removes the limitation from docs/limitations.md and AGENTS.md.