### PR TITLE
feat: add FuzzParser harness; fix two infinite-loop bugs found by fuzzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ LOG_LEVEL=info go test ./... -count=1
 
 Setting `LOG_LEVEL=info` suppresses debug output and makes test failures easier to read.
 
+### Fuzz testing
+
+MiniSQL uses Go's built-in fuzzer (`go test -fuzz`) to find parser bugs and
+storage corruption issues that structured unit tests are unlikely to reach.
+
+**Run the parser fuzzer** (stops after 60 s; adjust `-fuzztime` as needed):
+
+```sh
+go test -fuzz=FuzzParser -fuzztime=60s ./internal/parser/
+```
+
+**Run seeds only** (fast, no mutation — safe for CI):
+
+```sh
+go test -run=FuzzParser ./internal/parser/
+```
+
+Corpus entries that previously found real bugs live in
+`internal/parser/testdata/fuzz/FuzzParser/` and are automatically replayed as
+ordinary unit tests on every `go test` run. When the fuzzer discovers a new
+crash it writes the minimised input to that directory; commit it so the fix is
+covered by CI forever.
+
 ### Run linter
 
 ```sh

--- a/internal/parser/fuzz_test.go
+++ b/internal/parser/fuzz_test.go
@@ -1,0 +1,179 @@
+package parser
+
+import (
+	"context"
+	"testing"
+)
+
+// FuzzParser verifies that the SQL parser never panics on arbitrary input.
+// The only invariant enforced is no-panic: the parser must return either a
+// valid statement slice or an error, never crash.
+//
+// Run for a fixed time during development:
+//
+//	go test -fuzz=FuzzParser -fuzztime=60s ./internal/parser/
+//
+// Seeds are run as ordinary unit tests on every `go test` invocation.
+func FuzzParser(f *testing.F) {
+	seeds := []string{
+		// SELECT — basic
+		"SELECT * FROM users;",
+		"SELECT id, name FROM users;",
+		"SELECT DISTINCT id FROM users;",
+		"SELECT * FROM users LIMIT 10;",
+		"SELECT * FROM users LIMIT 10 OFFSET 20;",
+		"SELECT * FROM users ORDER BY id ASC;",
+		"SELECT * FROM users ORDER BY id DESC, name ASC;",
+
+		// SELECT — WHERE
+		"SELECT * FROM users WHERE id = 1;",
+		"SELECT * FROM users WHERE id != 1;",
+		"SELECT * FROM users WHERE id > 1 AND active = true;",
+		"SELECT * FROM users WHERE status = 'active' OR status = 'pending';",
+		"SELECT * FROM users WHERE id IN (1, 2, 3);",
+		"SELECT * FROM users WHERE id NOT IN (1, 2, 3);",
+		"SELECT * FROM users WHERE id BETWEEN 10 AND 20;",
+		"SELECT * FROM users WHERE name LIKE 'Al%';",
+		"SELECT * FROM users WHERE name ILIKE 'alice%';",
+		"SELECT * FROM users WHERE nickname IS NULL;",
+		"SELECT * FROM users WHERE email IS NOT NULL;",
+		"SELECT * FROM users WHERE id = ?;",
+		"SELECT * FROM users WHERE id > ? AND active = ?;",
+
+		// SELECT — aggregates / GROUP BY / HAVING
+		"SELECT COUNT(*) FROM orders;",
+		"SELECT SUM(total_paid) FROM orders;",
+		"SELECT user_id, COUNT(*) FROM orders GROUP BY user_id;",
+		"SELECT user_id, SUM(total) FROM orders GROUP BY user_id HAVING SUM(total) > 100;",
+		"SELECT user_id, COUNT(*) FROM orders GROUP BY user_id HAVING COUNT(*) >= ?;",
+
+		// SELECT — JOINs
+		"SELECT u.id, o.id FROM users AS u INNER JOIN orders AS o ON u.id = o.user_id;",
+		"SELECT u.id, o.id FROM users AS u LEFT JOIN orders AS o ON u.id = o.user_id;",
+		"SELECT u.id, o.id FROM users AS u RIGHT JOIN orders AS o ON u.id = o.user_id;",
+		"SELECT u.id, o.id FROM users AS u FULL OUTER JOIN orders AS o ON u.id = o.user_id;",
+
+		// SELECT — subqueries
+		"SELECT * FROM users WHERE id IN (SELECT user_id FROM orders WHERE total_paid > 100);",
+		"SELECT * FROM (SELECT id, name FROM users) AS sub;",
+
+		// SELECT — arithmetic and expressions
+		"SELECT price * quantity AS total FROM order_lines;",
+		"SELECT id, a + b * c FROM t;",
+		"SELECT CAST(score AS INT8) FROM results;",
+
+		// SELECT — JSON operators
+		"SELECT payload -> 'name' FROM events;",
+		"SELECT payload ->> 'uid' FROM events;",
+		"SELECT * FROM events WHERE payload ->> 'type' = 'login';",
+
+		// SELECT — CASE WHEN
+		"SELECT CASE WHEN score >= 90 THEN 'A' ELSE 'B' END FROM results;",
+		"SELECT CASE status WHEN 1 THEN 'active' WHEN 2 THEN 'pending' ELSE 'other' END FROM t;",
+
+		// SELECT — CTEs
+		"WITH cte AS (SELECT id, name FROM users) SELECT cte.name FROM cte;",
+		"WITH a AS (SELECT id FROM t), b AS (SELECT id FROM a) SELECT * FROM b;",
+
+		// SELECT — window functions
+		"SELECT id, ROW_NUMBER() OVER (ORDER BY id) FROM users;",
+		"SELECT id, RANK() OVER (PARTITION BY dept ORDER BY salary DESC) FROM employees;",
+
+		// SELECT — UNION
+		"SELECT id FROM a UNION SELECT id FROM b;",
+		"SELECT id FROM a UNION ALL SELECT id FROM b;",
+
+		// SELECT — EXPLAIN
+		"EXPLAIN SELECT * FROM users WHERE id = 1;",
+		"EXPLAIN ANALYZE SELECT * FROM users WHERE id = 1;",
+
+		// INSERT
+		"INSERT INTO users (name, email) VALUES ('alice', 'alice@example.com');",
+		"INSERT INTO users (id, name) VALUES (1, 'bob'), (2, 'carol');",
+		"INSERT INTO users (name) VALUES (?);",
+		"INSERT INTO users (name) VALUES (-42);",
+		"INSERT INTO users (name) VALUES (-3.14);",
+		"INSERT INTO users (name) VALUES (NULL);",
+		"INSERT INTO users (id, name) VALUES (1, 'x') ON CONFLICT DO NOTHING;",
+		"INSERT INTO users (id, name) VALUES (1, 'x') ON CONFLICT DO UPDATE SET name = EXCLUDED.name;",
+		"INSERT INTO users (id, name) SELECT id, name FROM staging;",
+		"INSERT INTO users (name) VALUES ('alice') RETURNING id;",
+
+		// UPDATE
+		"UPDATE users SET name = 'bob' WHERE id = 1;",
+		"UPDATE users SET name = ?, active = ? WHERE id = ?;",
+		"UPDATE users SET score = score + 1 WHERE active = true;",
+		"UPDATE users SET name = 'x' WHERE id = 1 RETURNING id, name;",
+
+		// DELETE
+		"DELETE FROM users WHERE id = 1;",
+		"DELETE FROM users WHERE id = ?;",
+		"DELETE FROM users;",
+		"DELETE FROM users WHERE id = 1 RETURNING id;",
+
+		// CREATE TABLE
+		"CREATE TABLE t (id INT8 PRIMARY KEY AUTOINCREMENT, name VARCHAR(255) NOT NULL);",
+		"CREATE TABLE t (id INT8, val DOUBLE, ts TIMESTAMP DEFAULT NOW());",
+		"CREATE TABLE t (id INT8 PRIMARY KEY, ref INT8 REFERENCES other(id));",
+		"CREATE TABLE IF NOT EXISTS t (id INT8);",
+		"CREATE TABLE t (id INT8, payload JSON, embedding VECTOR(128));",
+
+		// CREATE INDEX
+		"CREATE INDEX idx ON users (email);",
+		"CREATE UNIQUE INDEX idx ON users (email);",
+		"CREATE INDEX idx ON users (active) WHERE active = true;",
+		"CREATE FULLTEXT INDEX idx ON articles (body);",
+		"CREATE INVERTED INDEX idx ON events (payload);",
+		"CREATE HNSW INDEX idx ON documents (embedding);",
+		"CREATE HNSW INDEX idx ON documents (embedding) WITH (m = 16, ef_construction = 200);",
+
+		// DROP
+		"DROP TABLE users;",
+		"DROP TABLE IF EXISTS users;",
+		"DROP INDEX idx;",
+		"DROP INDEX IF EXISTS idx;",
+
+		// ALTER TABLE
+		"ALTER TABLE users ADD COLUMN bio TEXT;",
+		"ALTER TABLE users DROP COLUMN bio;",
+		"ALTER TABLE users RENAME COLUMN bio TO biography;",
+		"ALTER TABLE users RENAME TO members;",
+
+		// TRUNCATE
+		"TRUNCATE TABLE users;",
+
+		// PRAGMA
+		"PRAGMA quick_check;",
+		"PRAGMA integrity_check;",
+		"PRAGMA wal_checkpoint;",
+		"PRAGMA synchronous = normal;",
+		"PRAGMA parallel_scan = on;",
+		"PRAGMA foreign_keys = on;",
+
+		// Edge cases: empty-ish / degenerate inputs
+		"",
+		";",
+		"   ",
+		"SELECT",
+		"SELECT *",
+		"SELECT * FROM",
+		"WHERE id = 1",
+		"INSERT INTO",
+		"DROP",
+		"--",
+		"' OR '1'='1",
+		"SELECT * FROM users; DROP TABLE users;",
+		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, sql string) {
+		p := New()
+		// The only contract: Parse must never panic.
+		// Errors are expected and fine; panics are bugs.
+		_, _ = p.Parse(context.Background(), sql)
+	})
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -205,7 +205,18 @@ func New() *parser {
 
 // Parse parses the given SQL string and returns a slice of statements.
 func (p *parser) Parse(ctx context.Context, sql string) ([]minisql.Statement, error) {
-	normalised := strings.Join(strings.Fields(sql), " ")
+	// Replace all control characters with spaces before splitting. strings.Fields
+	// normalises common whitespace (tab, newline, etc.) but leaves other control
+	// characters such as \x15 (NAK) in place. The tokenizer has no rule for them
+	// and would loop infinitely. Replacing with a space (not dropping) preserves
+	// word boundaries for control chars used as separators in multi-line SQL.
+	stripped := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, sql)
+	normalised := strings.Join(strings.Fields(stripped), " ")
 	item := &parserItem{
 		sql:      normalised,
 		upperSQL: strings.ToUpper(normalised),
@@ -552,6 +563,11 @@ func (p *parserItem) doParse() ([]minisql.Statement, error) {
 				} else {
 					return statements, nil
 				}
+			} else if p.i < len(p.sql) {
+				// peek() returned "" but we are not at EOF: unrecognized bytes remain
+				// (e.g. non-ASCII outside a quoted string). Return an error instead of
+				// looping forever.
+				return statements, p.errorf("at STATEMENT: unexpected character")
 			}
 		}
 	}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -73,6 +73,41 @@ func TestPeekIntWithLength(t *testing.T) {
 	}
 }
 
+// TestParse_FuzzerRegressions covers inputs that previously caused infinite
+// loops in the parser. Each case must return within a reasonable time and
+// must not panic — an error return is acceptable.
+func TestParse_FuzzerRegressions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{
+			// \x15 (NAK) is a C0 control character that strings.Fields does not
+			// treat as whitespace. The tokenizer had no rule for it and returned
+			// ("", 0) from peekWithLength, so pop() never advanced p.i.
+			name: "control character mid-SQL causes infinite loop",
+			sql:  "SELECT * FROM users\x15ORDER BY id ASC;",
+		},
+		{
+			// \xe7 is an invalid UTF-8 lead byte; strings.Map re-encodes it as
+			// U+FFFD (\xef\xbf\xbd). The tokenizer also returned ("", 0) for
+			// U+FFFD, and stepStatementEnd looped forever when peek() returned ""
+			// but p.i was still less than len(sql).
+			name: "non-ASCII byte mid-SQL causes infinite loop",
+			sql:  "SELECT * FROM users\xe7\xe7\xe7\xe7\xe7E id IN (1, 2, 3);",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The test must complete (no hang); a parse error is fine.
+			_, _ = New().Parse(context.Background(), tc.sql)
+		})
+	}
+}
+
 func TestPeekIdentifierWithLength(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/testdata/fuzz/FuzzParser/1da3db25c5b5b931
+++ b/internal/parser/testdata/fuzz/FuzzParser/1da3db25c5b5b931
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("SELECT * FROM users\xe7\xe7\xe7\xe7\xe7E id IN (1, 2, 3);")

--- a/internal/parser/testdata/fuzz/FuzzParser/321b74cffff1c3f6
+++ b/internal/parser/testdata/fuzz/FuzzParser/321b74cffff1c3f6
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("SELECT * FROM users\x15ORDER BY id ASC;")


### PR DESCRIPTION
FuzzParser (internal/parser/fuzz_test.go) seeds the parser with one example of every statement kind and verifies that Parse never panics on arbitrary input. Running it for 15 s immediately found two bugs:

1. Control characters (e.g. \x15 NAK) that strings.Fields does not treat as whitespace were left in the normalized SQL. The tokenizer has no rule for them and looped forever. Fix: replace all Unicode control characters with spaces before field-splitting.

2. Non-ASCII bytes outside single-quoted strings (e.g. \xe7, which re-encodes as U+FFFD after strings.Map) produced the same result: peekWithLength returned ("", 0), leaving p.i stuck. The root cause was stepStatementEnd: when peek() returns "" but p.i < len(sql), neither the semicolon branch nor the error branch ran, so the outer for loop re-entered the same case forever. Fix: add an else branch that returns a parse error when unrecognized bytes remain.

The two minimised corpus entries are kept as regression seeds.