### PR TITLE
feat: support ? placeholders in HAVING clauses

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -22,7 +22,6 @@ MiniSQL is a research and learning project, not yet production-ready. This page 
 | Limitation | Workaround |
 |-----------|------------|
 | `FROM table alias` (bare alias) | Use `FROM table AS alias` |
-| `HAVING` does not accept `?` placeholders | Use literal values in HAVING conditions |
 
 ---
 

--- a/e2e_tests/aggregate_test.go
+++ b/e2e_tests/aggregate_test.go
@@ -632,6 +632,95 @@ func (s *TestSuite) TestHaving() {
 		s.Require().Error(err)
 		s.Contains(err.Error(), "HAVING requires GROUP BY")
 	})
+
+	s.Run("HAVING with placeholder", func() {
+		// Only groups where SUM(total_paid) > 40: user_id=2 (70) and user_id=3 (50).
+		rows, err := s.db.QueryContext(context.Background(),
+			`select user_id, SUM(total_paid) from orders GROUP BY user_id HAVING SUM(total_paid) > ?;`,
+			int64(40),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			sum    int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.sum))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 2)
+
+		sort.Slice(got, func(i, j int) bool { return got[i].userID < got[j].userID })
+		s.Equal(int64(2), got[0].userID)
+		s.Equal(int64(70), got[0].sum)
+		s.Equal(int64(3), got[1].userID)
+		s.Equal(int64(50), got[1].sum)
+	})
+
+	s.Run("WHERE and HAVING both with placeholders", func() {
+		// WHERE total_paid > 10 removes user_id=1 row with total=10.
+		// user_id=1: 20 → sum=20, user_id=2: 30+40 → sum=70, user_id=3: 50 → sum=50
+		// HAVING SUM > 30 keeps user_id=2 (70) and user_id=3 (50).
+		rows, err := s.db.QueryContext(context.Background(),
+			`select user_id, SUM(total_paid) from orders where total_paid > ? GROUP BY user_id HAVING SUM(total_paid) > ?;`,
+			int64(10), int64(30),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			sum    int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.sum))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 2)
+
+		sort.Slice(got, func(i, j int) bool { return got[i].userID < got[j].userID })
+		s.Equal(int64(2), got[0].userID)
+		s.Equal(int64(70), got[0].sum)
+		s.Equal(int64(3), got[1].userID)
+		s.Equal(int64(50), got[1].sum)
+	})
+
+	s.Run("HAVING COUNT with placeholder", func() {
+		// Only groups with COUNT(*) >= 2: user_id=1 and user_id=2.
+		rows, err := s.db.QueryContext(context.Background(),
+			`select user_id, COUNT(*) from orders GROUP BY user_id HAVING COUNT(*) >= ?;`,
+			int64(2),
+		)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			count  int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.count))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 2)
+
+		sort.Slice(got, func(i, j int) bool { return got[i].userID < got[j].userID })
+		s.Equal(int64(1), got[0].userID)
+		s.Equal(int64(2), got[0].count)
+		s.Equal(int64(2), got[1].userID)
+		s.Equal(int64(2), got[1].count)
+	})
 }
 
 func (s *TestSuite) TestGroupByWithJoinRejected() {

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -540,6 +540,22 @@ func (s Statement) NumPlaceholders() int {
 		count += cte.Body.NumPlaceholders()
 	}
 
+	for _, condGroup := range s.Having {
+		for _, cond := range condGroup {
+			if cond.Operand2.Type == OperandPlaceholder {
+				count += 1
+				continue
+			}
+			if cond.Operand2.Type == OperandList {
+				for _, value := range cond.Operand2.Value.([]any) {
+					if _, ok := value.(Placeholder); ok {
+						count += 1
+					}
+				}
+			}
+		}
+	}
+
 	// Count placeholders embedded in SELECT field expressions (e.g. VEC_L2(v, ?)).
 	if s.Kind == Select {
 		for _, field := range s.Fields {
@@ -838,6 +854,38 @@ func (s Statement) BindArguments(args ...any) (Statement, error) {
 				}
 				cond.Operand2.Value = newList
 				stmt.Conditions[i][j] = cond
+			}
+		}
+	}
+
+	for i, condGroup := range stmt.Having {
+		for j, cond := range condGroup {
+			if cond.Operand2.Type == OperandPlaceholder {
+				if len(args) == 0 {
+					return Statement{}, errors.New("not enough arguments to bind placeholders")
+				}
+				cond.Operand2.Type = operandTypeFromAny(args[0])
+				cond.Operand2.Value = args[0]
+				stmt.Having[i][j] = cond
+				args = args[1:]
+				continue
+			}
+			if cond.Operand2.Type == OperandList {
+				origList := cond.Operand2.Value.([]any)
+				newList := make([]any, len(origList))
+				copy(newList, origList)
+				for k, value := range newList {
+					if _, ok := value.(Placeholder); !ok {
+						continue
+					}
+					if len(args) == 0 {
+						return Statement{}, errors.New("not enough arguments to bind placeholders")
+					}
+					newList[k] = args[0]
+					args = args[1:]
+				}
+				cond.Operand2.Value = newList
+				stmt.Having[i][j] = cond
 			}
 		}
 	}

