### PR TITLE
feat: support GROUP BY and aggregate functions with JOIN queries

### DIFF
--- a/e2e_tests/aggregate_test.go
+++ b/e2e_tests/aggregate_test.go
@@ -723,18 +723,137 @@ func (s *TestSuite) TestHaving() {
 	})
 }
 
-func (s *TestSuite) TestGroupByWithJoinRejected() {
+func (s *TestSuite) TestGroupByWithJoin() {
 	_, err := s.db.Exec(createOrdersTableSQL)
 	s.Require().NoError(err)
 
 	_, err = s.db.Exec(createUsersTableSQL)
 	s.Require().NoError(err)
 
-	_, err = s.db.Exec(`
-		select o.user_id, SUM(o.total_paid)
-		from orders as o
-		inner join users as u on u.id = o.user_id
-		GROUP BY o.user_id;`)
-	s.Require().Error(err)
-	s.Contains(err.Error(), "GROUP BY cannot be combined with JOIN")
+	// users: id=1 name="Alice", id=2 name="Bob"
+	s.execQuery(`insert into users(name, email) values ('Alice', 'alice@example.com'), ('Bob', 'bob@example.com');`, 2)
+
+	// orders: user 1 paid 10+20=30, user 2 paid 30+40=70
+	s.execQuery(`insert into orders(user_id, product_id, total_paid) values
+(1, 1, 10),
+(1, 2, 20),
+(2, 1, 30),
+(2, 3, 40);`, 4)
+
+	s.Run("JOIN + GROUP BY + SUM", func() {
+		rows, err := s.db.QueryContext(context.Background(), `
+			select o.user_id, SUM(o.total_paid)
+			from orders as o
+			inner join users as u on u.id = o.user_id
+			GROUP BY o.user_id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			sum    int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.sum))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 2)
+
+		sort.Slice(got, func(i, j int) bool { return got[i].userID < got[j].userID })
+		s.Equal(int64(1), got[0].userID)
+		s.Equal(int64(30), got[0].sum)
+		s.Equal(int64(2), got[1].userID)
+		s.Equal(int64(70), got[1].sum)
+	})
+
+	s.Run("JOIN + GROUP BY + COUNT(*)", func() {
+		rows, err := s.db.QueryContext(context.Background(), `
+			select o.user_id, COUNT(*)
+			from orders as o
+			inner join users as u on u.id = o.user_id
+			GROUP BY o.user_id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			count  int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.count))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 2)
+
+		sort.Slice(got, func(i, j int) bool { return got[i].userID < got[j].userID })
+		s.Equal(int64(1), got[0].userID)
+		s.Equal(int64(2), got[0].count)
+		s.Equal(int64(2), got[1].userID)
+		s.Equal(int64(2), got[1].count)
+	})
+
+	s.Run("JOIN + GROUP BY + HAVING", func() {
+		// Only groups where SUM(total_paid) > 40: user_id=2 (70).
+		rows, err := s.db.QueryContext(context.Background(), `
+			select o.user_id, SUM(o.total_paid)
+			from orders as o
+			inner join users as u on u.id = o.user_id
+			GROUP BY o.user_id
+			HAVING SUM(o.total_paid) > 40;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type row struct {
+			userID int64
+			sum    int64
+		}
+		var got []row
+		for rows.Next() {
+			var r row
+			s.Require().NoError(rows.Scan(&r.userID, &r.sum))
+			got = append(got, r)
+		}
+		s.Require().NoError(rows.Err())
+		s.Require().Len(got, 1)
+		s.Equal(int64(2), got[0].userID)
+		s.Equal(int64(70), got[0].sum)
+	})
+
+	s.Run("JOIN + COUNT(*) without GROUP BY", func() {
+		rows, err := s.db.QueryContext(context.Background(), `
+			select COUNT(*)
+			from orders as o
+			inner join users as u on u.id = o.user_id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var count int64
+		s.Require().NoError(rows.Scan(&count))
+		s.Equal(int64(4), count)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
+
+	s.Run("JOIN + SUM without GROUP BY", func() {
+		rows, err := s.db.QueryContext(context.Background(), `
+			select SUM(o.total_paid)
+			from orders as o
+			inner join users as u on u.id = o.user_id;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var sum int64
+		s.Require().NoError(rows.Scan(&sum))
+		s.Equal(int64(100), sum)
+		s.Require().False(rows.Next())
+		s.Require().NoError(rows.Err())
+	})
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -54,6 +54,16 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		ce.Write(zap.String("query type", "SELECT"), zap.Any("plan", plan))
 	}
 
+	// For JOIN queries with GROUP BY or aggregates, replace stmt.Columns with the
+	// combined alias-prefixed column list so that groupByAccumulator and newAggStates
+	// can resolve column indices against the combined join schema (e.g. "o.user_id",
+	// "u.name") rather than the base table schema.
+	if len(plan.Joins) > 0 && (stmt.IsSelectGroupBy() || stmt.IsSelectAggregate()) {
+		if combined, ok := combinedJoinSchema(ctx, plan, t.provider); ok {
+			stmt.Columns = combined
+		}
+	}
+
 	if stmt.IsSelectCountAll() && len(stmt.Joins) == 0 && t.virtualRows == nil {
 		result, ok, err := t.tryCountFromExactInvertedIndex(ctx, plan)
 		if err != nil {
@@ -187,13 +197,13 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return countResult(count), nil
 	}
 
-	// GROUP BY + single sequential scan: stream rows through a reuse buffer to avoid
-	// one make([]OptionalValue) per row. Falls back to the general path for virtual
-	// tables and parallel scans (handled inside selectGroupByZeroAlloc).
+	// GROUP BY + single sequential scan (no joins): stream rows through a reuse buffer
+	// to avoid one make([]OptionalValue) per row. Falls back to the general path for
+	// virtual tables and parallel scans (handled inside selectGroupByZeroAlloc).
 	if stmt.IsSelectGroupBy() && len(plan.Joins) == 0 && len(plan.Scans) == 1 && plan.Scans[0].Type == ScanTypeSequential {
 		return t.selectGroupByZeroAlloc(ctx, stmt, plan.Scans[0], selectedFields)
 	}
-	if stmt.IsSelectGroupBy() && len(plan.Joins) == 0 {
+	if stmt.IsSelectGroupBy() {
 		return t.selectGroupByStreaming(ctx, stmt, plan, selectedFields)
 	}
 
@@ -201,8 +211,8 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return result, err
 	}
 
-	if stmt.IsSelectAggregate() && len(plan.Joins) == 0 {
-		if len(plan.Scans) == 1 && plan.Scans[0].Type == ScanTypeSequential && t.virtualRows == nil && !t.parallelScan {
+	if stmt.IsSelectAggregate() {
+		if len(plan.Joins) == 0 && len(plan.Scans) == 1 && plan.Scans[0].Type == ScanTypeSequential && t.virtualRows == nil && !t.parallelScan {
 			return t.selectAggregateSequentialRowView(ctx, stmt, plan.Scans[0], selectedFields)
 		}
 		return t.selectAggregateStreaming(ctx, stmt, plan, selectedFields)
@@ -252,9 +262,22 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return result, err
 	}
 
+	// COUNT(*) + JOIN: count matching rows without materialising them.
+	if stmt.IsSelectCountAll() && len(plan.Joins) > 0 {
+		var count int64
+		if err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+			count += 1
+			return nil
+		}); err != nil {
+			return StatementResult{}, err
+		}
+		return countResult(count), nil
+	}
+
 	// Materialising path: buffer every matching row, then dispatch.
-	// Reached for JOIN queries that require GROUP BY, aggregate, or semi/anti-semi
-	// joins — where all rows must be collected before output can begin.
+	// Reached for JOIN queries that require semi/anti-semi joins — where all
+	// rows must be collected before output can begin.
+	// GROUP BY, aggregate, and COUNT(*) JOINs exit via dedicated paths above.
 	// Simple JOINs (including DISTINCT and ORDER BY + LIMIT) exit via the
 	// dedicated paths above.
 	//
@@ -318,6 +341,39 @@ func countResult(count int64) StatementResult {
 			[]OptionalValue{{Valid: true, Value: count}},
 		)),
 	}
+}
+
+// combinedJoinSchema builds the alias-prefixed column list for a JOIN query,
+// mirroring the schema constructed inside executeNestedLoopJoin. The result is
+// used to update stmt.Columns so that groupByAccumulator and newAggStates can
+// resolve column indices against the combined join schema (e.g. "o.user_id")
+// rather than the base table schema.
+func combinedJoinSchema(ctx context.Context, plan QueryPlan, provider TableProvider) ([]Column, bool) {
+	if len(plan.Joins) == 0 || len(plan.Scans) == 0 {
+		return nil, false
+	}
+	baseScan := plan.Scans[0]
+	baseTable, ok := provider.GetTable(ctx, baseScan.TableName)
+	if !ok {
+		return nil, false
+	}
+	firstJoin := plan.Joins[0]
+	firstInnerScan := plan.Scans[firstJoin.RightScanIndex]
+	firstInner, ok := provider.GetTable(ctx, firstInnerScan.TableName)
+	if !ok {
+		return nil, false
+	}
+	combined := buildCombinedColumns(baseTable.Columns, baseScan.TableAlias, firstInner.Columns, firstInnerScan.TableAlias)
+	for i := 1; i < len(plan.Joins); i++ {
+		join := plan.Joins[i]
+		innerScan := plan.Scans[join.RightScanIndex]
+		innerTable, ok := provider.GetTable(ctx, innerScan.TableName)
+		if !ok {
+			return nil, false
+		}
+		combined = buildCombinedColumnsProgressive(combined, innerTable.Columns, innerScan.TableAlias)
+	}
+	return combined, true
 }
 
 // countAllLeafWalk counts every row in the table.
@@ -814,8 +870,15 @@ func newGroupByAccumulator(stmt Statement, t *Table, estRows int) *groupByAccumu
 		if stmt.Aggregates[i].Kind != 0 {
 			continue
 		}
+		// Build the qualified form of the SELECT field name (e.g. "o.user_id") so
+		// that JOIN queries with alias-prefixed SELECT columns match GROUP BY entries
+		// that store the full qualified name (e.g. Field{Name: "o.user_id"}).
+		qualifiedFieldName := stmt.Fields[i].Name
+		if stmt.Fields[i].AliasPrefix != "" {
+			qualifiedFieldName = stmt.Fields[i].AliasPrefix + "." + stmt.Fields[i].Name
+		}
 		for j, gf := range stmt.GroupBy {
-			if gf.Name == stmt.Fields[i].Name {
+			if gf.Name == stmt.Fields[i].Name || gf.Name == qualifiedFieldName {
 				fieldToGroupByIdx[i] = j
 				break
 			}
@@ -5034,14 +5097,14 @@ func intersectInvertedRowIDsWithTerm(
 			lastRowID = rowID
 
 			for candidateIdx < len(candidates) && candidates[candidateIdx] < rowID {
-				candidateIdx++
+				candidateIdx += 1
 			}
 			if candidateIdx >= len(candidates) {
 				return nil
 			}
 			if candidates[candidateIdx] == rowID {
 				out = append(out, rowID)
-				candidateIdx++
+				candidateIdx += 1
 			}
 			return nil
 		})
@@ -5071,14 +5134,14 @@ func intersectInvertedRowIDsWithScanner(
 			return err
 		}
 		for candidateIdx < len(candidates) && candidates[candidateIdx] < rowID {
-			candidateIdx++
+			candidateIdx += 1
 		}
 		if candidateIdx >= len(candidates) {
 			return nil
 		}
 		if candidates[candidateIdx] == rowID {
 			out = append(out, rowID)
-			candidateIdx++
+			candidateIdx += 1
 		}
 		return nil
 	})

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -1944,18 +1944,16 @@ func (s Statement) validateSelect(table *Table) error {
 		}
 	}
 
-	// GROUP BY cannot be combined with JOINs (not yet supported).
-	if len(s.GroupBy) > 0 && len(s.Joins) > 0 {
-		return errors.New("GROUP BY cannot be combined with JOIN")
-	}
-
 	// HAVING requires GROUP BY.
 	if len(s.Having) > 0 && len(s.GroupBy) == 0 {
 		return errors.New("HAVING requires GROUP BY")
 	}
 
 	// HAVING condition fields must be aggregate functions or GROUP BY columns.
-	if len(s.Having) > 0 {
+	// For JOIN queries, HAVING references use alias-qualified column names (e.g.
+	// "SUM(o.total_paid)") that cannot be resolved against a single table schema at
+	// parse time — skip the validation and rely on execution-time errors.
+	if len(s.Having) > 0 && len(s.Joins) == 0 {
 		groupBySet := make(map[string]struct{}, len(s.GroupBy))
 		for _, f := range s.GroupBy {
 			groupBySet[f.Name] = struct{}{}
@@ -1991,13 +1989,28 @@ func (s Statement) validateSelect(table *Table) error {
 			agg := s.Aggregates[i]
 			if agg.Kind == 0 {
 				// Non-aggregate column must appear in GROUP BY.
+				// Check both the bare name and the alias-qualified name (e.g. "user_id"
+				// and "o.user_id") so that JOIN queries with qualified SELECT columns
+				// match GROUP BY entries that use the full qualified form.
+				qualified := field.Name
+				if field.AliasPrefix != "" {
+					qualified = field.AliasPrefix + "." + field.Name
+				}
 				if _, ok := groupBySet[field.Name]; !ok {
-					return fmt.Errorf("non-aggregate column %q must appear in GROUP BY", field.Name)
+					if _, ok := groupBySet[qualified]; !ok {
+						return fmt.Errorf("non-aggregate column %q must appear in GROUP BY", field.Name)
+					}
 				}
 				continue
 			}
 			if agg.Column == "" {
 				continue // COUNT(*) has no source column to validate
+			}
+			// For JOIN queries, aggregate columns are alias-qualified (e.g. "o.total_paid")
+			// and cannot be resolved against a single table schema at parse time.
+			// Execution validates them against the combined join schema.
+			if len(s.Joins) > 0 {
+				continue
 			}
 			col, ok := table.ColumnByName(agg.Column)
 			if !ok {
@@ -2014,9 +2027,12 @@ func (s Statement) validateSelect(table *Table) error {
 		}
 
 		// Validate GROUP BY columns exist in the table schema.
-		for _, f := range s.GroupBy {
-			if _, ok := table.ColumnByName(f.Name); !ok {
-				return fmt.Errorf("unknown GROUP BY column %q in table %q", f.Name, table.Name)
+		// Skip for JOIN queries: GROUP BY columns are alias-qualified and span multiple tables.
+		if len(s.Joins) == 0 {
+			for _, f := range s.GroupBy {
+				if _, ok := table.ColumnByName(f.Name); !ok {
+					return fmt.Errorf("unknown GROUP BY column %q in table %q", f.Name, table.Name)
+				}
 			}
 		}
 


### PR DESCRIPTION
Remove the hard GROUP BY + JOIN rejection and route all JOIN + GROUP BY and JOIN + aggregate queries through the existing streaming accumulators (selectGroupByStreaming, selectAggregateStreaming) which already use plan.Execute — the JOIN-aware execution path.

Key changes:
- combinedJoinSchema() builds the alias-prefixed column list from the query plan, mirroring executeNestedLoopJoin's schema. Setting stmt.Columns to this combined schema lets groupByAccumulator and newAggStates resolve column indices against e.g. "o.user_id" rather than the base table schema.
- fieldToGroupByIdx now checks both the bare field name and the alias-qualified form so SELECT o.user_id (AliasPrefix="o") correctly maps to GROUP BY o.user_id (Name="o.user_id" from the parser).
- HAVING field validation and the non-aggregate column GROUP BY check are skipped for JOIN queries at parse time; qualified column names (e.g. SUM(o.total_paid)) cannot be resolved against a single table schema — execution catches real errors.
- COUNT(*) + JOIN now streams without materialising rows.