### PR TITLE
Add FuzzRowView and fix RowView/TextPointer bounds panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,32 @@ Setting `LOG_LEVEL=info` suppresses debug output and makes test failures easier 
 MiniSQL uses Go's built-in fuzzer (`go test -fuzz`) to find parser bugs and
 storage corruption issues that structured unit tests are unlikely to reach.
 
-**Run the parser fuzzer** (stops after 60 s; adjust `-fuzztime` as needed):
+Three fuzz targets are maintained:
+
+| Target | Package | What it finds |
+|--------|---------|---------------|
+| `FuzzParser` | `./internal/parser/` | Parser panics / infinite loops on arbitrary SQL input |
+| `FuzzPageUnmarshal` | `./internal/minisql/` | Panics in B-tree page deserialization on truncated/corrupt pages |
+| `FuzzRowView` | `./internal/minisql/` | Panics in row value decoding (`RowView.ValueAt`) on arbitrary cell bytes |
+
+**Run a fuzzer** (stops after 60 s; adjust `-fuzztime` as needed):
 
 ```sh
-go test -fuzz=FuzzParser -fuzztime=60s ./internal/parser/
+go test -fuzz=FuzzParser       -fuzztime=60s ./internal/parser/
+go test -fuzz=FuzzPageUnmarshal -fuzztime=60s ./internal/minisql/
+go test -fuzz=FuzzRowView      -fuzztime=60s ./internal/minisql/
 ```
 
 **Run seeds only** (fast, no mutation — safe for CI):
 
 ```sh
-go test -run=FuzzParser ./internal/parser/
+go test -run=FuzzParser        ./internal/parser/
+go test -run=FuzzPageUnmarshal ./internal/minisql/
+go test -run=FuzzRowView       ./internal/minisql/
 ```
 
-Corpus entries that previously found real bugs live in
-`internal/parser/testdata/fuzz/FuzzParser/` and are automatically replayed as
+Corpus entries that previously found real bugs live under each package's
+`testdata/fuzz/<FuzzTarget>/` directory and are automatically replayed as
 ordinary unit tests on every `go test` run. When the fuzzer discovers a new
 crash it writes the minimised input to that directory; commit it so the fix is
 covered by CI forever.