--- a/internal/parser/select_test.go
+++ b/internal/parser/select_test.go
@@ -962,6 +962,67 @@ func TestParse_SelectHaving(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"HAVING with placeholder",
+			"SELECT user_id, SUM(total) FROM orders GROUP BY user_id HAVING SUM(total) > ?;",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Select,
+					TableName: "orders",
+					Fields: []minisql.Field{
+						{Name: "user_id"},
+						{Name: "SUM(total)"},
+					},
+					Aggregates: []minisql.AggregateExpr{
+						{},
+						{Kind: minisql.AggregateSum, Column: "total"},
+					},
+					GroupBy: []minisql.Field{{Name: "user_id"}},
+					Having: minisql.OneOrMore{
+						{{
+							Operand1: minisql.Operand{Type: minisql.OperandField, Value: minisql.Field{Name: "SUM(total)"}},
+							Operator: minisql.Gt,
+							Operand2: minisql.Operand{Type: minisql.OperandPlaceholder},
+						}},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"WHERE and HAVING both with placeholders",
+			"SELECT user_id, COUNT(*) FROM orders WHERE status = ? GROUP BY user_id HAVING COUNT(*) >= ?;",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.Select,
+					TableName: "orders",
+					Fields: []minisql.Field{
+						{Name: "user_id"},
+						{Name: "COUNT(*)"},
+					},
+					Aggregates: []minisql.AggregateExpr{
+						{},
+						{Kind: minisql.AggregateCount},
+					},
+					GroupBy: []minisql.Field{{Name: "user_id"}},
+					Conditions: minisql.OneOrMore{
+						{{
+							Operand1: minisql.Operand{Type: minisql.OperandField, Value: minisql.Field{Name: "status"}},
+							Operator: minisql.Eq,
+							Operand2: minisql.Operand{Type: minisql.OperandPlaceholder},
+						}},
+					},
+					Having: minisql.OneOrMore{
+						{{
+							Operand1: minisql.Operand{Type: minisql.OperandField, Value: minisql.Field{Name: "COUNT(*)"}},
+							Operator: minisql.Gte,
+							Operand2: minisql.Operand{Type: minisql.OperandPlaceholder},
+						}},
+					},
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, aTestCase := range testCases {


### PR DESCRIPTION
NumPlaceholders and BindArguments in stmt.go only iterated over Conditions (WHERE), silently ignoring Having. The parser already accepted ? via the shared parseCondScalarValue path; the missing piece was counting and binding them in the correct left-to-right order (after WHERE, before SELECT field expressions).