### PR TITLE
feat: add key rotation via db.ReKey and PRAGMA rekey

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ MiniSQL is an embedded, single-file SQL database written in Go, inspired by SQLi
 │   │   │
 │   │   │  ── Infrastructure ──
 │   │   ├── ports.go              # All key interfaces (Parser, Pager, TxPager, BTreeIndex, …)
-│   │   ├── pragma.go             # PRAGMA handler (synchronous, parallel_scan, foreign_keys, …)
+│   │   ├── pragma.go             # PRAGMA handler (synchronous, parallel_scan, foreign_keys, rekey, …)
 │   │   ├── config.go             # Constants: PageSize, MaxColumns, LRU defaults, …
 │   │   └── mocks_test.go         # Auto-generated mocks (never edit by hand)
 │   │
@@ -677,6 +677,8 @@ When adding filtering/transformation stages, insert them as goroutines between `
 - Opening a database requires a valid header magic/version/page size; old header layouts are intentionally rejected during the unstable pre-1.0 period.
 - When changing the header format, update both `internal/minisql/config.go` and `agent-os/standards/storage-engine/page-layout.md` in the same change.
 - WAL commits write frames to `{dbpath}-wal` and update the in-memory WAL index; the main database file is only written during a checkpoint.
+- **Transparent page encryption**: `WithEncryptionKey(key []byte)` option enables AES-256-CTR. The encryption salt (32 bytes) is stored in the plaintext header; the AES key is `HKDF(userKey, salt)`. Page 0 bytes 0-99 are always plaintext.
+- **Key rotation**: `db.ReKey(ctx, newKey)` or `PRAGMA rekey = '<hex>'` — uses the VACUUM copy-and-swap mechanism; the output file gets a fresh salt. `db.ReKey(ctx, nil)` removes encryption.
 
 ---
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -143,9 +143,80 @@ func main() {
 
 ---
 
+---
+
+## Key rotation
+
+Key rotation re-encrypts the entire database with a new key.  It is implemented
+as a crash-safe copy-and-swap (the same mechanism as `VACUUM`) so the original
+file is never modified in place.  A `.bak` backup is kept until the swap
+succeeds.
+
+### Via SQL (PRAGMA rekey)
+
+```sql
+PRAGMA rekey = '<hex-encoded-new-key>';
+```
+
+The value must be a hex-encoded key (same encoding as the DSN `encryption_key`
+parameter).
+
+```go
+import "encoding/hex"
+
+newKey := make([]byte, 32)
+rand.Read(newKey)
+
+// Rotate while the connection is still open.
+_, err = db.ExecContext(ctx, `PRAGMA rekey = '`+hex.EncodeToString(newKey)+`'`)
+if err != nil {
+    log.Fatal(err)
+}
+
+// After this call the in-process connection uses the new key.
+// The next time you open the file you must supply newKey, not the old one.
+```
+
+### Via the Go API
+
+```go
+import "github.com/RichardKnop/minisql/internal/minisql"
+
+// db is a *minisql.Database (obtained via NewDatabase or cast from driver.Conn).
+err := db.ReKey(ctx, newKey)   // key rotation / adding encryption
+err  = db.ReKey(ctx, nil)      // remove encryption
+```
+
+`ReKey(ctx, nil)` strips encryption — the resulting file is plaintext.
+There is no SQL equivalent for removing encryption; use the Go API directly.
+
+### Adding encryption to an existing plaintext database
+
+```sql
+-- DB was opened without a key; add encryption in-place.
+PRAGMA rekey = '<hex-encoded-new-key>';
+```
+
+After this, re-open the database with the key in the DSN:
+
+```go
+dsn := "/path/to/db.db?encryption_key=" + hex.EncodeToString(newKey)
+```
+
+### What happens during rotation
+
+1. A temporary database file is created and encrypted with the new key (gets a fresh random salt).
+2. All schema and rows are copied from the live database (decrypted with the old key → re-encrypted with the new key).
+3. The live file is atomically replaced by the temp file.
+4. The in-process connection is re-opened and the new cipher is installed.
+
+The operation holds the exclusive write lock for its full duration (same as `VACUUM`).
+
+---
+
 ## Notes
 
 - Encryption adds one AES-CTR encrypt/decrypt operation per page read or write. For most workloads the overhead is negligible.
 - The database file and WAL file should be treated as equally sensitive — both contain encrypted pages.
-- There is no support for key rotation; to change the key, use `VACUUM` after re-opening with the new key (VACUUM rewrites all pages, but key change support is a planned feature).
+- Key rotation always generates a fresh random salt, so the derived AES key changes even if the raw key material is the same.
 - `PRAGMA integrity_check` works on encrypted databases — pages are decrypted in-memory before the check.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -54,7 +54,7 @@ MiniSQL is a research and learning project, not yet production-ready. This page 
 |-----------|-------|
 | No connection pooling | `db.SetMaxOpenConns(1)` is required |
 | No online backup API | Use `VACUUM` to compact; copy the file while no writes are active |
-| No key rotation for encryption | Re-encrypt by opening with old key, then VACUUM (planned feature) |
+| Removing encryption has no SQL equivalent | Use `PRAGMA rekey = '<hex>'` to rotate or add a key; to remove encryption entirely use `db.ReKey(ctx, nil)` via the Go API |
 | `VACUUM` requires exclusive access | Blocks all other connections for its duration |
 
 ---

--- a/e2e_tests/encryption_test.go
+++ b/e2e_tests/encryption_test.go
@@ -186,6 +186,135 @@ func TestEncryption_KeyForUnencryptedDB(t *testing.T) {
 	assert.Contains(t, pingErr.Error(), "not encrypted")
 }
 
+// TestEncryption_ReKey_Rotation verifies that PRAGMA rekey rotates to a new key:
+// the database is unreadable with the old key and readable with the new key.
+func TestEncryption_ReKey_Rotation(t *testing.T) {
+	t.Parallel()
+
+	oldKey := []byte("e2e-old-key-rotation-32bytes-pad")
+	newKey := []byte("e2e-new-key-rotation-32bytes-pad")
+
+	f, err := os.CreateTemp("", "minisql-e2e-rekey-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// Create encrypted DB and insert a sentinel row.
+	{
+		db := openEncryptedDB(t, path, oldKey)
+		_, err = db.Exec(`create table "vault" (id int8 primary key autoincrement, secret text not null)`)
+		require.NoError(t, err)
+		_, err = db.Exec(`insert into "vault" (secret) values (?)`, "top-secret-value")
+		require.NoError(t, err)
+
+		// Rotate the key via PRAGMA.
+		_, err = db.ExecContext(context.Background(),
+			`PRAGMA rekey = '`+hex.EncodeToString(newKey)+`'`)
+		require.NoError(t, err)
+
+		// Data must be readable on the same (now re-keyed) connection.
+		var secret string
+		err = db.QueryRow(`select secret from "vault" where id = 1`).Scan(&secret)
+		require.NoError(t, err)
+		assert.Equal(t, "top-secret-value", secret)
+
+		require.NoError(t, db.Close())
+	}
+
+	// File must still be encrypted (no plaintext).
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("top-secret-value")), "plaintext found after key rotation")
+
+	// Opening with the old key must fail.
+	db2, err := sql.Open("minisql", encryptedDSN(path, oldKey))
+	require.NoError(t, err)
+	db2.SetMaxOpenConns(1)
+	assert.Error(t, db2.Ping(), "expected error when opening with old key after rotation")
+	db2.Close()
+
+	// Opening with the new key must succeed and data must be intact.
+	{
+		db := openEncryptedDB(t, path, newKey)
+		defer func() { require.NoError(t, db.Close()) }()
+		var secret string
+		err = db.QueryRow(`select secret from "vault" where id = 1`).Scan(&secret)
+		require.NoError(t, err)
+		assert.Equal(t, "top-secret-value", secret)
+	}
+}
+
+// TestEncryption_ReKey_AddEncryption verifies that PRAGMA rekey on a plaintext
+// database encrypts it and makes it unreadable without a key.
+func TestEncryption_ReKey_AddEncryption(t *testing.T) {
+	t.Parallel()
+
+	newKey := []byte("e2e-add-encryption-key-32bytes!!")
+
+	f, err := os.CreateTemp("", "minisql-e2e-rekey-add-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	}()
+
+	// Create a plaintext database and insert data.
+	{
+		db, err := sql.Open("minisql", path)
+		require.NoError(t, err)
+		db.SetMaxOpenConns(1)
+		require.NoError(t, db.Ping())
+
+		_, err = db.Exec(`create table "vault" (id int8 primary key autoincrement, secret text not null)`)
+		require.NoError(t, err)
+		_, err = db.Exec(`insert into "vault" (secret) values (?)`, "plaintext-to-encrypt")
+		require.NoError(t, err)
+
+		// Add encryption via PRAGMA rekey.
+		_, err = db.ExecContext(context.Background(),
+			`PRAGMA rekey = '`+hex.EncodeToString(newKey)+`'`)
+		require.NoError(t, err)
+
+		// Data must be readable immediately after.
+		var secret string
+		err = db.QueryRow(`select secret from "vault" where id = 1`).Scan(&secret)
+		require.NoError(t, err)
+		assert.Equal(t, "plaintext-to-encrypt", secret)
+
+		require.NoError(t, db.Close())
+	}
+
+	// File must now be encrypted.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("plaintext-to-encrypt")), "plaintext found after adding encryption")
+
+	// Opening without a key must fail.
+	db2, err := sql.Open("minisql", path)
+	require.NoError(t, err)
+	db2.SetMaxOpenConns(1)
+	pingErr := db2.Ping()
+	db2.Close()
+	require.Error(t, pingErr)
+	assert.Contains(t, pingErr.Error(), "encrypted")
+
+	// Opening with the new key must succeed.
+	{
+		db := openEncryptedDB(t, path, newKey)
+		defer func() { require.NoError(t, db.Close()) }()
+		var secret string
+		err = db.QueryRow(`select secret from "vault" where id = 1`).Scan(&secret)
+		require.NoError(t, err)
+		assert.Equal(t, "plaintext-to-encrypt", secret)
+	}
+}
+
 // TestEncryption_VacuumPreservesEncryption verifies that VACUUM on an encrypted
 // database produces a compacted file that is still encrypted and readable.
 func TestEncryption_VacuumPreservesEncryption(t *testing.T) {

--- a/e2e_tests/encryption_test.go
+++ b/e2e_tests/encryption_test.go
@@ -234,8 +234,9 @@ func TestEncryption_ReKey_Rotation(t *testing.T) {
 	db2, err := sql.Open("minisql", encryptedDSN(path, oldKey))
 	require.NoError(t, err)
 	db2.SetMaxOpenConns(1)
-	assert.Error(t, db2.Ping(), "expected error when opening with old key after rotation")
+	pingErr := db2.Ping()
 	db2.Close()
+	require.Error(t, pingErr, "expected error when opening with old key after rotation")
 
 	// Opening with the new key must succeed and data must be intact.
 	{

--- a/internal/minisql/encryption_test.go
+++ b/internal/minisql/encryption_test.go
@@ -246,3 +246,266 @@ func TestEncryption_SaltInHeader(t *testing.T) {
 	assert.Equal(t, EncryptionModeAES256CTR, hdr.EncryptionMode)
 	assert.NotEqual(t, [32]byte{}, hdr.EncryptionSalt, "salt must be non-zero")
 }
+
+// openPlainDB opens (or creates) a plaintext (unencrypted) file-backed database.
+func openPlainDB(t *testing.T, path string, p Parser) *Database {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	db, err := NewDatabase(context.Background(), testLogger, path, p, pager, pager, nil)
+	require.NoError(t, err)
+	return db
+}
+
+func encryptionTestRows(t *testing.T, db *Database) []string {
+	t.Helper()
+	ctx := context.Background()
+	var names []string
+	err := db.txManager.ExecuteReadOnlyTransaction(ctx, func(ctx context.Context) error {
+		result, err := db.ExecuteStatement(ctx, Statement{
+			Kind:      Select,
+			TableName: "users",
+			Columns:   encColumns,
+			Fields:    fieldsFromColumns(encColumns...),
+		})
+		if err != nil {
+			return err
+		}
+		for result.Rows.Next(ctx) {
+			row := result.Rows.Row()
+			v, ok := row.GetValue("name")
+			if ok && v.Valid {
+				names = append(names, v.Value.(TextPointer).String())
+			}
+		}
+		return result.Rows.Err()
+	})
+	require.NoError(t, err)
+	return names
+}
+
+// TestEncryption_ReKey_Rotation verifies that ReKey(ctx, newKey) re-encrypts
+// the database so it is readable with newKey and unreadable with the old key.
+func TestEncryption_ReKey_Rotation(t *testing.T) {
+	t.Parallel()
+
+	oldKey := []byte("old-secret-key-for-rotation-test")
+	newKey := []byte("new-secret-key-for-rotation-test")
+
+	f, err := os.CreateTemp("", "minisql-rekey-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	usersStmt := Statement{
+		Kind:      CreateTable,
+		TableName: "users",
+		Columns:   encColumns,
+	}
+
+	// Create encrypted DB with old key and insert rows.
+	{
+		db := openEncryptedDB(t, path, oldKey, nil)
+		ctx := context.Background()
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, usersStmt)
+			return err
+		}))
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: "users",
+				Columns:   encColumns,
+				Fields:    fieldsFromColumns(encColumns...),
+				Inserts: [][]OptionalValue{
+					{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("alice")), Valid: true}},
+					{{Value: int64(2), Valid: true}, {Value: NewTextPointer([]byte("bob")), Valid: true}},
+				},
+			})
+			return err
+		}))
+
+		// Wire the mock parser before ReKey — vacuumWithKey calls d.parser.Parse
+		// to re-parse stored table DDL when recreating schemas in the temp DB.
+		mp := new(MockParser)
+		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+		db.parser = mp
+
+		// Rotate the key while the DB is still open.
+		require.NoError(t, db.ReKey(ctx, newKey))
+
+		// Read-back after rotation — same connection, new cipher installed.
+		names := encryptionTestRows(t, db)
+		assert.ElementsMatch(t, []string{"alice", "bob"}, names)
+
+		require.NoError(t, db.Close())
+	}
+
+	// Reopen with new key — must succeed and data must be intact.
+	{
+		mp := new(MockParser)
+		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+		db := openEncryptedDB(t, path, newKey, mp)
+		defer func() { require.NoError(t, db.Close()) }()
+		names := encryptionTestRows(t, db)
+		assert.ElementsMatch(t, []string{"alice", "bob"}, names)
+	}
+
+	// Verify the file is still encrypted (no plaintext user names).
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("alice")), "plaintext 'alice' found after key rotation")
+	assert.False(t, bytes.Contains(raw, []byte("bob")), "plaintext 'bob' found after key rotation")
+
+	// Reopen with old key — must fail (wrong key / checksum mismatch).
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f2, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	_, dbErr := NewDatabase(context.Background(), testLogger, path, nil, pager, pager, nil,
+		WithEncryptionKey(oldKey),
+	)
+	assert.Error(t, dbErr, "expected error when opening with old key after rotation")
+}
+
+// TestEncryption_ReKey_AddEncryption verifies that ReKey(ctx, newKey) on an
+// unencrypted database produces an encrypted file.
+func TestEncryption_ReKey_AddEncryption(t *testing.T) {
+	t.Parallel()
+
+	newKey := []byte("brand-new-encryption-key-testing")
+
+	f, err := os.CreateTemp("", "minisql-rekey-add-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	usersStmt := Statement{
+		Kind:      CreateTable,
+		TableName: "users",
+		Columns:   encColumns,
+	}
+
+	// Create plaintext DB and insert a row.
+	{
+		db := openPlainDB(t, path, nil)
+		ctx := context.Background()
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, usersStmt)
+			return err
+		}))
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: "users",
+				Columns:   encColumns,
+				Fields:    fieldsFromColumns(encColumns...),
+				Inserts: [][]OptionalValue{
+					{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("carol")), Valid: true}},
+				},
+			})
+			return err
+		}))
+
+		// Wire the mock parser before ReKey — vacuumWithKey calls d.parser.Parse.
+		mp := new(MockParser)
+		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+		db.parser = mp
+
+		// Add encryption while the DB is open.
+		require.NoError(t, db.ReKey(ctx, newKey))
+		require.NoError(t, db.Close())
+	}
+
+	// File must no longer contain plaintext values.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.False(t, bytes.Contains(raw, []byte("carol")), "plaintext found after adding encryption")
+
+	// Reopen without key — must fail.
+	f2, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	pager, err := NewPager(f2, PageSize, PageCacheSize)
+	require.NoError(t, err)
+	_, dbErr := NewDatabase(context.Background(), testLogger, path, nil, pager, pager, nil)
+	require.Error(t, dbErr)
+	assert.Contains(t, dbErr.Error(), "encrypted")
+
+	// Reopen with the new key — must succeed and data must be intact.
+	mp := new(MockParser)
+	mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+	db := openEncryptedDB(t, path, newKey, mp)
+	defer func() { require.NoError(t, db.Close()) }()
+	names := encryptionTestRows(t, db)
+	assert.Equal(t, []string{"carol"}, names)
+}
+
+// TestEncryption_ReKey_RemoveEncryption verifies that ReKey(ctx, nil) on an
+// encrypted database produces a plaintext file.
+func TestEncryption_ReKey_RemoveEncryption(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("key-to-be-removed-after-this-op!")
+
+	f, err := os.CreateTemp("", "minisql-rekey-remove-*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	defer os.Remove(path)
+
+	usersStmt := Statement{
+		Kind:      CreateTable,
+		TableName: "users",
+		Columns:   encColumns,
+	}
+
+	// Create encrypted DB and insert a row.
+	{
+		db := openEncryptedDB(t, path, key, nil)
+		ctx := context.Background()
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, usersStmt)
+			return err
+		}))
+		require.NoError(t, db.txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			_, err := db.ExecuteStatement(ctx, Statement{
+				Kind:      Insert,
+				TableName: "users",
+				Columns:   encColumns,
+				Fields:    fieldsFromColumns(encColumns...),
+				Inserts: [][]OptionalValue{
+					{{Value: int64(1), Valid: true}, {Value: NewTextPointer([]byte("dave")), Valid: true}},
+				},
+			})
+			return err
+		}))
+
+		// Wire the mock parser before ReKey — vacuumWithKey calls d.parser.Parse.
+		mp := new(MockParser)
+		mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+		db.parser = mp
+
+		// Remove encryption.
+		require.NoError(t, db.ReKey(ctx, nil))
+		require.NoError(t, db.Close())
+	}
+
+	// Header must now show EncryptionModeNone.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var hdr DatabaseHeader
+	require.NoError(t, UnmarshalDatabaseHeader(raw[:RootPageConfigSize], &hdr))
+	assert.Equal(t, EncryptionModeNone, hdr.EncryptionMode)
+
+	// Reopen without key — must succeed and data must be intact.
+	mp := new(MockParser)
+	mp.On("Parse", mock.Anything, usersStmt.DDL()).Return([]Statement{usersStmt}, nil)
+	db := openPlainDB(t, path, mp)
+	defer func() { require.NoError(t, db.Close()) }()
+	names := encryptionTestRows(t, db)
+	assert.Equal(t, []string{"dave"}, names)
+}

--- a/internal/minisql/pragma.go
+++ b/internal/minisql/pragma.go
@@ -2,6 +2,7 @@ package minisql
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 )
@@ -39,6 +40,8 @@ func (d *Database) executePragmaStatement(ctx context.Context, stmt Statement) (
 			return StatementResult{}, fmt.Errorf("WAL checkpoint failed: %w", err)
 		}
 		return walCheckpointResult(), nil
+	case "rekey":
+		return d.executeRekeyPragma(ctx, stmt)
 	case "synchronous":
 		return d.executeSynchronousPragma(stmt)
 	case "parallel_scan":
@@ -228,6 +231,37 @@ func walCheckpointResult() StatementResult {
 		Columns: walCheckpointResultColumns,
 		Rows:    rowsIterator([]Row{row}),
 	}
+}
+
+var rekeyResultColumns = []Column{
+	{Kind: Text, Name: "rekey"},
+}
+
+// executeRekeyPragma handles PRAGMA rekey = '<hex-encoded-key>'.
+// It re-encrypts the database with the supplied key (key rotation or adding
+// encryption).  Pass an empty string to remove encryption.
+func (d *Database) executeRekeyPragma(ctx context.Context, stmt Statement) (StatementResult, error) {
+	if stmt.PragmaValue == "" {
+		return StatementResult{}, fmt.Errorf("PRAGMA rekey: a hex-encoded key value is required; " +
+			"to remove encryption use the Go API db.ReKey(ctx, nil)")
+	}
+	newKey, err := hex.DecodeString(stmt.PragmaValue)
+	if err != nil {
+		return StatementResult{}, fmt.Errorf("PRAGMA rekey: key must be hex-encoded: %w", err)
+	}
+	if len(newKey) == 0 {
+		return StatementResult{}, fmt.Errorf("PRAGMA rekey: decoded key must not be empty")
+	}
+	if err := d.ReKey(ctx, newKey); err != nil {
+		return StatementResult{}, fmt.Errorf("PRAGMA rekey: %w", err)
+	}
+	row := NewRowWithValues(rekeyResultColumns, []OptionalValue{
+		{Value: NewTextPointer([]byte("ok")), Valid: true},
+	})
+	return StatementResult{
+		Columns: rekeyResultColumns,
+		Rows:    rowsIterator([]Row{row}),
+	}, nil
 }
 
 func rowsIterator(rows []Row) Iterator {

--- a/internal/minisql/vacuum.go
+++ b/internal/minisql/vacuum.go
@@ -28,6 +28,29 @@ import (
 // VACUUM must not be called from inside an explicit user transaction; doing so
 // returns an error.
 func (d *Database) Vacuum(ctx context.Context) error {
+	return d.vacuumWithKey(ctx, d.encryptionKey)
+}
+
+// ReKey re-encrypts the database with newKey, atomically replacing the
+// database file via the same crash-safe copy-and-swap as VACUUM.
+//
+// Use cases:
+//   - Key rotation:         open with oldKey, call ReKey(ctx, newKey)
+//   - Add encryption:       open unencrypted DB, call ReKey(ctx, newKey)
+//   - Remove encryption:    open with oldKey, call ReKey(ctx, nil)
+//
+// The new file gets a fresh random salt, so the derived AES key changes even
+// if the raw key material is the same as before.  All data is preserved.
+//
+// ReKey must not be called from inside an explicit user transaction.
+func (d *Database) ReKey(ctx context.Context, newKey []byte) error {
+	return d.vacuumWithKey(ctx, newKey)
+}
+
+// vacuumWithKey is the shared implementation for Vacuum and ReKey.
+// It creates a temp database encrypted with newKey (nil = plaintext), copies
+// all data, atomically swaps the files, and reopens with newKey.
+func (d *Database) vacuumWithKey(ctx context.Context, newKey []byte) error {
 	tempFile := d.GetFileName() + ".tmp"
 	backupFile := d.GetFileName() + ".bak"
 
@@ -58,8 +81,8 @@ func (d *Database) Vacuum(ctx context.Context) error {
 	}
 
 	tempDBOpts := []DatabaseOption{}
-	if len(d.encryptionKey) > 0 {
-		tempDBOpts = append(tempDBOpts, WithEncryptionKey(d.encryptionKey))
+	if len(newKey) > 0 {
+		tempDBOpts = append(tempDBOpts, WithEncryptionKey(newKey))
 	}
 	tempDB, err := NewDatabase(context.Background(), d.logger, tempFile, d.parser, tempPager, tempPager, nil, tempDBOpts...)
 	if err != nil {
@@ -239,6 +262,11 @@ func (d *Database) Vacuum(ctx context.Context) error {
 		newFile.Close()
 		return fmt.Errorf("vacuum: create new pager: %w", err)
 	}
+
+	// Update the encryption key before reopening so that setupEncryption inside
+	// Reopen uses the new key (relevant when adding, rotating, or removing
+	// encryption via ReKey).
+	d.encryptionKey = newKey
 
 	// Reopen replaces d.txManager with a fresh instance so stale page version
 	// numbers from the old file cannot cause spurious OCC conflicts.


### PR DESCRIPTION
Implement Database.ReKey(ctx, newKey) using the existing VACUUM copy-and-swap machinery. vacuumWithKey is extracted as an internal method shared by both Vacuum (same key) and ReKey (new key).

PRAGMA rekey = '<hex-key>' exposes key rotation over SQL. Supports:
  - Key rotation: open with old key, PRAGMA rekey = '<new-hex>'
  - Adding encryption: open plaintext DB, PRAGMA rekey = '<new-hex>'
  - Removing encryption: db.ReKey(ctx, nil) via Go API

The output file always gets a fresh random salt so the derived AES key changes even when the raw key material is reused. The operation is crash-safe (live.bak backup) and holds the exclusive write lock for its full duration, identical to VACUUM.

Adds unit tests (rotation, add, remove) and e2e tests (rotation, add-encryption via PRAGMA). Updates docs/encryption.md with a full key rotation section and removes the stale limitation entry.