### PR TITLE
Add FuzzPageUnmarshal and fix Unmarshal bounds panics

### DIFF
--- a/internal/minisql/free_page.go
+++ b/internal/minisql/free_page.go
@@ -26,6 +26,10 @@ func (n *FreePage) Marshal(buf []byte) error {
 // Unmarshal deserialises a free-page record from buf, reading the type byte
 // and the next-free-page pointer.
 func (n *FreePage) Unmarshal(buf []byte) error {
+	const minSize = 1 + 4 // type byte + NextFreePage
+	if len(buf) < minSize {
+		return fmt.Errorf("free page unmarshal: buffer too short (%d < %d)", len(buf), minSize)
+	}
 	i := uint64(0)
 
 	if buf[i] != PageTypeFree {

--- a/internal/minisql/fuzz_page_test.go
+++ b/internal/minisql/fuzz_page_test.go
@@ -1,0 +1,165 @@
+package minisql
+
+import (
+	"testing"
+)
+
+// FuzzPageUnmarshal verifies that the B-tree page deserialization paths never
+// panic on arbitrary byte input. The only invariant enforced is no-panic:
+// every Unmarshal must return either a valid struct or an error.
+//
+// Run for a fixed time during development:
+//
+//	go test -fuzz=FuzzPageUnmarshal -fuzztime=60s ./internal/minisql/
+//
+// Seeds are run as ordinary unit tests on every `go test` invocation.
+func FuzzPageUnmarshal(f *testing.F) {
+	// --- Seed: minimal valid leaf page (two INT8 rows) ---
+	f.Add(makeLeafSeed(), PageTypeLeaf)
+
+	// --- Seed: minimal valid internal page (one separator key) ---
+	f.Add(makeInternalSeed(), PageTypeInternal)
+
+	// --- Seed: minimal valid overflow page ---
+	f.Add(makeOverflowSeed(), PageTypeOverflow)
+
+	// --- Seed: minimal valid free page ---
+	f.Add(makeFreeSeed(), PageTypeFree)
+
+	// --- Seed: zero-length buffer (always an error, must not panic) ---
+	f.Add([]byte{}, PageTypeLeaf)
+
+	// --- Seed: single byte (too short for any header) ---
+	f.Add([]byte{PageTypeLeaf}, PageTypeLeaf)
+	f.Add([]byte{PageTypeInternal}, PageTypeInternal)
+
+	f.Fuzz(func(t *testing.T, buf []byte, hint byte) {
+		// Exercise every Unmarshal path. None may panic regardless of input.
+
+		// Cell (innermost unit — used by LeafNode)
+		c := &Cell{}
+		_, _ = c.Unmarshal(buf)
+
+		// LeafNode
+		leaf := NewLeafNode()
+		_, _ = leaf.Unmarshal(buf)
+
+		// InternalNode
+		internal := new(InternalNode)
+		_, _ = internal.Unmarshal(buf)
+
+		// OverflowPage
+		overflow := new(OverflowPage)
+		_ = overflow.Unmarshal(buf)
+
+		// FreePage
+		free := new(FreePage)
+		_ = free.Unmarshal(buf)
+
+		// tablePager dispatcher: routes on the first byte, same as on-disk reads.
+		// Use hint to force each page-type branch even when buf starts differently.
+		if len(buf) > 0 {
+			// Drive the dispatcher with the original buf (any leading byte).
+			dispatchUnmarshal(buf)
+
+			// Also drive it with hint as the leading type byte so the fuzzer can
+			// explore the less-common branches (free, overflow) more easily.
+			patched := make([]byte, len(buf))
+			copy(patched, buf)
+			patched[0] = hint
+			dispatchUnmarshal(patched)
+		}
+	})
+}
+
+// dispatchUnmarshal replicates the tablePager.unmarshal dispatcher for a
+// non-root page (pageIdx > 0, so no RootPageConfigSize prefix is skipped).
+func dispatchUnmarshal(buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+	switch buf[0] {
+	case PageTypeLeaf:
+		leaf := NewLeafNode()
+		_, _ = leaf.Unmarshal(buf)
+	case PageTypeInternal:
+		internal := new(InternalNode)
+		_, _ = internal.Unmarshal(buf)
+	case PageTypeOverflow:
+		overflow := new(OverflowPage)
+		_ = overflow.Unmarshal(buf)
+	case PageTypeFree:
+		free := new(FreePage)
+		_ = free.Unmarshal(buf)
+	}
+}
+
+// --- seed helpers -----------------------------------------------------------
+
+// makeLeafSeed builds a valid 4096-byte leaf-page buffer containing two INT8
+// cells. This gives the fuzzer a realistic starting point.
+func makeLeafSeed() []byte {
+	cells := []Cell{
+		makeInt8Cell(1, 100),
+		makeInt8Cell(2, 200),
+	}
+	leaf := &LeafNode{
+		Header: LeafNodeHeader{
+			Header: Header{IsInternal: false, IsRoot: true, Parent: 0},
+			Cells:  uint32(len(cells)),
+		},
+		Cells: cells,
+	}
+	buf := make([]byte, PageSize)
+	_ = leaf.Marshal(buf)
+	return buf
+}
+
+// makeInternalSeed builds a valid 4096-byte internal-page buffer with one
+// separator key and two child pointers.
+func makeInternalSeed() []byte {
+	node := NewInternalNode()
+	node.Header.IsRoot = true
+	node.Header.KeysNum = 1
+	node.Header.RightChild = PageIndex(2)
+	node.ICells[0] = ICell{Key: RowID(50), Child: PageIndex(1)}
+	buf := make([]byte, PageSize)
+	_ = node.Marshal(buf)
+	return buf
+}
+
+// makeOverflowSeed builds a valid 4096-byte overflow page with a small payload.
+func makeOverflowSeed() []byte {
+	data := []byte("hello overflow world")
+	op := &OverflowPage{
+		Header: OverflowPageHeader{
+			NextPage: 0,
+			DataSize: uint32(len(data)),
+		},
+		Data: data,
+	}
+	buf := make([]byte, PageSize)
+	_ = op.Marshal(buf)
+	return buf
+}
+
+// makeFreeSeed builds a valid 4096-byte free page.
+func makeFreeSeed() []byte {
+	fp := &FreePage{NextFreePage: 0}
+	buf := make([]byte, PageSize)
+	_ = fp.Marshal(buf)
+	return buf
+}
+
+// makeInt8Cell constructs a self-describing Cell with a single INT8 column.
+func makeInt8Cell(key RowID, value int64) Cell {
+	valueBuf := make([]byte, 8)
+	marshalInt64(valueBuf, value, 0)
+	return Cell{
+		NullBitmask: 0,
+		Key:         key,
+		ColumnCount: 1,
+		TypeCodes:   []byte{byte(TypeCodeInt8)},
+		Value:       valueBuf,
+	}
+}

--- a/internal/minisql/header.go
+++ b/internal/minisql/header.go
@@ -44,6 +44,9 @@ func (h *Header) Marshal(buf []byte) {
 
 // Unmarshal reads the header fields from buf and returns the number of bytes consumed.
 func (h *Header) Unmarshal(buf []byte) (uint64, error) {
+	if uint64(len(buf)) < h.Size() {
+		return 0, fmt.Errorf("header unmarshal: buffer too short (%d < %d)", len(buf), h.Size())
+	}
 	if buf[0] != PageTypeLeaf && buf[0] != PageTypeInternal {
 		return 0, fmt.Errorf("unrecognised page type byte %d", buf[0])
 	}

--- a/internal/minisql/internal_node.go
+++ b/internal/minisql/internal_node.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"fmt"
 	"math"
 )
 
@@ -49,6 +50,9 @@ func (h *InternalNodeHeader) Marshal(buf []byte) {
 
 // Unmarshal deserialises the header from buf and returns the number of bytes consumed.
 func (h *InternalNodeHeader) Unmarshal(buf []byte) (uint64, error) {
+	if uint64(len(buf)) < h.Size() {
+		return 0, fmt.Errorf("internal node header unmarshal: buffer too short (%d < %d)", len(buf), h.Size())
+	}
 	i := uint64(0)
 
 	hi, err := h.Header.Unmarshal(buf[i:])
@@ -99,6 +103,9 @@ func (c *ICell) Marshal(buf []byte) {
 
 // Unmarshal deserialises an ICell from buf and returns the number of bytes consumed.
 func (c *ICell) Unmarshal(buf []byte) (uint64, error) {
+	if uint64(len(buf)) < c.Size() {
+		return 0, fmt.Errorf("ICell unmarshal: buffer too short (%d < %d)", len(buf), c.Size())
+	}
 	i := uint64(0)
 
 	c.Key = RowID(unmarshalUint64(buf, i))
@@ -179,6 +186,10 @@ func (n *InternalNode) Unmarshal(buf []byte) (uint64, error) {
 		return 0, err
 	}
 	i += hi
+
+	if n.Header.KeysNum > InternalNodeMaxCells {
+		return 0, fmt.Errorf("internal node unmarshal: KeysNum %d exceeds max %d", n.Header.KeysNum, InternalNodeMaxCells)
+	}
 
 	for idx := range n.ICells[0:n.Header.KeysNum] {
 		ci, err := n.ICells[idx].Unmarshal(buf[i:])

--- a/internal/minisql/leaf_node.go
+++ b/internal/minisql/leaf_node.go
@@ -35,6 +35,9 @@ func (h *LeafNodeHeader) Marshal(buf []byte) {
 
 // Unmarshal deserialises the header from buf and returns the number of bytes consumed.
 func (h *LeafNodeHeader) Unmarshal(buf []byte) (uint64, error) {
+	if uint64(len(buf)) < h.Size() {
+		return 0, fmt.Errorf("leaf node header unmarshal: buffer too short (%d < %d)", len(buf), h.Size())
+	}
 	i := uint64(0)
 
 	hi, err := h.Header.Unmarshal(buf[i:])
@@ -97,6 +100,10 @@ func (c *Cell) Marshal(buf []byte) {
 // Value is copied into owned memory so that the cell does not alias the source
 // buffer (WAL frame buffers are pooled and reused across commits).
 func (c *Cell) Unmarshal(buf []byte) (uint64, error) {
+	const minCellSize = 8 + 8 + 1 // NullBitmask + Key + ColumnCount
+	if len(buf) < minCellSize {
+		return 0, fmt.Errorf("cell unmarshal: buffer too short (%d < %d)", len(buf), minCellSize)
+	}
 	offset := uint64(0)
 
 	c.NullBitmask = unmarshalUint64(buf, offset)
@@ -110,6 +117,9 @@ func (c *Cell) Unmarshal(buf []byte) (uint64, error) {
 
 	// Read TypeCodes (nil when ColumnCount == 0 to match uninitialized Cell).
 	if c.ColumnCount > 0 {
+		if offset+uint64(c.ColumnCount) > uint64(len(buf)) {
+			return 0, fmt.Errorf("cell unmarshal: TypeCodes truncated (need %d bytes at offset %d, have %d)", c.ColumnCount, offset, len(buf))
+		}
 		c.TypeCodes = make([]byte, c.ColumnCount)
 		copy(c.TypeCodes, buf[offset:offset+uint64(c.ColumnCount)])
 		offset += uint64(c.ColumnCount)
@@ -140,6 +150,9 @@ func (c *Cell) Unmarshal(buf []byte) (uint64, error) {
 
 	// Pass 2: copy value bytes into owned memory.
 	if totalSize > 0 {
+		if offset+totalSize > uint64(len(buf)) {
+			return 0, fmt.Errorf("cell unmarshal: value data truncated (need %d bytes at offset %d, have %d)", totalSize, offset, len(buf))
+		}
 		c.Value = make([]byte, totalSize)
 		copy(c.Value, buf[offset:offset+totalSize])
 		c.isOwned = true
@@ -290,6 +303,12 @@ func (n *LeafNode) Unmarshal(buf []byte) (uint64, error) {
 		return 0, err
 	}
 	i += hi
+
+	// A single 4096-byte page can hold at most PageSize cells even if each were 1 byte.
+	// Guard against a corrupted Cells field that would cause a multi-GB allocation.
+	if n.Header.Cells > PageSize {
+		return 0, fmt.Errorf("leaf node unmarshal: Cells count %d exceeds maximum %d", n.Header.Cells, PageSize)
+	}
 
 	if cap(n.Cells) <= int(n.Header.Cells) {
 		// Allocate one extra slot so the next append (insert into this page)

--- a/internal/minisql/overflow_page.go
+++ b/internal/minisql/overflow_page.go
@@ -61,6 +61,10 @@ func (h *OverflowPage) Marshal(buf []byte) error {
 // Unmarshal deserialises the overflow page from buf, validating the type byte.
 // Data is sub-sliced directly into the page buffer (zero-copy).
 func (h *OverflowPage) Unmarshal(buf []byte) error {
+	const minHeaderSize = 1 + 4 + 4 // type byte + NextPage + DataSize
+	if len(buf) < minHeaderSize {
+		return fmt.Errorf("overflow page unmarshal: buffer too short (%d < %d)", len(buf), minHeaderSize)
+	}
 	i := uint64(0)
 
 	if buf[i] != PageTypeOverflow {
@@ -76,6 +80,9 @@ func (h *OverflowPage) Unmarshal(buf []byte) error {
 
 	// Sub-slice page buffer directly — zero allocation, zero copy.
 	// Callers only read h.Data (readOverflowTexts appends it); nothing mutates it after unmarshal.
+	if i+uint64(h.Header.DataSize) > uint64(len(buf)) {
+		return fmt.Errorf("overflow page unmarshal: data truncated (need %d bytes at offset %d, have %d)", h.Header.DataSize, i, len(buf))
+	}
 	h.Data = buf[i : i+uint64(h.Header.DataSize)]
 
 	return nil

--- a/internal/minisql/testdata/fuzz/FuzzPageUnmarshal/606b89ad45b2b835
+++ b/internal/minisql/testdata/fuzz/FuzzPageUnmarshal/606b89ad45b2b835
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("00000000000000")
+byte('\x01')


### PR DESCRIPTION
All B-tree page Unmarshal functions now return errors instead of panicking on truncated or arbitrarily corrupt input:
- Header.Unmarshal: guard len(buf) < 6
- LeafNodeHeader.Unmarshal: guard len(buf) < 14
- Cell.Unmarshal: guard < 17 bytes, TypeCodes truncation, value data truncation
- InternalNodeHeader.Unmarshal: guard len(buf) < 14
- ICell.Unmarshal: guard len(buf) < 12
- InternalNode.Unmarshal: reject KeysNum > InternalNodeMaxCells to prevent OOB slice
- LeafNode.Unmarshal: reject Cells > PageSize to prevent multi-GB allocation
- OverflowPage.Unmarshal: guard header < 9 bytes and data bounds
- FreePage.Unmarshal: guard len(buf) < 5

FuzzPageUnmarshal harness exercises all deserialization paths with realistic seeds (valid leaf/internal/overflow/free pages) plus degenerate inputs (empty, single-byte). Corpus entry from the first panic is committed so CI replays it permanently.