--- a/internal/minisql/fuzz_row_view_test.go
+++ b/internal/minisql/fuzz_row_view_test.go
@@ -1,0 +1,161 @@
+package minisql
+
+import (
+	"testing"
+)
+
+// FuzzRowView verifies that RowView.ValueAt never panics on arbitrary cell
+// value bytes. The only invariant enforced is no-panic: every read must return
+// either a value or an error, never crash.
+//
+// Run for a fixed time during development:
+//
+//	go test -fuzz=FuzzRowView -fuzztime=60s ./internal/minisql/
+//
+// Seeds are run as ordinary unit tests on every `go test` invocation.
+func FuzzRowView(f *testing.F) {
+	// Seed: single INT8 column, all non-NULL (8 bytes).
+	f.Add(makeSeedInt8(), uint64(0))
+
+	// Seed: fixed-size mix (Boolean + INT4 + INT8 + Real + Double + Timestamp + UUID).
+	f.Add(makeSeedFixed(), uint64(0))
+
+	// Seed: text (Varchar) column (4-byte length prefix + data).
+	f.Add(makeSeedText(), uint64(0))
+
+	// Seed: mixed schema (INT8 + Varchar + INT4 + Boolean).
+	f.Add(makeSeedMixed(), uint64(0))
+
+	// Seed: all NULL — value area is empty regardless of schema.
+	f.Add([]byte{}, uint64(^uint64(0)))
+
+	// Seed: zero-length buffer, all non-NULL.
+	f.Add([]byte{}, uint64(0))
+
+	f.Fuzz(func(t *testing.T, valueBytes []byte, nullBitmask uint64) {
+		// Drive every schema × every column index through ValueAt.
+		// None may panic regardless of the value bytes or null bitmask.
+		for _, schema := range fuzzRowSchemas {
+			cell := Cell{
+				ColumnCount: uint8(len(schema)),
+				TypeCodes:   TypeCodesFromColumns(schema),
+				NullBitmask: nullBitmask,
+				Value:       valueBytes,
+			}
+			rv := NewRowView(schema, cell)
+			for i := range schema {
+				_, _ = rv.ValueAt(i)
+			}
+		}
+	})
+}
+
+// fuzzRowSchemas is the set of column layouts exercised by FuzzRowView.
+// Each schema exercises different TypeCode paths in offsetOf / ValueAt.
+var fuzzRowSchemas = [][]Column{
+	// Single fixed-size types
+	{{Name: "v", Kind: Boolean, Size: 1}},
+	{{Name: "v", Kind: Int4, Size: 4}},
+	{{Name: "v", Kind: Int8, Size: 8}},
+	{{Name: "v", Kind: Real, Size: 4}},
+	{{Name: "v", Kind: Double, Size: 8}},
+	{{Name: "v", Kind: Timestamp, Size: 8}},
+	{{Name: "v", Kind: UUID, Size: 16}},
+
+	// Variable-length text types
+	{{Name: "v", Kind: Varchar, Size: 255}},
+	{{Name: "v", Kind: Text, Size: 255}},
+	{{Name: "v", Kind: JSON, Size: 255}},
+
+	// All fixed-size types together (exercises cumulative offset computation)
+	{
+		{Name: "b", Kind: Boolean, Size: 1},
+		{Name: "i4", Kind: Int4, Size: 4},
+		{Name: "i8", Kind: Int8, Size: 8},
+		{Name: "r", Kind: Real, Size: 4},
+		{Name: "d", Kind: Double, Size: 8},
+		{Name: "ts", Kind: Timestamp, Size: 8},
+		{Name: "u", Kind: UUID, Size: 16},
+	},
+
+	// Mixed: mirrors testColumns used throughout the unit test suite
+	{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "email", Kind: Varchar, Size: 255, Nullable: true},
+		{Name: "age", Kind: Int4, Size: 4, Nullable: true},
+		{Name: "ok", Kind: Boolean, Size: 1, Nullable: true},
+		{Name: "score", Kind: Real, Size: 4, Nullable: true},
+		{Name: "created", Kind: Timestamp, Size: 8, Nullable: true},
+	},
+
+	// Multi-text: exercises offsetOf advancing past multiple variable-length columns
+	{
+		{Name: "a", Kind: Varchar, Size: 255},
+		{Name: "b", Kind: Text, Size: 255},
+		{Name: "c", Kind: JSON, Size: 255},
+	},
+}
+
+// --- seed helpers -----------------------------------------------------------
+
+// makeSeedInt8 returns valid marshaled bytes for a single INT8 column with value 42.
+func makeSeedInt8() []byte {
+	cols := []Column{{Name: "v", Kind: Int8, Size: 8}}
+	row := NewRowWithValues(cols, []OptionalValue{{Value: int64(42), Valid: true}})
+	data, _ := row.Marshal()
+	return data
+}
+
+// makeSeedFixed returns valid marshaled bytes for all fixed-size column types.
+func makeSeedFixed() []byte {
+	cols := []Column{
+		{Name: "b", Kind: Boolean, Size: 1},
+		{Name: "i4", Kind: Int4, Size: 4},
+		{Name: "i8", Kind: Int8, Size: 8},
+		{Name: "r", Kind: Real, Size: 4},
+		{Name: "d", Kind: Double, Size: 8},
+		{Name: "ts", Kind: Timestamp, Size: 8},
+		{Name: "u", Kind: UUID, Size: 16},
+	}
+	var uid UUIDValue
+	copy(uid[:], "abcdefghijklmnop")
+	row := NewRowWithValues(cols, []OptionalValue{
+		{Value: true, Valid: true},
+		{Value: int32(100), Valid: true},
+		{Value: int64(200), Valid: true},
+		{Value: float32(1.5), Valid: true},
+		{Value: float64(3.14), Valid: true},
+		{Value: TimestampMicros(1_000_000), Valid: true},
+		{Value: uid, Valid: true},
+	})
+	data, _ := row.Marshal()
+	return data
+}
+
+// makeSeedText returns valid marshaled bytes for a single Varchar column.
+func makeSeedText() []byte {
+	cols := []Column{{Name: "v", Kind: Varchar, Size: 255}}
+	tp := NewTextPointer([]byte("hello fuzz"))
+	row := NewRowWithValues(cols, []OptionalValue{{Value: tp, Valid: true}})
+	data, _ := row.Marshal()
+	return data
+}
+
+// makeSeedMixed returns valid marshaled bytes for a mixed schema (INT8 + Varchar + INT4 + Boolean).
+func makeSeedMixed() []byte {
+	cols := []Column{
+		{Name: "id", Kind: Int8, Size: 8},
+		{Name: "email", Kind: Varchar, Size: 255, Nullable: true},
+		{Name: "age", Kind: Int4, Size: 4, Nullable: true},
+		{Name: "ok", Kind: Boolean, Size: 1, Nullable: true},
+	}
+	tp := NewTextPointer([]byte("alice@example.com"))
+	row := NewRowWithValues(cols, []OptionalValue{
+		{Value: int64(1), Valid: true},
+		{Value: tp, Valid: true},
+		{Value: int32(30), Valid: true},
+		{Value: true, Valid: true},
+	})
+	data, _ := row.Marshal()
+	return data
+}

