### PR TITLE
refactor: replace ForIndex panic with proper error; document B-tree c…

### DIFF
--- a/docs/indexes/btree.md
+++ b/docs/indexes/btree.md
@@ -1,6 +1,6 @@
 # B-tree Indexes
 
-Every table's primary key is a B-tree. Additional B-tree indexes can be created on any column or combination of columns.
+Every table's primary key is a B-tree. Additional B-tree indexes can be created on most column types — see [Supported column types](#supported-column-types) for the full list.
 
 ---
 
@@ -142,10 +142,37 @@ Dropping a primary key index requires dropping the table.
 
 ---
 
+## Supported column types
+
+B-tree secondary indexes support the following column types:
+
+| Column type | Notes |
+|-------------|-------|
+| `BOOLEAN` | |
+| `INT4` | |
+| `INT8` | |
+| `REAL` | |
+| `DOUBLE` | |
+| `TIMESTAMP` | |
+| `UUID` | |
+| `VARCHAR(n)` | Keys are stored inline up to 255 bytes; longer values are rejected |
+| Composite | Any combination of the above in a multi-column index |
+
+### Types that do not support B-tree indexes
+
+| Column type | Alternative |
+|-------------|-------------|
+| `TEXT` | Use `CREATE FULLTEXT INDEX` for token search, or an expression index on `SUBSTR(col, 1, 255)` for prefix matching |
+| `JSON` | Use `CREATE INVERTED INDEX` for `JSON_CONTAINS` queries |
+| `VECTOR(n)` | Use `CREATE HNSW INDEX` for approximate nearest-neighbour search |
+
+`TEXT` and `JSON` columns are designed for unbounded content. A B-tree index requires keys that fit within a single 4 KiB page (255 bytes for `VARCHAR`); text that overflows to linked overflow pages cannot be used as a B-tree key without truncation, which would silently break equality and uniqueness semantics. The dedicated index types (`FULLTEXT`, `INVERTED`, `HNSW`) are purpose-built for each data shape.
+
+---
+
 ## Notes
 
 - B-tree indexes are stored as independent B+ trees with doubly-linked leaf pages.
-- `VARCHAR(n)` and `UUID` columns can be indexed; `TEXT` columns can be indexed only via expression indexes.
 - The planner uses table statistics from `ANALYZE` to choose between indexes.
 - `CREATE UNIQUE INDEX` enforces uniqueness at the storage level.
 - Composite primary keys (`PRIMARY KEY (col1, col2)`) use a composite B-tree key.

--- a/docs/indexes/overview.md
+++ b/docs/indexes/overview.md
@@ -4,12 +4,14 @@ MiniSQL supports four index types. The query planner automatically selects the b
 
 ## Index types
 
-| Type | Best for | SQL |
-|------|----------|-----|
-| [B-tree](btree.md) | Equality, range, ORDER BY, covering | `CREATE INDEX` |
-| [Full-text](fulltext.md) | Token search in TEXT columns | `CREATE FULLTEXT INDEX` |
-| [JSON inverted](json-inverted.md) | Containment queries on JSON columns | `CREATE INVERTED INDEX` |
-| [HNSW vector](hnsw.md) | Approximate nearest-neighbour on VECTOR columns | `CREATE HNSW INDEX` |
+| Type | Column types | Best for | SQL |
+|------|-------------|----------|-----|
+| [B-tree](btree.md) | `BOOLEAN`, `INT4`, `INT8`, `REAL`, `DOUBLE`, `TIMESTAMP`, `UUID`, `VARCHAR(n)` | Equality, range, ORDER BY, covering | `CREATE INDEX` |
+| [Full-text](fulltext.md) | `TEXT` | Token search (BM25 ranking) | `CREATE FULLTEXT INDEX` |
+| [JSON inverted](json-inverted.md) | `JSON` | Containment queries (`JSON_CONTAINS`) | `CREATE INVERTED INDEX` |
+| [HNSW vector](hnsw.md) | `VECTOR(n)` | Approximate nearest-neighbour (`VEC_L2`, `VEC_COSINE`) | `CREATE HNSW INDEX` |
+
+Each index type is purpose-built for its column kind. `TEXT`, `JSON`, and `VECTOR` columns cannot be used in a B-tree secondary index — attempting to do so returns an error with a suggestion to use the appropriate index type.
 
 ---
 

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -341,7 +341,7 @@ func (d *Database) pagerFactory(ctx context.Context, tableName, indexName string
 		}
 	}
 
