### PR TITLE
fix: validate all B-tree index column types including TEXT, VECTOR, a…

### DIFF
--- a/e2e_tests/create_index_unsupported_column_test.go
+++ b/e2e_tests/create_index_unsupported_column_test.go
@@ -1,0 +1,89 @@
+package e2etests
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/RichardKnop/minisql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openUnsupportedIndexDB opens a fresh database for unsupported-index tests.
+func openUnsupportedIndexDB(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+	f, err := os.CreateTemp("", "unsupported_index_")
+	require.NoError(t, err)
+	path := f.Name()
+	require.NoError(t, f.Close())
+
+	db, err := sql.Open("minisql", path)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.Close()
+		_ = os.Remove(path)
+		_ = os.Remove(path + "-wal")
+	}
+	return db, cleanup
+}
+
+// TestCreateIndex_UnsupportedColumnType verifies that CREATE INDEX on TEXT,
+// JSON, and VECTOR columns (single and composite) returns an error instead of
+// panicking or silently creating a broken index.
+func TestCreateIndex_UnsupportedColumnType(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openUnsupportedIndexDB(t)
+	defer cleanup()
+
+	_, err := db.Exec(`CREATE TABLE things (
+		id      INT8 PRIMARY KEY AUTOINCREMENT,
+		name    TEXT NOT NULL,
+		meta    JSON,
+		vec     VECTOR(3),
+		label   VARCHAR(100)
+	)`)
+	require.NoError(t, err)
+
+	t.Run("TEXT column single-column index", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_name ON things (name)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TEXT")
+	})
+
+	t.Run("JSON column single-column index", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_meta ON things (meta)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON")
+	})
+
+	t.Run("VECTOR column single-column index", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_vec ON things (vec)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "VECTOR")
+	})
+
+	t.Run("composite index containing TEXT column", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_label_name ON things (label, name)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TEXT")
+	})
+
+	t.Run("composite index containing JSON column", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_label_meta ON things (label, meta)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JSON")
+	})
+
+	t.Run("composite index containing VECTOR column", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_label_vec ON things (label, vec)`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "VECTOR")
+	})
+
+	t.Run("supported column types still work", func(t *testing.T) {
+		_, err := db.Exec(`CREATE INDEX idx_things_label ON things (label)`)
+		require.NoError(t, err)
+	})
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -21,6 +21,8 @@ import (
 var (
 	errUnrecognizedStatementType = errors.New("unrecognised statement type")
 	errIndexOnJSONColumn         = errors.New("b-tree index on JSON column is not supported")
+	errIndexOnTextColumn         = errors.New("b-tree index on TEXT column is not supported")
+	errIndexOnVectorColumn       = errors.New("b-tree index on VECTOR column is not supported")
 )
 
 const populateInvertedIndexFlushPostings = 64 * 1024
@@ -1699,8 +1701,13 @@ func (d *Database) createIndex(ctx context.Context, stmt Statement, table *Table
 			if !ok {
 				return fmt.Errorf("column %s does not exist on table %s", stmtCol.Name, stmt.TableName)
 			}
-			if stmt.IndexMethod == IndexMethodBTree && col.Kind == JSON {
+			switch {
+			case stmt.IndexMethod == IndexMethodBTree && col.Kind == JSON:
 				return fmt.Errorf("%w: column %q on table %q", errIndexOnJSONColumn, col.Name, stmt.TableName)
+			case stmt.IndexMethod == IndexMethodBTree && col.Kind == Text:
+				return fmt.Errorf("%w: column %q on table %q", errIndexOnTextColumn, col.Name, stmt.TableName)
+			case stmt.IndexMethod == IndexMethodBTree && col.Kind == Vector:
+				return fmt.Errorf("%w: column %q on table %q", errIndexOnVectorColumn, col.Name, stmt.TableName)
 			}
 			indexColumns = append(indexColumns, col)
 		}

--- a/internal/minisql/pager_factory.go
+++ b/internal/minisql/pager_factory.go
@@ -35,6 +35,20 @@ func (p *pagerImpl) ForHNSWIndex() Pager {
 //   - VECTOR: use CREATE HNSW INDEX instead.
 func (p *pagerImpl) ForIndex(columns []Column, unique bool) (Pager, error) {
 	if len(columns) > 1 {
+		for _, col := range columns {
+			switch col.Kind {
+			case Text, JSON:
+				return nil, fmt.Errorf(
+					"column %q (%s) cannot be used in a B-tree secondary index: "+
+						"TEXT and JSON columns support only FULLTEXT INDEX or INVERTED INDEX",
+					col.Name, col.Kind)
+			case Vector:
+				return nil, fmt.Errorf(
+					"column %q (%s) cannot be used in a B-tree secondary index: "+
+						"VECTOR columns support only HNSW INDEX",
+					col.Name, col.Kind)
+			}
+		}
 		return &indexPager[CompositeKey]{p, columns, unique}, nil
 	}
 	switch columns[0].Kind {


### PR DESCRIPTION
…nd composite columns

createIndex now rejects TEXT and VECTOR columns (not just JSON) with wrapped sentinel errors (errIndexOnTextColumn, errIndexOnVectorColumn) early in the DDL path before any storage is allocated.

ForIndex now validates every column in composite indexes — previously len(columns) > 1 returned CompositeKey immediately, silently allowing TEXT/JSON/VECTOR in multi-column indexes.

E2e tests added for all six rejection cases (TEXT/JSON/VECTOR single- column and composite) plus a positive case confirming VARCHAR still works.