--- a/internal/minisql/row_view.go
+++ b/internal/minisql/row_view.go
@@ -158,6 +158,17 @@ func (rv RowView) ValueAt(idx int) (OptionalValue, error) {
 	}
 
 	col := rv.columns[idx]
+
+	// Guard against a truncated value buffer: verify enough bytes remain for
+	// this column's fixed-width data before doing any direct index reads.
+	if idx < len(rv.typeCodes) {
+		sz := typeCodeFixedSize(TypeCode(rv.typeCodes[idx]))
+		if sz > 0 && offset+sz > len(rv.value) {
+			return OptionalValue{}, fmt.Errorf("column %d (%s): value data truncated (need %d bytes at offset %d, have %d)",
+				idx, col.Name, sz, offset, len(rv.value))
+		}
+	}
+
 	switch col.Kind {
 	case Boolean:
 		return OptionalValue{Value: unmarshalBool(rv.value, uint64(offset)), Valid: true}, nil
@@ -422,6 +433,9 @@ func (rv RowView) UUIDAt(idx int) (UUIDValue, bool, error) {
 	offset, err := rv.offsetOf(idx)
 	if err != nil {
 		return UUIDValue{}, false, err
+	}
+	if offset+16 > len(rv.value) {
+		return UUIDValue{}, false, fmt.Errorf("UUID column %d: value data truncated (need 16 bytes at offset %d, have %d)", idx, offset, len(rv.value))
 	}
 	var value UUIDValue
 	copy(value[:], rv.value[offset:offset+16])

--- a/internal/minisql/text_pointer.go
+++ b/internal/minisql/text_pointer.go
@@ -75,11 +75,17 @@ func (tp *TextPointer) Marshal(buf []byte, i uint64) error {
 // is sub-sliced directly into the page buffer (zero-copy). For overflow text,
 // only FirstPage is set; actual data is loaded later by readOverflowTexts.
 func (tp *TextPointer) Unmarshal(buf []byte, i uint64) error {
+	if i+4 > uint64(len(buf)) {
+		return fmt.Errorf("text pointer unmarshal: buffer too short for length prefix at offset %d (have %d bytes)", i, len(buf))
+	}
 	// Read length prefix
 	tp.Length = unmarshalUint32(buf, i)
 	i += 4
 
 	if tp.IsInline() {
+		if i+uint64(tp.Length) > uint64(len(buf)) {
+			return fmt.Errorf("text pointer unmarshal: buffer too short for inline data (need %d bytes at offset %d, have %d)", tp.Length, i, len(buf))
+		}
 		// Sub-slice page buffer directly — zero allocation, zero copy.
 		// Inline text is read-only after unmarshal; Marshal copies it out via copy().
 		tp.Data = buf[i : i+uint64(tp.Length)]
@@ -88,6 +94,9 @@ func (tp *TextPointer) Unmarshal(buf []byte, i uint64) error {
 	}
 
 	// Read first overflow page index
+	if i+4 > uint64(len(buf)) {
+		return fmt.Errorf("text pointer unmarshal: buffer too short for overflow page index at offset %d (have %d bytes)", i, len(buf))
+	}
 	tp.FirstPage = PageIndex(unmarshalUint32(buf, i))
 	i += 4
 	return nil


### PR DESCRIPTION
FuzzRowView exercises RowView.ValueAt across all column kinds (Boolean, Int4, Int8, Real, Double, Timestamp, UUID, Varchar, Text, JSON) with arbitrary cell value bytes. No-panic is the only contract.

Two classes of panic were found and fixed:

RowView.ValueAt: after offsetOf() returns a valid offset, fixed-width reads (unmarshalBool/Int32/Int64/Float32/Float64, UUID slice, Vector) had no remaining-byte guard. Added a single sz > 0 && offset+sz > len(rv.value) check using typeCodeFixedSize before the switch, and a separate offset+16 guard in UUIDAt.

TextPointer.Unmarshal: read tp.Data = buf[i:i+length] without checking the buffer was long enough. Added bounds checks before the length-prefix read, the inline-data slice, and the overflow page-index read.

README updated with a table of all three fuzz targets and their run/seed commands.