-	return d.factory.ForIndex(columns, unique), nil
+	return d.factory.ForIndex(columns, unique)
 }
 
 // applyRowCountDeltas applies committed insert/delete row-count changes to the
@@ -947,12 +947,11 @@ func (d *Database) initPrimaryKey(_ context.Context, schema Schema) error {
 	if !ok {
 		return fmt.Errorf("table %s for primary key index %s does not exist", schema.TableName, schema.Name)
 	}
-	tp := NewTransactionalPager(
-		d.factory.ForIndex(table.PrimaryKey.Columns, true),
-		d.txManager,
-		table.Name,
-		schema.Name,
-	)
+	pkPager, err := d.factory.ForIndex(table.PrimaryKey.Columns, true)
+	if err != nil {
+		return err
+	}
+	tp := NewTransactionalPager(pkPager, d.txManager, table.Name, schema.Name)
 	btreeIndex, err := table.newBTreeIndex(tp, schema.RootPage, table.PrimaryKey.Columns, table.PrimaryKey.Name, true)
 	if err != nil {
 		return err
@@ -980,12 +979,11 @@ func (d *Database) initUniqueIndex(_ context.Context, schema Schema) error {
 	if !ok {
 		return fmt.Errorf("unique index %s does not exist on table %s", schema.Name, schema.TableName)
 	}
-	tp := NewTransactionalPager(
-		d.factory.ForIndex(uniqueIndex.Columns, true),
-		d.txManager,
-		table.Name,
-		schema.Name,
-	)
+	uiPager, err := d.factory.ForIndex(uniqueIndex.Columns, true)
+	if err != nil {
+		return err
+	}
+	tp := NewTransactionalPager(uiPager, d.txManager, table.Name, schema.Name)
 	btreeIndex, err := table.newBTreeIndex(tp, schema.RootPage, uniqueIndex.Columns, uniqueIndex.Name, true)
 	if err != nil {
 		return err
@@ -1071,13 +1069,11 @@ func (d *Database) initSecondaryIndex(ctx context.Context, schema Schema) error 
 		secondaryIndex.HNSWIndex = OpenHNSWIndex(tp, schema.RootPage)
 	default:
 		storageColumns := secondaryIndexStorageColumns(secondaryIndex)
-
-		tp := NewTransactionalPager(
-			d.factory.ForIndex(storageColumns, false),
-			d.txManager,
-			table.Name,
-			schema.Name,
-		)
+		siPager, err := d.factory.ForIndex(storageColumns, false)
+		if err != nil {
+			return err
+		}
+		tp := NewTransactionalPager(siPager, d.txManager, table.Name, schema.Name)
 		btreeIndex, err := table.newBTreeIndex(tp, schema.RootPage, storageColumns, secondaryIndex.Name, false)
 		if err != nil {
 			return err
@@ -1612,13 +1608,11 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 	})
 	// And then free pages for the primary key index if any
 	if tableToDelete.HasPrimaryKey() {
-
-		txPager := NewTransactionalPager(
-			d.factory.ForIndex(tableToDelete.PrimaryKey.Columns, true),
-			d.txManager,
-			tableToDelete.Name,
-			tableToDelete.PrimaryKey.Name,
-		)
+		pkPager, err := d.factory.ForIndex(tableToDelete.PrimaryKey.Columns, true)
+		if err != nil {
+			return err
+		}
+		txPager := NewTransactionalPager(pkPager, d.txManager, tableToDelete.Name, tableToDelete.PrimaryKey.Name)
 
 		_ = tableToDelete.PrimaryKey.Index.BFS(ctx, func(page *Page) {
 			if err := txPager.AddFreePage(ctx, page.Index); err != nil {
@@ -1633,13 +1627,11 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 	}
 	// And then free pages for unique indexes index if any
 	for _, uniqueIndex := range tableToDelete.UniqueIndexes {
-
-		txPager := NewTransactionalPager(
-			d.factory.ForIndex(uniqueIndex.Columns, true),
-			d.txManager,
-			tableToDelete.Name,
-			uniqueIndex.Name,
-		)
+		uiPager, err := d.factory.ForIndex(uniqueIndex.Columns, true)
+		if err != nil {
+			return err
+		}
+		txPager := NewTransactionalPager(uiPager, d.txManager, tableToDelete.Name, uniqueIndex.Name)
 
 		_ = uniqueIndex.Index.BFS(ctx, func(page *Page) {
 			if err := txPager.AddFreePage(ctx, page.Index); err != nil {
@@ -1654,13 +1646,12 @@ func (d *Database) dropTable(ctx context.Context, name string) error {
 	}
 	// And then free pages for secondary indexes index if any
 	for _, secondaryIndex := range tableToDelete.SecondaryIndexes {
-
-		txPager := NewTransactionalPager(
-			d.factory.ForIndex(secondaryIndexStorageColumns(secondaryIndex), false),
-			d.txManager,
-			tableToDelete.Name,
-			secondaryIndex.Name,
-		)
+		siCols := secondaryIndexStorageColumns(secondaryIndex)
+		siPager, err := d.factory.ForIndex(siCols, false)
+		if err != nil {
+			return err
+		}
+		txPager := NewTransactionalPager(siPager, d.txManager, tableToDelete.Name, secondaryIndex.Name)
 
 		_ = secondaryIndex.Index.BFS(ctx, func(page *Page) {
 			if err := txPager.AddFreePage(ctx, page.Index); err != nil {
@@ -2273,14 +2264,11 @@ func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {
 		}
 	default:
 		storageColumns := secondaryIndexStorageColumns(secondaryIndex)
-
-		txPager := NewTransactionalPager(
-			d.factory.ForIndex(storageColumns, false),
-			d.txManager,
-			table.Name,
-			schema.Name,
-		)
-
+		siPager, err := d.factory.ForIndex(storageColumns, false)
+		if err != nil {
+			return err
+		}
+		txPager := NewTransactionalPager(siPager, d.txManager, table.Name, schema.Name)
 		btreeIndex, err := table.newBTreeIndex(txPager, schema.RootPage, storageColumns, schema.Name, false)
 		if err != nil {
 			return err
@@ -2307,12 +2295,11 @@ func (d *Database) dropIndex(ctx context.Context, stmt Statement) error {
 func (d *Database) createPrimaryKey(ctx context.Context, table *Table, columns []Column) (BTreeIndex, error) {
 	d.logger.Sugar().With("columns", columns).Debug("creating primary key")
 
-	txPager := NewTransactionalPager(
-		d.factory.ForIndex(columns, true),
-		d.txManager,
-		table.Name,
-		table.PrimaryKey.Name,
-	)
+	pkPager, err := d.factory.ForIndex(columns, true)
+	if err != nil {
+		return nil, err
+	}
+	txPager := NewTransactionalPager(pkPager, d.txManager, table.Name, table.PrimaryKey.Name)
 
 	freePage, err := txPager.GetFreePage(ctx)
 	if err != nil {
@@ -2339,12 +2326,11 @@ func (d *Database) createPrimaryKey(ctx context.Context, table *Table, columns [
 func (d *Database) createUniqueIndex(ctx context.Context, table *Table, uniqueIndex UniqueIndex) (BTreeIndex, error) {
 	d.logger.Sugar().With("column", uniqueIndex.Columns[0].Name).Debug("creating unique index")
 
-	txPager := NewTransactionalPager(
-		d.factory.ForIndex(uniqueIndex.Columns, true),
-		d.txManager,
-		table.Name,
-		uniqueIndex.Name,
-	)
+	uiPager, err := d.factory.ForIndex(uniqueIndex.Columns, true)
+	if err != nil {
+		return nil, err
+	}
+	txPager := NewTransactionalPager(uiPager, d.txManager, table.Name, uniqueIndex.Name)
 
 	freePage, err := txPager.GetFreePage(ctx)
 	if err != nil {
@@ -2405,12 +2391,11 @@ func (d *Database) createSecondaryIndex(ctx context.Context, stmt Statement, tab
 		secondaryIndex.InvertedIndex = invertedIdx
 	case !secondaryIndexUsesDedicatedHNSWStorage(secondaryIndex.Method):
 		storageColumns := secondaryIndexStorageColumns(secondaryIndex)
-		txPager := NewTransactionalPager(
-			d.factory.ForIndex(storageColumns, false),
-			d.txManager,
-			table.Name,
-			secondaryIndex.Name,
-		)
+		siPager, err := d.factory.ForIndex(storageColumns, false)
+		if err != nil {
+			return SecondaryIndex{}, err
+		}
+		txPager := NewTransactionalPager(siPager, d.txManager, table.Name, secondaryIndex.Name)
 
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {

--- a/internal/minisql/delete_primary_key_test.go
+++ b/internal/minisql/delete_primary_key_test.go
@@ -41,12 +41,9 @@ func TestTable_Delete_PrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{
@@ -139,12 +136,9 @@ func TestTable_Delete_CompositePrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager2, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager2, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{

--- a/internal/minisql/delete_secondary_index_test.go
+++ b/internal/minisql/delete_secondary_index_test.go
@@ -44,12 +44,9 @@ func TestTable_Delete_SingleSecondaryIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(indexCol, false),
-		txManager,
-		testTableName,
-		indexName,
-	)
+	idxPager, err := pager.ForIndex(indexCol, false)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, txManager, testTableName, indexName)
 
 	// Build the secondary index and insert rows.
 	stmt := Statement{
@@ -134,12 +131,9 @@ func TestTable_Delete_CompositeSecondaryIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(indexCols, false),
-		txManager,
-		testTableName,
-		indexName,
-	)
+	idxPager2, err := pager.ForIndex(indexCols, false)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager2, txManager, testTableName, indexName)
 
 	// Build the composite secondary index and insert rows.
 	stmt := Statement{

--- a/internal/minisql/delete_unique_index_test.go
+++ b/internal/minisql/delete_unique_index_test.go
@@ -47,15 +47,9 @@ func TestTable_Delete_UniqueIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(
-			table.UniqueIndexes[indexName].Columns,
-			true,
-		),
-		table.txManager,
-		table.Name,
-		table.UniqueIndexes[indexName].Name,
-	)
+	idxPager, err := pager.ForIndex(table.UniqueIndexes[indexName].Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, table.txManager, table.Name, table.UniqueIndexes[indexName].Name)
 
 	// Batch insert test rows
 	stmt := Statement{
@@ -156,12 +150,9 @@ func TestTable_Delete_CompositeUniqueIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.UniqueIndexes[indexName].Columns, true),
-		table.txManager,
-		testTableName,
-		table.UniqueIndexes[indexName].Name,
-	)
+	idxPager2, err := pager.ForIndex(table.UniqueIndexes[indexName].Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager2, table.txManager, testTableName, table.UniqueIndexes[indexName].Name)
 
 	// Batch insert test rows
 	stmt := Statement{

--- a/internal/minisql/index_cursor_test.go
+++ b/internal/minisql/index_cursor_test.go
@@ -15,10 +15,11 @@ func TestIndex_Seek(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -116,13 +117,14 @@ func TestIndex_SeekLastKey(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 
 	// Initialize empty index, this normally happens in the database init step
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err

--- a/internal/minisql/index_delete_non_unique_test.go
+++ b/internal/minisql/index_delete_non_unique_test.go
@@ -42,10 +42,11 @@ func TestIndex_NonUnique_Delete(t *testing.T) {
 		pager, dbFile = initTest(t)
 		ctx           = context.Background()
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewNonUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 

--- a/internal/minisql/index_delete_test.go
+++ b/internal/minisql/index_delete_test.go
@@ -17,10 +17,11 @@ func TestIndex_Delete(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -981,10 +982,11 @@ func TestIndex_Delete_Random_Shuffle(t *testing.T) {
 		pager, dbFile = initTest(t)
 		ctx           = context.Background()
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	// Insert 10000 keys in random order
@@ -1028,10 +1030,11 @@ func TestIndex_Delete_Varchar(t *testing.T) {
 		pager, dbFile = initTest(t)
 		ctx           = context.Background()
 		col           = Column{Name: "test_column", Kind: Varchar, Size: 100}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[string](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	// Insert 100 keys in random order

--- a/internal/minisql/index_insert_nonunique_test.go
+++ b/internal/minisql/index_insert_nonunique_test.go
@@ -14,10 +14,11 @@ func TestIndex_NonUnique_Insert(t *testing.T) {
 		pager, dbFile = initTest(t)
 		ctx           = context.Background()
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, false)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, false)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewNonUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 
@@ -164,10 +165,11 @@ func TestIndex_FindRowIDs_WithOverflow(t *testing.T) {
 		pager, dbFile = initTest(t)
 		ctx           = context.Background()
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, false)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, false)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewNonUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 

--- a/internal/minisql/index_insert_test.go
+++ b/internal/minisql/index_insert_test.go
@@ -15,10 +15,11 @@ func TestIndex_Insert(t *testing.T) {
 		ctx           = context.Background()
 		key           = int64(1)
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -263,10 +264,11 @@ func TestIndex_Insert_OutOfOrder(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3

--- a/internal/minisql/index_scan_test.go
+++ b/internal/minisql/index_scan_test.go
@@ -15,10 +15,11 @@ func TestIndex_ScanAll(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -84,10 +85,11 @@ func TestIndex_ScanAll_NonUnique(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewNonUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -161,10 +163,11 @@ func TestIndex_ScanRange(t *testing.T) {
 		ctx           = context.Background()
 		keys          = []int64{16, 9, 5, 18, 11, 1, 14, 7, 10, 6, 20, 19, 8, 2, 13, 12, 17, 3, 4, 21, 15}
 		col           = Column{Name: "test_column", Kind: Int8, Size: 8}
-		indexPager    = pager.ForIndex([]Column{col}, true)
-		txManager     = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager       = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[int64](testLogger, txManager, "test_index", []Column{col}, txPager, 0)
 	require.NoError(t, err)
 	idx.maximumKeys = 3
@@ -438,10 +441,11 @@ func TestIndex_ScanRange_CompositeKey(t *testing.T) {
 			NewCompositeKey(columns, "Vanessa", "Eldred"),
 			NewCompositeKey(columns, "Ralph", "Darren"),
 		}
-		indexPager = pager.ForIndex(columns, true)
-		txManager  = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
-		txPager    = NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	)
+	indexPager, err := pager.ForIndex(columns, true)
+	require.NoError(t, err)
+	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
+	txPager := NewTransactionalPager(indexPager, txManager, testTableName, "test_index")
 	idx, err := NewUniqueIndex[CompositeKey](testLogger, txManager, "test_index", columns, txPager, 0)
 	require.NoError(t, err)
 

--- a/internal/minisql/index_uuid_test.go
+++ b/internal/minisql/index_uuid_test.go
@@ -15,7 +15,8 @@ func TestUUIDIndex_InsertAndSeek(t *testing.T) {
 	ctx := context.Background()
 
 	col := Column{Name: "id", Kind: UUID, Size: 16}
-	indexPager := pager.ForIndex([]Column{col}, true)
+	indexPager, err := pager.ForIndex([]Column{col}, true)
+	require.NoError(t, err)
 	txManager := NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil)
 	txPager := NewTransactionalPager(indexPager, txManager, "uuid_table", "uuid_index")
 

--- a/internal/minisql/insert_on_conflict_test.go
+++ b/internal/minisql/insert_on_conflict_test.go
@@ -19,11 +19,12 @@ func TestTable_Insert_OnConflictDoUpdate_UniqueIndex(t *testing.T) {
 		rows          = gen.RowsWithUniqueIndex(5)
 		table         *Table
 		indexName     = UniqueIndexName(testTableName, "email")
-		indexPager    = pager.ForIndex(testColumns[1:2], true)
-		txIndexPager  = NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 	)
+	indexPager, err := pager.ForIndex(testColumns[1:2], true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err
@@ -205,11 +206,12 @@ func TestTable_Insert_OnConflictDoUpdate_ExcludedRef_UniqueIndex(t *testing.T) {
 		rows          = gen.RowsWithUniqueIndex(5)
 		table         *Table
 		indexName     = UniqueIndexName(testTableName, "email")
-		indexPager    = pager.ForIndex(testColumns[1:2], true)
-		txIndexPager  = NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 	)
+	indexPager, err := pager.ForIndex(testColumns[1:2], true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err
@@ -380,13 +382,14 @@ func TestTable_Insert_OnConflictDoNothing_UniqueIndex(t *testing.T) {
 		rows          = gen.RowsWithUniqueIndex(5)
 		table         *Table
 		indexName     = UniqueIndexName(testTableName, "email")
-		indexPager    = pager.ForIndex(testColumns[1:2], true)
-		// Use the same txManager for the index pager so page-version tracking is consistent.
-		txIndexPager = NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 	)
+	indexPager, err := pager.ForIndex(testColumns[1:2], true)
+	require.NoError(t, err)
+	// Use the same txManager for the index pager so page-version tracking is consistent.
+	txIndexPager := NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 
 	// Set up table and insert initial rows
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err

--- a/internal/minisql/insert_primary_key_test.go
+++ b/internal/minisql/insert_primary_key_test.go
@@ -42,12 +42,9 @@ func TestTable_Insert_PrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{
@@ -131,12 +128,9 @@ func TestTable_Insert_PrimaryKey_Autoincrement(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	t.Run("Insert rows without primary key, autoincrement should generate primary keys", func(t *testing.T) {
 		stmt := Statement{
@@ -215,12 +209,9 @@ func TestTable_Insert_CompositePrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager2, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager2, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{

--- a/internal/minisql/insert_unique_index_test.go
+++ b/internal/minisql/insert_unique_index_test.go
@@ -18,16 +18,17 @@ func TestTable_Insert_UniqueIndex(t *testing.T) {
 		rows          = gen.RowsWithUniqueIndex(10)
 		table         *Table
 		indexName     = UniqueIndexName(testTableName, "email")
-		indexPager    = pager.ForIndex(testColumns[1:2], true)
-		txIndexPager  = NewTransactionalPager(
-			indexPager,
-			NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil),
-			testTableName,
-			indexName,
-		)
+	)
+	indexPager, err := pager.ForIndex(testColumns[1:2], true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(
+		indexPager,
+		NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil),
+		testTableName,
+		indexName,
 	)
 
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err
@@ -116,16 +117,17 @@ func TestTable_Insert_CompositeUniqueIndex(t *testing.T) {
 		rows          = gen.RowsWithCompositeKey(10)
 		table         *Table
 		indexName     = UniqueIndexName(testTableName, "email")
-		indexPager    = pager.ForIndex(testCompositeKeyColumns[1:3], true)
-		txIndexPager  = NewTransactionalPager(
-			indexPager,
-			NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil),
-			testTableName,
-			indexName,
-		)
+	)
+	indexPager, err := pager.ForIndex(testCompositeKeyColumns[1:3], true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(
+		indexPager,
+		NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(indexPager), pager, nil),
+		testTableName,
+		indexName,
 	)
 
-	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+	err = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
 		freePage, err := txPager.GetFreePage(ctx)
 		if err != nil {
 			return err

--- a/internal/minisql/integrity_check.go
+++ b/internal/minisql/integrity_check.go
@@ -340,7 +340,16 @@ func (d *Database) checkIndexRoot(ctx context.Context, report IntegrityReport, t
 		return report
 	}
 
-	page, err := d.factory.ForIndex(columns, unique).GetPage(ctx, pageIdx)
+	idxPager, err := d.factory.ForIndex(columns, unique)
+	if err != nil {
+		report.Issues = append(report.Issues, IntegrityIssue{
+			Code:    "index_unsupported_column_type",
+			Message: fmt.Sprintf("index %s on table %s has an unsupported column type: %v", indexName, tableName, err),
+			Object:  indexName,
+		})
+		return report
+	}
+	page, err := idxPager.GetPage(ctx, pageIdx)
 	if err != nil {
 		report.Issues = append(report.Issues, IntegrityIssue{
 			Code:    "index_root_decode_failed",
@@ -681,7 +690,15 @@ func (d *Database) walkOverflowPages(report IntegrityReport, objectName string, 
 }
 
 func (d *Database) walkIndexPages(ctx context.Context, report IntegrityReport, tableName, indexName string, columns []Column, unique bool, root PageIndex, livePages map[PageIndex]string) IntegrityReport {
-	pager := d.factory.ForIndex(columns, unique)
+	pager, err := d.factory.ForIndex(columns, unique)
+	if err != nil {
+		report.Issues = append(report.Issues, IntegrityIssue{
+			Code:    "index_unsupported_column_type",
+			Message: fmt.Sprintf("index %s on table %s has an unsupported column type: %v", indexName, tableName, err),
+			Object:  indexName,
+		})
+		return report
+	}
 	visited := make(map[PageIndex]struct{})
 	stack := []PageIndex{root}
 	objectName := fmt.Sprintf("index %s on table %s", indexName, tableName)

--- a/internal/minisql/integrity_check_test.go
+++ b/internal/minisql/integrity_check_test.go
@@ -544,12 +544,16 @@ func addQuickCheckTestTableWithSecondaryIndex(db *Database, pager *pagerImpl, ta
 		pager.totalPages = uint32(indexRootPageIdx) + 1
 	}
 
+	indexForPager, indexForPagerErr := pager.ForIndex(columns[1:2], false)
+	if indexForPagerErr != nil {
+		panic(indexForPagerErr)
+	}
 	index, err := NewNonUniqueIndex[string](
 		testLogger,
 		db.txManager,
 		indexName,
 		columns[1:2],
-		NewTransactionalPager(pager.ForIndex(columns[1:2], false), db.txManager, tableName, indexName),
+		NewTransactionalPager(indexForPager, db.txManager, tableName, indexName),
 		indexRootPageIdx,
 	)
 	if err != nil {

--- a/internal/minisql/pager_factory.go
+++ b/internal/minisql/pager_factory.go
@@ -29,26 +29,40 @@ func (p *pagerImpl) ForHNSWIndex() Pager {
 // chosen from the column kind. Composite (multi-column) indexes always use
 // CompositeKey; single-column indexes select the concrete key type that matches
 // the column kind (int8, int32, int64, float32, float64, string, or UUIDValue).
-func (p *pagerImpl) ForIndex(columns []Column, unique bool) Pager {
+//
+// Text, JSON, and Vector columns are not supported for B-tree secondary indexes:
+//   - TEXT / JSON: use CREATE FULLTEXT INDEX or CREATE INVERTED INDEX instead.
+//   - VECTOR: use CREATE HNSW INDEX instead.
+func (p *pagerImpl) ForIndex(columns []Column, unique bool) (Pager, error) {
 	if len(columns) > 1 {
-		return &indexPager[CompositeKey]{p, columns, unique}
+		return &indexPager[CompositeKey]{p, columns, unique}, nil
 	}
 	switch columns[0].Kind {
 	case Boolean:
-		return &indexPager[int8]{p, columns, unique}
+		return &indexPager[int8]{p, columns, unique}, nil
 	case Int4:
-		return &indexPager[int32]{p, columns, unique}
+		return &indexPager[int32]{p, columns, unique}, nil
 	case Int8, Timestamp:
-		return &indexPager[int64]{p, columns, unique}
+		return &indexPager[int64]{p, columns, unique}, nil
 	case Real:
-		return &indexPager[float32]{p, columns, unique}
+		return &indexPager[float32]{p, columns, unique}, nil
 	case Double:
-		return &indexPager[float64]{p, columns, unique}
+		return &indexPager[float64]{p, columns, unique}, nil
 	case Varchar:
-		return &indexPager[string]{p, columns, unique}
+		return &indexPager[string]{p, columns, unique}, nil
 	case UUID:
-		return &indexPager[UUIDValue]{p, columns, unique}
+		return &indexPager[UUIDValue]{p, columns, unique}, nil
+	case Text, JSON:
+		return nil, fmt.Errorf(
+			"column %q (%s) cannot be used in a B-tree secondary index: "+
+				"TEXT and JSON columns support only FULLTEXT INDEX or INVERTED INDEX",
+			columns[0].Name, columns[0].Kind)
+	case Vector:
+		return nil, fmt.Errorf(
+			"column %q (%s) cannot be used in a B-tree secondary index: "+
+				"VECTOR columns support only HNSW INDEX",
+			columns[0].Name, columns[0].Kind)
 	default:
-		panic(fmt.Sprintf("unsupported index column type: %v", columns[0].Kind))
+		return nil, fmt.Errorf("unsupported index column type %q", columns[0].Kind)
 	}
 }

--- a/internal/minisql/ports.go
+++ b/internal/minisql/ports.go
@@ -38,7 +38,9 @@ type PagerFactory interface {
 	// ForTable returns a Pager that unmarshals rows using the given column schema.
 	ForTable([]Column) Pager
 	// ForIndex returns a Pager that unmarshals index nodes for the given columns.
-	ForIndex(columns []Column, unique bool) Pager
+	// Returns an error if the column type is not supported for B-tree indexes
+	// (e.g. TEXT columns require a FULLTEXT INDEX instead).
+	ForIndex(columns []Column, unique bool) (Pager, error)
 	// ForInvertedIndex returns a Pager for inverted (full-text / JSON) index pages.
 	ForInvertedIndex() Pager
 	// ForHNSWIndex returns a Pager that unmarshals HNSW meta and data pages.

--- a/internal/minisql/select_primary_key_test.go
+++ b/internal/minisql/select_primary_key_test.go
@@ -43,12 +43,9 @@ func TestTable_Select_PrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txPrimaryKeyPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txPrimaryKeyPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{

--- a/internal/minisql/select_test.go
+++ b/internal/minisql/select_test.go
@@ -747,7 +747,10 @@ func TestTable_Select_NonUniqueSecondaryIndexPointUsesRowViews(t *testing.T) {
 		freePage.LeafNode.Header.IsRoot = true
 		table = NewTable(testLogger, txPager, txManager, testTableName, testColumns[0:3], freePage.Index, nil)
 
-		indexPager := pager.ForIndex(indexCols, false)
+		indexPager, err := pager.ForIndex(indexCols, false)
+		if err != nil {
+			return err
+		}
 		txIndexPager := NewTransactionalPager(indexPager, txManager, testTableName, indexName)
 		indexRoot, err := txIndexPager.GetFreePage(ctx)
 		if err != nil {

--- a/internal/minisql/select_unique_index_test.go
+++ b/internal/minisql/select_unique_index_test.go
@@ -49,14 +49,13 @@ func TestTable_Select_UniqueIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var (
-		indexPager   = pager.ForIndex(testColumns[1:2], true)
-		txIndexPager = NewTransactionalPager(
-			indexPager,
-			table.txManager,
-			testTableName,
-			table.UniqueIndexes[indexName].Name,
-		)
+	indexPager, err := pager.ForIndex(testColumns[1:2], true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(
+		indexPager,
+		table.txManager,
+		testTableName,
+		table.UniqueIndexes[indexName].Name,
 	)
 
 	// Batch insert test rows

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -1273,7 +1273,7 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 
 func insertFieldOrderMatchesColumnOrder(colFieldIdx []int, nInsertFields int) bool {
 	lastColIdx := -1
-	for fieldIdx := 0; fieldIdx < nInsertFields; fieldIdx++ {
+	for fieldIdx := range nInsertFields {
 		colIdx := -1
 		for i, idx := range colFieldIdx {
 			if idx == fieldIdx {

--- a/internal/minisql/update_primary_key_test.go
+++ b/internal/minisql/update_primary_key_test.go
@@ -41,12 +41,9 @@ func TestTable_Update_PrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txPrimaryKeyPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txPrimaryKeyPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{
@@ -211,12 +208,9 @@ func TestTable_Update_CompositePrimaryKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txPrimaryKeyPager := NewTransactionalPager(
-		pager.ForIndex(table.PrimaryKey.Columns, true),
-		table.txManager,
-		testTableName,
-		table.PrimaryKey.Name,
-	)
+	idxPager2, err := pager.ForIndex(table.PrimaryKey.Columns, true)
+	require.NoError(t, err)
+	txPrimaryKeyPager := NewTransactionalPager(idxPager2, table.txManager, testTableName, table.PrimaryKey.Name)
 
 	// Batch insert test rows
 	stmt := Statement{

--- a/internal/minisql/update_secondary_index_test.go
+++ b/internal/minisql/update_secondary_index_test.go
@@ -43,12 +43,9 @@ func TestTable_Update_SingleSecondaryIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(indexCol, false),
-		txManager,
-		testTableName,
-		indexName,
-	)
+	idxPager, err := pager.ForIndex(indexCol, false)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, txManager, testTableName, indexName)
 
 	stmt := Statement{
 		Kind:    Insert,

--- a/internal/minisql/update_unique_index_test.go
+++ b/internal/minisql/update_unique_index_test.go
@@ -47,15 +47,9 @@ func TestTable_Update_UniqueIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(
-			table.UniqueIndexes[indexName].Columns,
-			true,
-		),
-		table.txManager,
-		testTableName,
-		table.UniqueIndexes[indexName].Name,
-	)
+	idxPager, err := pager.ForIndex(table.UniqueIndexes[indexName].Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager, table.txManager, testTableName, table.UniqueIndexes[indexName].Name)
 
 	// Batch insert test rows
 	stmt := Statement{
@@ -230,15 +224,9 @@ func TestTable_Update_CompositeUniqueIndex(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	txIndexPager := NewTransactionalPager(
-		pager.ForIndex(
-			table.UniqueIndexes[indexName].Columns,
-			true,
-		),
-		table.txManager,
-		testTableName,
-		table.UniqueIndexes[indexName].Name,
-	)
+	idxPager2, err := pager.ForIndex(table.UniqueIndexes[indexName].Columns, true)
+	require.NoError(t, err)
+	txIndexPager := NewTransactionalPager(idxPager2, table.txManager, testTableName, table.UniqueIndexes[indexName].Name)
 
 	// Batch insert test rows
 	stmt := Statement{


### PR DESCRIPTION
…olumn type restrictions

PagerFactory.ForIndex now returns (Pager, error) instead of panicking on unsupported column types (TEXT, JSON, VECTOR). All 11 call sites in database.go and 2 in integrity_check.go propagate the error correctly; integrity_check surfaces it as an IntegrityIssue rather than crashing.

All 20 affected test files updated to handle the new two-return signature.

docs/indexes/btree.md gains a "Supported column types" table and a "Types that do not support B-tree indexes" table explaining that TEXT, JSON, and VECTOR columns require FULLTEXT, INVERTED, or HNSW indexes respectively. docs/indexes/overview.md index-type table gains a "Column types" column so readers can see at a glance which column kinds each index type serves.