### PR TITLE
Reduce groupByAccumulator alloc footprint; add computeGroupValues helper

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,7 +9,7 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`) median of 3 runs; memory figures are heap allocations reported by the Go runtime.
 
-This file was refreshed after the GROUP BY + JOIN support addition, the `groupOrder` slice removal from `groupByAccumulator`, and the `computeGroupValues` refactor. The GROUP BY / HAVING memory is modestly improved (was 35.5 / 27.4 KiB, now 33.6 / 25.6 KiB) after eliminating the redundant per-group string copy in `groupOrder`.
+This file was refreshed after the GROUP BY + JOIN support addition, the `groupOrder` slice removal from `groupByAccumulator`, and the `computeGroupValues` refactor. The GROUP BY / HAVING memory is modestly improved (was 35.5 / 27.4 KiB, now 33.6 / 25.6 KiB) after eliminating the redundant per-group string copy in `groupOrder`. A new `DISTINCT + ORDER BY indexed` row was added (2026-06-07) to capture the streaming adjacent-compare dedup path that activates when an index covers the ORDER BY columns.
 
 ---
 
@@ -52,6 +52,7 @@ The results are grouped by benchmark family so each table can be read without ho
 | HAVING filter | 822.4 µs | 2.10 ms | 0.4× | 25.6 KiB | 1.9 KiB | 263 / 111 |
 | DISTINCT high cardinality | 3.17 ms | 6.39 ms | 0.5× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
 | DISTINCT + ORDER BY high cardinality | 4.46 ms | 5.79 ms | 0.8× | 4.53 MiB | 586.3 KiB | 90,097 / 40,010 |
+| DISTINCT + ORDER BY indexed | 3.99 ms | 3.81 ms | 1.0× | 4.59 MiB | 586.3 KiB | 60,079 / 40,010 |
 | CTE materialise | 380.4 µs | 502.0 µs | 0.8× | 6.6 KiB | 400 B | 89 / 13 |
 | Subquery IN list | 2.90 ms | 4.10 ms | 0.7× | 559.0 KiB | 234.7 KiB | 15,197 / 20,010 |
 
@@ -175,5 +176,6 @@ The results are grouped by benchmark family so each table can be read without ho
 - Full-text and JSON build paths still allocate multiple MiB per operation and remain the most relevant inverted-index targets.
 - GROUP BY / HAVING memory gap vs SQLite (9.6× / 13.1×) is largely structural: Go's runtime map has higher per-entry overhead than SQLite's C hash table. The `groupOrder` redundancy was removed (saved ~1.6–2 KiB/op); arena interning was tried and rejected (old backing arrays accumulate in GC via map string references). Further reduction requires a custom open-address hash table — low ROI at this stage.
 - DISTINCT high cardinality without ORDER BY (1.27 MiB vs SQLite 586 KiB, 2.2×): streaming hash-set path; the gap is structural — SQLite sorts/hashes on the C side and delivers rows lazily, avoiding upfront Go heap allocation.
-- DISTINCT + ORDER BY high cardinality (4.53 MiB vs SQLite 586 KiB): ORDER BY requires upfront materialization of all rows before sorting, which doubles alloc count vs the no-ORDER-BY streaming path. The sort-then-adjacent-dedup optimization (committed 2026-06-07) removes the hash-set overhead from deduplication, but the dominant cost is now the O(N) row materialization for sorting — unavoidable without a C-side or disk-backed sort.
+- DISTINCT + ORDER BY high cardinality (4.53 MiB vs SQLite 586 KiB): ORDER BY requires upfront materialization of all rows before sorting, which doubles alloc count vs the no-ORDER-BY streaming path. The sort-then-adjacent-dedup optimization removes the hash-set overhead from deduplication, but the dominant cost is the O(N) row materialization for sorting — unavoidable without a disk-backed sort (see ROADMAP).
+- DISTINCT + ORDER BY indexed (3.99 ms / 4.59 MiB / 60,079 allocs): when an index covers ORDER BY, streaming adjacent-compare dedup (`newDistinctAdjacentRowViewIteratorFactory`) eliminates the hash set, saving ~30,018 allocs/op vs the in-memory sort path. Still limited by per-row materialization overhead from the `database/sql` layer.
 - VACUUM is much improved after streaming row copy, though it still allocates far more than SQLite because it rebuilds the compacted MiniSQL database through normal table/index write paths.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -3,13 +3,13 @@
 ## Current Baseline
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
-**Branch:** `codex/profile-remaining-outliers`  
-**Command:** `make bench BENCH_COUNT=1` followed by `make bench-report`; HNSW tables refreshed with targeted `go test -tags bench -bench '^BenchmarkHNSW_...' -benchmem` runs; DISTINCT/subquery rows refreshed with `go test -tags bench -run '^$' -bench 'Benchmark(Distinct_HighCardinality|Subquery_InList)$' -benchmem -count=1 ./benchmarks/`; VACUUM row refreshed with `go test -tags bench -run '^$' -bench '^BenchmarkVacuum_Small$' -benchmem -count=1 ./benchmarks/`; latest subquery and HNSW build rows refreshed with `go test -tags bench -run '^$' -bench '^BenchmarkSubquery_InList$' -benchmem -count=1 ./benchmarks/` and `go test -tags bench -run '^$' -bench '^BenchmarkHNSW_BuildIndex$' -benchmem -benchtime=1x ./benchmarks/`  
-**GOMAXPROCS:** 10  
+**Branch:** `main`  
+**Command:** `go test -tags bench ./benchmarks/ -run='^$' -bench='...' -benchmem -count=3` for each family; HNSW rows from a previous run (unchanged — HNSW build takes 50+ s per sub-benchmark). All other rows refreshed 2026-06-07.  
+**GOMAXPROCS:** 10
 
-SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`); memory figures are heap allocations reported by the Go runtime.
+SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`) median of 3 runs; memory figures are heap allocations reported by the Go runtime.
 
-This file was refreshed from scratch after the latest DML allocation work, including transaction write-set inlining, auto-commit transaction reuse, direct prepared DML argument binding, and HNSW typed candidate-heap allocation reduction. DISTINCT/subquery rows were subsequently refreshed after RowView predicate fast paths and DISTINCT seen-set pre-sizing. VACUUM was refreshed after streaming row copy into the temporary compacted database. Subquery and HNSW build rows were refreshed again after typed semi-join membership and per-node HNSW neighbor backing allocation.
+This file was refreshed after the GROUP BY + JOIN support addition, the `groupOrder` slice removal from `groupByAccumulator`, and the `computeGroupValues` refactor. The GROUP BY / HAVING memory is modestly improved (was 35.5 / 27.4 KiB, now 33.6 / 25.6 KiB) after eliminating the redundant per-group string copy in `groupOrder`.
 
 ---
 
@@ -21,91 +21,91 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Point scan | 4.80 µs | 3.47 µs | 1.4× | 3.7 KiB | 679 B | 47 / 26 |
-| Limit | 7.13 µs | 7.95 µs | 0.9× | 3.8 KiB | 1.7 KiB | 97 / 104 |
-| Full scan | 3.65 ms | 5.12 ms | 0.7× | 1.23 MiB | 1.29 MiB | 79,822 / 99,758 |
-| Count star | 6.30 µs | 9.65 µs | 0.7× | 2.6 KiB | 400 B | 27 / 13 |
-| Index range scan | 670.66 µs | 752.23 µs | 0.9× | 83.8 KiB | 85.9 KiB | 5,539 / 6,581 |
-| Secondary index, low selectivity | 1.76 ms | 2.67 ms | 0.7× | 314.9 KiB | 313.0 KiB | 24,920 / 29,886 |
-| Secondary index, low selectivity limit | 7.90 µs | 8.32 µs | 1.0× | 4.1 KiB | 1.1 KiB | 89 / 64 |
-| Range scan | 1.49 ms | 879.16 µs | 1.7× | 80.8 KiB | 85.9 KiB | 5,507 / 6,581 |
+| Point scan | 6.39 µs | 4.15 µs | 1.5× | 3.7 KiB | 679 B | 47 / 26 |
+| Limit | 8.77 µs | 9.66 µs | 0.9× | 3.8 KiB | 1.7 KiB | 97 / 104 |
+| Full scan | 4.42 ms | 6.12 ms | 0.7× | 1.23 MiB | 1.29 MiB | 79,823 / 99,758 |
+| Count star | 7.65 µs | 10.93 µs | 0.7× | 2.6 KiB | 400 B | 27 / 13 |
+| Index range scan | 1.11 ms | 879.6 µs | 1.3× | 83.8 KiB | 85.9 KiB | 5,539 / 6,581 |
+| Secondary index, low selectivity | 2.01 ms | 3.14 ms | 0.6× | 315.0 KiB | 313.0 KiB | 24,920 / 29,886 |
+| Secondary index, low selectivity limit | 9.41 µs | 9.30 µs | 1.0× | 4.1 KiB | 1.1 KiB | 89 / 64 |
+| Range scan | 879.6 µs | 1.01 ms | 0.9× | 80.8 KiB | 85.9 KiB | 5,511 / 6,581 |
 
 ### INSERT, UPDATE, DELETE, and Constraints
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Insert single row | 10.88 µs | 43.95 µs | 0.2× | 2.1 KiB | 311 B | 31 / 12 |
-| Insert batch | 369.66 µs | 253.47 µs | 1.5× | 133.6 KiB | 31.0 KiB | 2,637 / 1,300 |
-| Insert prepared batch | 396.14 µs | 234.67 µs | 1.7× | 132.5 KiB | 31.0 KiB | 2,634 / 1,300 |
-| Insert multi-values | 198.06 µs | 177.99 µs | 1.1× | 109.6 KiB | 25.2 KiB | 1,757 / 616 |
-| Update by PK | 8.26 µs | 37.67 µs | 0.2× | 3.8 KiB | 263 B | 40 / 10 |
-| Delete by PK | 16.80 µs | 78.92 µs | 0.2× | 3.3 KiB | 447 B | 55 / 19 |
-| ON CONFLICT DO UPDATE | 7.42 µs | 36.39 µs | 0.2× | 1.6 KiB | 260 B | 31 / 10 |
-| Foreign key insert | 11.32 µs | 43.07 µs | 0.3× | 1.9 KiB | 192 B | 28 / 8 |
-| Foreign key delete cascade | 23.35 µs | 50.96 µs | 0.5× | 7.2 KiB | 128 B | 112 / 5 |
+| Insert single row | 12.67 µs | 54.64 µs | 0.2× | 2.1 KiB | 311 B | 31 / 12 |
+| Insert batch | 437.0 µs | 309.3 µs | 1.4× | 133.6 KiB | 31.0 KiB | 2,632 / 1,299 |
+| Insert prepared batch | 402.6 µs | 249.8 µs | 1.6× | 132.4 KiB | 31.0 KiB | 2,633 / 1,299 |
+| Insert multi-values | 219.5 µs | 193.3 µs | 1.1× | 109.5 KiB | 25.2 KiB | 1,756 / 616 |
+| Update by PK | 9.81 µs | 47.98 µs | 0.2× | 3.8 KiB | 263 B | 40 / 10 |
+| Delete by PK | 18.48 µs | 103.2 µs | 0.2× | 3.3 KiB | 447 B | 55 / 19 |
+| ON CONFLICT DO UPDATE | 9.08 µs | 43.20 µs | 0.2× | 1.6 KiB | 259 B | 31 / 10 |
+| Foreign key insert | 12.28 µs | 57.78 µs | 0.2× | 1.9 KiB | 191 B | 28 / 8 |
+| Foreign key delete cascade | 51.50 µs | 83.25 µs | 0.6× | 7.2 KiB | 128 B | 111 / 5 |
 
 ### Aggregates, DISTINCT, CTE, and Subquery
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| GROUP BY aggregate | 979.73 µs | 2.10 ms | 0.5× | 35.5 KiB | 3.5 KiB | 459 / 309 |
-| HAVING filter | 741.87 µs | 1.95 ms | 0.4× | 27.4 KiB | 1.9 KiB | 264 / 111 |
-| DISTINCT high cardinality | 4.10 ms | 8.44 ms | 0.5× | 1.26 MiB | 586.3 KiB | 40,093 / 40,010 |
-| CTE materialise | 793.64 µs | 437.25 µs | 1.8× | 6.6 KiB | 400 B | 86 / 13 |
-| Subquery IN list | 4.46 ms | 5.81 ms | 0.8× | 559.1 KiB | 234.7 KiB | 15,198 / 20,010 |
+| GROUP BY aggregate | 987.1 µs | 2.31 ms | 0.4× | 33.6 KiB | 3.5 KiB | 458 / 309 |
+| HAVING filter | 822.4 µs | 2.10 ms | 0.4× | 25.6 KiB | 1.9 KiB | 263 / 111 |
+| DISTINCT high cardinality | 3.57 ms | 6.48 ms | 0.6× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
+| CTE materialise | 380.4 µs | 502.0 µs | 0.8× | 6.6 KiB | 400 B | 89 / 13 |
+| Subquery IN list | 2.90 ms | 4.10 ms | 0.7× | 559.0 KiB | 234.7 KiB | 15,197 / 20,010 |
 
 ### Joins
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Inner join, small-large | 5.68 ms | 4.66 ms | 1.2× | 1.00 MiB | 1.07 MiB | 79,855 / 99,757 |
-| Inner join, low selectivity | 108.11 µs | 735.45 µs | 0.1× | 21.1 KiB | 11.3 KiB | 1,198 / 1,009 |
-| Left join, unmatched rows | 3.64 ms | 4.13 ms | 0.9× | 869.4 KiB | 708.2 KiB | 79,643 / 70,157 |
+| Inner join, small-large | 6.56 ms | 5.98 ms | 1.1× | 1.00 MiB | 1.07 MiB | 79,855 / 99,757 |
+| Inner join, low selectivity | 129.6 µs | 860.9 µs | 0.15× | 21.0 KiB | 11.3 KiB | 1,198 / 1,009 |
+| Left join, unmatched rows | 4.38 ms | 5.19 ms | 0.8× | 869.0 KiB | 708.2 KiB | 79,643 / 70,157 |
 
 ### Full-Text Inverted Index
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Build index | 2.95 ms | 2.01 ms | 1.5× | 1.39 MiB | 392 B | 12,295 / 20 |
-| Insert with index | 36.43 µs | 87.09 µs | 0.4× | 12.8 KiB | 271 B | 132 / 10 |
-| Search single term, rare | 4.57 µs | 6.54 µs | 0.7× | 2.4 KiB | 408 B | 41 / 13 |
-| Search single term, medium | 4.14 µs | 7.61 µs | 0.5× | 2.4 KiB | 408 B | 41 / 13 |
-| Search single term, common | 4.24 µs | 61.16 µs | 0.1× | 2.4 KiB | 424 B | 43 / 15 |
-| Search multi-term AND | 14.93 µs | 33.26 µs | 0.4× | 11.4 KiB | 408 B | 62 / 13 |
-| Search phrase | 15.61 µs | 24.50 µs | 0.6× | 26.3 KiB | 416 B | 278 / 14 |
-| Update with index | 35.41 µs | 97.40 µs | 0.4× | 18.0 KiB | 291 B | 187 / 12 |
-| Delete with index | 48.01 µs | 138.41 µs | 0.3× | 17.4 KiB | 135 B | 175 / 6 |
+| Build index | 4.34 ms | 2.71 ms | 1.6× | 1.43 MiB | 392 B | 12,359 / 20 |
+| Insert with index | 41.71 µs | 112.5 µs | 0.4× | 13.0 KiB | 271 B | 133 / 10 |
+| Search single term, rare | 6.64 µs | 7.65 µs | 0.9× | 2.4 KiB | 408 B | 41 / 13 |
+| Search single term, medium | 6.85 µs | 8.73 µs | 0.8× | 2.4 KiB | 408 B | 41 / 13 |
+| Search single term, common | 6.13 µs | 70.71 µs | 0.1× | 2.4 KiB | 424 B | 43 / 15 |
+| Search multi-term AND | 20.59 µs | 39.08 µs | 0.5× | 11.4 KiB | 408 B | 62 / 13 |
+| Search phrase | 27.43 µs | 26.53 µs | 1.0× | 26.3 KiB | 416 B | 278 / 14 |
+| Update with index | 44.66 µs | 133.9 µs | 0.3× | 18.4 KiB | 290 B | 190 / 12 |
+| Delete with index | 57.07 µs | 175.3 µs | 0.3× | 17.1 KiB | 135 B | 173 / 6 |
 
 ### Full-Text MiniSQL-Only Checks
 
 | Benchmark | Time | Memory | Allocs |
 |---|---|---|---|
-| Search after deletes | 81.57 µs | 11.1 KiB | 49 |
+| Search after deletes | 93.63 µs | 11.1 KiB | 49 |
 
 ### JSON Inverted Index DML
 
 | Benchmark | Time | Memory | Allocs |
 |---|---|---|---|
-| Build index | 1.93 ms | 1.26 MiB | 26,669 |
-| Insert with index | 48.91 µs | 59.6 KiB | 146 |
-| Contains after deletes | 59.19 µs | 19.2 KiB | 77 |
-| Update with index | 5.97 µs | 4.2 KiB | 46 |
-| Delete with index | 112.67 µs | 26.6 KiB | 150 |
+| Build index | 3.55 ms | 1.25 MiB | 26,674 |
+| Insert with index | 66.64 µs | 48.1 KiB | 144 |
+| Contains after deletes | 75.47 µs | 19.2 KiB | 77 |
+| Update with index | 9.30 µs | 4.2 KiB | 46 |
+| Delete with index | 134.9 µs | 26.6 KiB | 150 |
 
 ### JSON Contains Comparisons
 
 | Predicate | MiniSQL indexed | MiniSQL sequential | SQLite JSON scan | SQLite expression index |
 |---|---|---|---|---|
-| Key/value | 16.39 µs / 7.8 KiB | 1.90 ms / 1.94 MiB | 712.05 µs / 424 B | 26.02 µs / 424 B |
-| Object subset | 28.70 µs / 8.8 KiB | 1.98 ms / 1.94 MiB | 730.76 µs / 424 B | 121.03 µs / 424 B |
+| Key/value | 21.82 µs / 7.8 KiB | 3.62 ms / 1.94 MiB | 858.0 µs / 424 B | 30.48 µs / 424 B |
+| Object subset | 33.52 µs / 8.8 KiB | 3.58 ms / 1.94 MiB | 830.6 µs / 424 B | 140.7 µs / 424 B |
 
 ### Maintenance and Explain
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| VACUUM small | 2.34 ms | 556.88 µs | 4.2× | 752.5 KiB | 91 B | 6,982 / 4 |
-| WAL checkpoint | 194.44 µs | 104.85 µs | 1.9× | 3.3 KiB | 440 B | 37 / 12 |
-| EXPLAIN | 5.46 µs | 1.21 µs | 4.5× | 6.0 KiB | 680 B | 55 / 18 |
+| VACUUM small | 2.15 ms | 583.7 µs | 3.7× | 752.5 KiB | 91 B | 6,982 / 4 |
+| WAL checkpoint | 357.0 µs | 171.8 µs | 2.1× | 3.3 KiB | 441 B | 37 / 12 |
+| EXPLAIN | 7.45 µs | 1.75 µs | 4.3× | 6.0 KiB | 680 B | 55 / 18 |
 
 ### HNSW Build Index
 
@@ -155,20 +155,22 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Area | Benchmark | MiniSQL memory |
 |---|---|---|
-| HNSW | Build index, dims768, 10k rows | 208.1 MiB |
-| HNSW | Build index, dims128, 10k rows | 134.7 MiB |
-| HNSW | Build index, dims3, 10k rows | 120.2 MiB |
-| Full-text | Build index | 1.39 MiB |
-| DISTINCT | High-cardinality distinct | 1.26 MiB |
-| JSON inverted | Build index | 1.26 MiB |
+| HNSW | Build index, dims768, 10k rows | 207.7 MiB |
+| HNSW | Build index, dims128, 10k rows | 136.7 MiB |
+| HNSW | Build index, dims3, 10k rows | 140.8 MiB |
+| Full-text | Build index | 1.43 MiB |
+| DISTINCT | High-cardinality distinct | 1.27 MiB |
+| JSON inverted | Build index | 1.25 MiB |
 | SELECT | Full scan | 1.23 MiB |
 | Join | Inner join, small-large | 1.00 MiB |
+| Join | Left join, unmatched rows | 869.0 KiB |
 | Maintenance | VACUUM small | 752.5 KiB |
-| Subquery | IN list | 715.8 KiB |
+| Subquery | IN list | 559.0 KiB |
 
 ### Good Next Optimisation Targets
 
 - HNSW build allocation counts are much lower after typed candidate heaps and per-node neighbor backing allocation, but build memory remains the largest broad-suite outlier at 10k rows.
 - Full-text and JSON build paths still allocate multiple MiB per operation and remain the most relevant inverted-index targets.
-- DISTINCT and subquery materialisation are improved after RowView predicate fast paths, DISTINCT seen-set pre-sizing, and typed semi-join membership, but DISTINCT remains near the MiB/op outlier group.
+- GROUP BY / HAVING memory gap vs SQLite (9.6× / 13.1×) is largely structural: Go's runtime map has higher per-entry overhead than SQLite's C hash table. The `groupOrder` redundancy was removed (saved ~1.6–2 KiB/op); arena interning was tried and rejected (old backing arrays accumulate in GC via map string references). Further reduction requires a custom open-address hash table — low ROI at this stage.
+- DISTINCT high cardinality (1.27 MiB vs SQLite 586 KiB, 2.2×): a sort-then-deduplicate path for `DISTINCT … ORDER BY` queries would eliminate the hash set entirely for that shape — in progress.
 - VACUUM is much improved after streaming row copy, though it still allocates far more than SQLite because it rebuilds the compacted MiniSQL database through normal table/index write paths.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -50,7 +50,8 @@ The results are grouped by benchmark family so each table can be read without ho
 |---|---|---|---|---|---|---|
 | GROUP BY aggregate | 987.1 µs | 2.31 ms | 0.4× | 33.6 KiB | 3.5 KiB | 458 / 309 |
 | HAVING filter | 822.4 µs | 2.10 ms | 0.4× | 25.6 KiB | 1.9 KiB | 263 / 111 |
-| DISTINCT high cardinality | 3.57 ms | 6.48 ms | 0.6× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
+| DISTINCT high cardinality | 3.17 ms | 6.39 ms | 0.5× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
+| DISTINCT + ORDER BY high cardinality | 4.46 ms | 5.79 ms | 0.8× | 4.53 MiB | 586.3 KiB | 90,097 / 40,010 |
 | CTE materialise | 380.4 µs | 502.0 µs | 0.8× | 6.6 KiB | 400 B | 89 / 13 |
 | Subquery IN list | 2.90 ms | 4.10 ms | 0.7× | 559.0 KiB | 234.7 KiB | 15,197 / 20,010 |
 
@@ -159,7 +160,8 @@ The results are grouped by benchmark family so each table can be read without ho
 | HNSW | Build index, dims128, 10k rows | 136.7 MiB |
 | HNSW | Build index, dims3, 10k rows | 140.8 MiB |
 | Full-text | Build index | 1.43 MiB |
-| DISTINCT | High-cardinality distinct | 1.27 MiB |
+| DISTINCT | High-cardinality distinct (no ORDER BY) | 1.27 MiB |
+| DISTINCT | High-cardinality distinct + ORDER BY | 4.53 MiB |
 | JSON inverted | Build index | 1.25 MiB |
 | SELECT | Full scan | 1.23 MiB |
 | Join | Inner join, small-large | 1.00 MiB |
@@ -172,5 +174,6 @@ The results are grouped by benchmark family so each table can be read without ho
 - HNSW build allocation counts are much lower after typed candidate heaps and per-node neighbor backing allocation, but build memory remains the largest broad-suite outlier at 10k rows.
 - Full-text and JSON build paths still allocate multiple MiB per operation and remain the most relevant inverted-index targets.
 - GROUP BY / HAVING memory gap vs SQLite (9.6× / 13.1×) is largely structural: Go's runtime map has higher per-entry overhead than SQLite's C hash table. The `groupOrder` redundancy was removed (saved ~1.6–2 KiB/op); arena interning was tried and rejected (old backing arrays accumulate in GC via map string references). Further reduction requires a custom open-address hash table — low ROI at this stage.
-- DISTINCT high cardinality (1.27 MiB vs SQLite 586 KiB, 2.2×): a sort-then-deduplicate path for `DISTINCT … ORDER BY` queries would eliminate the hash set entirely for that shape — in progress.
+- DISTINCT high cardinality without ORDER BY (1.27 MiB vs SQLite 586 KiB, 2.2×): streaming hash-set path; the gap is structural — SQLite sorts/hashes on the C side and delivers rows lazily, avoiding upfront Go heap allocation.
+- DISTINCT + ORDER BY high cardinality (4.53 MiB vs SQLite 586 KiB): ORDER BY requires upfront materialization of all rows before sorting, which doubles alloc count vs the no-ORDER-BY streaming path. The sort-then-adjacent-dedup optimization (committed 2026-06-07) removes the hash-set overhead from deduplication, but the dominant cost is now the O(N) row materialization for sorting — unavoidable without a C-side or disk-backed sort.
 - VACUUM is much improved after streaming row copy, though it still allocates far more than SQLite because it rebuilds the compacted MiniSQL database through normal table/index write paths.

--- a/benchmarks/aggregate_bench_test.go
+++ b/benchmarks/aggregate_bench_test.go
@@ -177,3 +177,74 @@ func BenchmarkDistinct_HighCardinality(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkDistinct_OrderBy measures DISTINCT + ORDER BY on the email column
+// (all unique, high cardinality). Exercises the sort-then-adjacent-dedup path
+// in selectWithSortRowView which avoids the per-row hash-set allocation.
+func BenchmarkDistinct_OrderBy(b *testing.B) {
+	for _, d := range drivers {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openDB(b, d)
+			defer cleanup()
+
+			var (
+				createT string
+				insertT string
+				query   string
+			)
+			switch d.name {
+			case "minisql":
+				createT = `create table "bench_distinct_ob" (id int8 primary key autoincrement, email varchar(255))`
+				insertT = `insert into "bench_distinct_ob" (email) values (?)`
+				query = `select distinct email from "bench_distinct_ob" order by email`
+			default:
+				createT = `CREATE TABLE bench_distinct_ob (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT)`
+				insertT = `INSERT INTO bench_distinct_ob (email) VALUES (?)`
+				query = `SELECT DISTINCT email FROM bench_distinct_ob ORDER BY email`
+			}
+
+			mustExec(b, db, createT)
+			tx, err := db.Begin()
+			if err != nil {
+				b.Fatalf("begin: %v", err)
+			}
+			ins, err := tx.Prepare(insertT)
+			if err != nil {
+				_ = tx.Rollback()
+				b.Fatalf("prepare insert: %v", err)
+			}
+			for i := range aggregateSeedN {
+				if _, err := ins.Exec(fmt.Sprintf("user%06d@example.com", i)); err != nil {
+					_ = tx.Rollback()
+					b.Fatalf("insert %d: %v", i, err)
+				}
+			}
+			ins.Close()
+			if err := tx.Commit(); err != nil {
+				b.Fatalf("commit: %v", err)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				rows, err := db.Query(query)
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+				n := 0
+				for rows.Next() {
+					var email string
+					if err := rows.Scan(&email); err != nil {
+						rows.Close()
+						b.Fatalf("scan: %v", err)
+					}
+					n += 1
+				}
+				rows.Close()
+				if err := rows.Err(); err != nil {
+					b.Fatalf("rows err: %v", err)
+				}
+				b.ReportMetric(float64(n), "rows/op")
+			}
+		})
+	}
+}

--- a/benchmarks/aggregate_bench_test.go
+++ b/benchmarks/aggregate_bench_test.go
@@ -248,3 +248,80 @@ func BenchmarkDistinct_OrderBy(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkDistinct_OrderBy_Indexed measures DISTINCT + ORDER BY on an indexed
+// column (all unique, high cardinality).  With an index on email the query
+// planner sets SortInMemory=false and delivers rows via index scan already in
+// email order.  MiniSQL uses streaming adjacent-compare dedup — O(1) memory —
+// instead of materialising all rows or building a hash set.
+func BenchmarkDistinct_OrderBy_Indexed(b *testing.B) {
+	for _, d := range drivers {
+		b.Run(d.name, func(b *testing.B) {
+			db, cleanup := openDB(b, d)
+			defer cleanup()
+
+			var (
+				createT   string
+				createIdx string
+				insertT   string
+				query     string
+			)
+			switch d.name {
+			case "minisql":
+				createT = `create table "bench_distinct_idx" (id int8 primary key autoincrement, email varchar(255))`
+				createIdx = `create index "idx_bench_distinct_email" on "bench_distinct_idx" (email)`
+				insertT = `insert into "bench_distinct_idx" (email) values (?)`
+				query = `select distinct email from "bench_distinct_idx" order by email`
+			default:
+				createT = `CREATE TABLE bench_distinct_idx (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT)`
+				createIdx = `CREATE INDEX IF NOT EXISTS idx_bench_distinct_email ON bench_distinct_idx (email)`
+				insertT = `INSERT INTO bench_distinct_idx (email) VALUES (?)`
+				query = `SELECT DISTINCT email FROM bench_distinct_idx ORDER BY email`
+			}
+
+			mustExec(b, db, createT)
+			tx, err := db.Begin()
+			if err != nil {
+				b.Fatalf("begin: %v", err)
+			}
+			ins, err := tx.Prepare(insertT)
+			if err != nil {
+				_ = tx.Rollback()
+				b.Fatalf("prepare insert: %v", err)
+			}
+			for i := range aggregateSeedN {
+				if _, err := ins.Exec(fmt.Sprintf("user%06d@example.com", i)); err != nil {
+					_ = tx.Rollback()
+					b.Fatalf("insert %d: %v", i, err)
+				}
+			}
+			ins.Close()
+			if err := tx.Commit(); err != nil {
+				b.Fatalf("commit: %v", err)
+			}
+			mustExec(b, db, createIdx)
+
+			b.ResetTimer()
+			for range b.N {
+				rows, err := db.Query(query)
+				if err != nil {
+					b.Fatalf("query: %v", err)
+				}
+				n := 0
+				for rows.Next() {
+					var email string
+					if err := rows.Scan(&email); err != nil {
+						rows.Close()
+						b.Fatalf("scan: %v", err)
+					}
+					n += 1
+				}
+				rows.Close()
+				if err := rows.Err(); err != nil {
+					b.Fatalf("rows err: %v", err)
+				}
+				b.ReportMetric(float64(n), "rows/op")
+			}
+		})
+	}
+}

--- a/e2e_tests/distinct_test.go
+++ b/e2e_tests/distinct_test.go
@@ -178,4 +178,89 @@ func (s *TestSuite) TestSelectDistinct() {
 		// Expect: NULL, 'bar', 'foo' — 3 distinct values
 		s.Require().Len(vals, 3)
 	})
+
+	// The next two subtests exercise the sort-then-adjacent-dedup path introduced
+	// to eliminate the per-group hash-set allocation for DISTINCT + ORDER BY queries.
+
+	s.Run("DISTINCT on multiple columns ORDER BY subset — sort-then-dedup path", func() {
+		// ORDER BY player (subset of projected player, level) — exercises extended sort
+		// where level is added as a secondary tiebreaker so equal (player, level) pairs
+		// are adjacent and can be removed by adjacent comparison without a hash set.
+		rows, err := s.db.QueryContext(context.Background(), `select distinct player, level from scores order by player, level;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type pair struct {
+			Player string
+			Level  int32
+		}
+		var pairs []pair
+		for rows.Next() {
+			var p pair
+			s.Require().NoError(rows.Scan(&p.Player, &p.Level))
+			pairs = append(pairs, p)
+		}
+		s.Require().NoError(rows.Err())
+
+		// (Alice,1), (Alice,2), (Bob,1), (Bob,2), (Carol,3) = 5 distinct pairs, sorted
+		s.Require().Len(pairs, 5)
+		s.Equal("Alice", pairs[0].Player)
+		s.Equal(int32(1), pairs[0].Level)
+		s.Equal("Alice", pairs[1].Player)
+		s.Equal(int32(2), pairs[1].Level)
+		s.Equal("Bob", pairs[2].Player)
+		s.Equal("Carol", pairs[4].Player)
+		s.Equal(int32(3), pairs[4].Level)
+	})
+
+	s.Run("DISTINCT ORDER BY desc preserves correct order after dedup", func() {
+		// Descending ORDER BY forces a different sort order — adjacent dedup must still
+		// correctly identify and remove the duplicate (Alice, 1) and (Bob, 2) pairs.
+		rows, err := s.db.QueryContext(context.Background(), `select distinct player, level from scores order by player desc, level desc;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		type pair struct {
+			Player string
+			Level  int32
+		}
+		var pairs []pair
+		for rows.Next() {
+			var p pair
+			s.Require().NoError(rows.Scan(&p.Player, &p.Level))
+			pairs = append(pairs, p)
+		}
+		s.Require().NoError(rows.Err())
+
+		// Same 5 distinct pairs but in reverse order
+		s.Require().Len(pairs, 5)
+		s.Equal("Carol", pairs[0].Player)
+		s.Equal(int32(3), pairs[0].Level)
+		s.Equal("Bob", pairs[1].Player)
+		s.Equal(int32(2), pairs[1].Level)
+		s.Equal("Bob", pairs[2].Player)
+		s.Equal(int32(1), pairs[2].Level)
+		s.Equal("Alice", pairs[3].Player)
+		s.Equal("Alice", pairs[4].Player)
+	})
+
+	s.Run("DISTINCT ORDER BY with OFFSET and no LIMIT", func() {
+		rows, err := s.db.QueryContext(context.Background(), `select distinct level from scores order by level;`)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var levels []int32
+		for rows.Next() {
+			var l int32
+			s.Require().NoError(rows.Scan(&l))
+			levels = append(levels, l)
+		}
+		s.Require().NoError(rows.Err())
+
+		// levels 1, 2, 3 — all three distinct
+		s.Require().Len(levels, 3)
+		s.Equal(int32(1), levels[0])
+		s.Equal(int32(2), levels[1])
+		s.Equal(int32(3), levels[2])
+	})
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -1,6 +1,7 @@
 package minisql
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1498,10 +1499,15 @@ func (t *Table) selectStreamingDirect(
 		offset = stmt.Offset.Value.(int64)
 	}
 
+	// When the index delivers rows in ORDER BY order and every projected field
+	// is in ORDER BY, equal projected rows are adjacent → adjacent-compare dedup
+	// uses O(1) memory instead of an O(N) hash set.
+	adjacentDedup := stmt.Distinct && !plan.SortInMemory && len(plan.OrderBy) > 0 && allProjectedInOrderBy(requestedFields, plan.OrderBy)
 	var seen map[string]struct{}
-	if stmt.Distinct {
+	if stmt.Distinct && !adjacentDedup {
 		seen = make(map[string]struct{})
 	}
+	var prevDistinctKey string
 
 	// When LIMIT is present, pre-size to exactly the limit so append never reallocates.
 	// Without LIMIT, start empty and grow as needed.
@@ -1519,10 +1525,17 @@ func (t *Table) selectStreamingDirect(
 		}
 		if stmt.Distinct {
 			key := p.rowDistinctKey()
-			if _, dup := seen[key]; dup {
-				return nil
+			if adjacentDedup {
+				if key == prevDistinctKey {
+					return nil
+				}
+				prevDistinctKey = key
+			} else {
+				if _, dup := seen[key]; dup {
+					return nil
+				}
+				seen[key] = struct{}{}
 			}
-			seen[key] = struct{}{}
 		}
 		if hasOffset && offset > 0 {
 			offset -= 1
@@ -1863,11 +1876,19 @@ func (t *Table) selectStreamingDirectRowView(
 	}
 
 	if stmt.Distinct {
-		distinctFactory := newDistinctRowViewIteratorFactory(
-			ctx, t.pager, newRowViewIter, fieldIndexes, t.Columns,
-			distinctSeenCapacityFromEstimate(t.estimatedRowCount()),
-			remaining, offset, hasLimit, hasOffset,
-		)
+		var distinctFactory func() RowViewIterator
+		if !plan.SortInMemory && allProjectedInOrderBy(requestedFields, plan.OrderBy) {
+			distinctFactory = newDistinctAdjacentRowViewIteratorFactory(
+				ctx, t.pager, newRowViewIter, fieldIndexes, t.Columns,
+				remaining, offset, hasLimit, hasOffset,
+			)
+		} else {
+			distinctFactory = newDistinctRowViewIteratorFactory(
+				ctx, t.pager, newRowViewIter, fieldIndexes, t.Columns,
+				distinctSeenCapacityFromEstimate(t.estimatedRowCount()),
+				remaining, offset, hasLimit, hasOffset,
+			)
+		}
 		result.RowViews = distinctFactory()
 		result.RowViewPager = t.pager
 		result.RowViewFieldIndexes = fieldIndexes
@@ -3279,6 +3300,66 @@ func newDistinctRowViewIteratorFactory(
 				}
 				if hasLimit {
 					rem -= 1
+				}
+				return view, nil
+			}
+		}, inner.Close)
+	}
+}
+
+// newDistinctAdjacentRowViewIteratorFactory is like newDistinctRowViewIteratorFactory
+// but uses adjacent-compare instead of a hash set.  It is only correct when the
+// underlying iterator delivers rows in ORDER BY order and every projected field
+// is covered by ORDER BY — in that case equal projected rows are guaranteed to
+// be adjacent, so a single prevKey []byte suffices for dedup (O(1) memory).
+func newDistinctAdjacentRowViewIteratorFactory(
+	ctx context.Context,
+	pager TxPager,
+	innerFactory func() RowViewIterator,
+	fieldIndexes []int,
+	columns []Column,
+	remaining int64,
+	offset int64,
+	hasLimit bool,
+	hasOffset bool,
+) func() RowViewIterator {
+	return func() RowViewIterator {
+		inner := innerFactory()
+		var prevKey []byte
+		buf := make([]byte, 0, 64)
+		rem := remaining
+		off := offset
+		done := false
+
+		return newRowViewIteratorWithClose(func(iterCtx context.Context) (RowView, error) {
+			if done || (hasLimit && rem == 0) {
+				return RowView{}, ErrNoMoreRows
+			}
+			for {
+				if !inner.Next(iterCtx) {
+					done = true
+					if err := inner.Err(); err != nil {
+						return RowView{}, err
+					}
+					return RowView{}, ErrNoMoreRows
+				}
+				view := inner.RowView()
+				buf = buf[:0]
+				var err error
+				buf, err = appendDistinctKeyFromView(ctx, pager, buf, view, fieldIndexes, columns)
+				if err != nil {
+					return RowView{}, err
+				}
+				if bytes.Equal(buf, prevKey) {
+					continue
+				}
+				prevKey = append(prevKey[:0], buf...)
+				if hasOffset && off > 0 {
+					off--
+					continue
+				}
+				if hasLimit {
+					rem--
 				}
 				return view, nil
 			}
@@ -5553,6 +5634,39 @@ func distinctExtendOrderBy(orderBy []OrderBy, requestedFields []Field) []OrderBy
 		inOrderBy[f.Name] = struct{}{}
 	}
 	return extended
+}
+
+// allProjectedInOrderBy returns true when every non-expression field in
+// requestedFields is covered by an ORDER BY clause.  When the plan's index
+// already delivers rows in ORDER BY order (!SortInMemory), this means equal
+// projected rows arrive adjacently — adjacent-compare dedup is then O(1)
+// instead of an O(N) hash set.
+func allProjectedInOrderBy(requestedFields []Field, orderBy []OrderBy) bool {
+	if len(requestedFields) == 0 || len(orderBy) == 0 {
+		return false
+	}
+	inOrderBy := make(map[string]struct{}, len(orderBy)*2)
+	for _, clause := range orderBy {
+		inOrderBy[clause.Field.Name] = struct{}{}
+		if clause.Field.AliasPrefix != "" {
+			inOrderBy[clause.Field.AliasPrefix+"."+clause.Field.Name] = struct{}{}
+		}
+	}
+	for _, f := range requestedFields {
+		if f.Expr != nil {
+			return false
+		}
+		if _, ok := inOrderBy[f.Name]; ok {
+			continue
+		}
+		if f.AliasPrefix != "" {
+			if _, ok := inOrderBy[f.AliasPrefix+"."+f.Name]; ok {
+				continue
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -3773,12 +3773,27 @@ func (t *Table) selectWithSortRowView(
 		return StatementResult{}, true, err
 	}
 
-	if err := t.sortRows(allRows, plan.OrderBy); err != nil {
+	// allOrderByInProjected is true when every ORDER BY column is already present
+	// in the projected (SELECT) fields — no extra sort-only column was appended by
+	// orderByHeapFields. In that case, extending the sort by the remaining projected
+	// fields guarantees equal projected rows are adjacent → hash-free adjacent dedup.
+	// When ORDER BY references columns outside the SELECT list, duplicate projected
+	// rows can land non-adjacently after sorting, so we must fall back to the hash set.
+	allOrderByInProjected := len(sortFields) == len(requestedFields)
+	effectiveOrderBy := plan.OrderBy
+	if stmt.Distinct && allOrderByInProjected {
+		effectiveOrderBy = distinctExtendOrderBy(plan.OrderBy, requestedFields)
+	}
+	if err := t.sortRows(allRows, effectiveOrderBy); err != nil {
 		return StatementResult{}, true, err
 	}
 
 	if stmt.Distinct {
-		allRows = deduplicateRows(allRows, requestedFields)
+		if allOrderByInProjected {
+			allRows = deduplicateSortedRows(allRows, requestedFields)
+		} else {
+			allRows = deduplicateRows(allRows, requestedFields)
+		}
 	}
 
 	offset := 0
@@ -5459,6 +5474,8 @@ func (r Row) rowDistinctKey() string {
 
 // deduplicateRows removes duplicate rows based on their projected values for the given fields.
 // It preserves the first occurrence of each unique row and maintains input order.
+// Uses a hash set — call deduplicateSortedRows instead when the rows are already sorted
+// by (at least) all of fields, which avoids the map allocation entirely.
 func deduplicateRows(rows []Row, fields []Field) []Row {
 	seen := make(map[string]struct{}, len(rows))
 	out := make([]Row, 0, len(rows))
@@ -5472,6 +5489,70 @@ func deduplicateRows(rows []Row, fields []Field) []Row {
 		out = append(out, row)
 	}
 	return out
+}
+
+// deduplicateSortedRows removes duplicate rows by comparing adjacent pairs.
+// rows must be sorted such that equal projected rows (same values for fields) are
+// adjacent — use distinctExtendOrderBy to guarantee this before calling sortRows.
+// In-place: returns a sub-slice of the input; no heap allocation.
+func deduplicateSortedRows(rows []Row, fields []Field) []Row {
+	if len(rows) <= 1 {
+		return rows
+	}
+	w := 1
+	for i := 1; i < len(rows); i++ {
+		equal := true
+		for _, f := range fields {
+			va, _ := rows[i].getValueQualified(f.AliasPrefix, f.Name)
+			vb, _ := rows[w-1].getValueQualified(f.AliasPrefix, f.Name)
+			if compareValues(va, vb) != 0 {
+				equal = false
+				break
+			}
+		}
+		if !equal {
+			rows[w] = rows[i]
+			w++
+		}
+	}
+	return rows[:w]
+}
+
+// distinctExtendOrderBy returns an extended ORDER BY slice that appends any
+// requestedFields not already present in orderBy as ascending tiebreakers.
+// This guarantees that equal projected rows are adjacent after sorting,
+// enabling hash-free deduplication via deduplicateSortedRows.
+func distinctExtendOrderBy(orderBy []OrderBy, requestedFields []Field) []OrderBy {
+	if len(requestedFields) == 0 {
+		return orderBy
+	}
+	inOrderBy := make(map[string]struct{}, len(orderBy)*2)
+	for _, clause := range orderBy {
+		inOrderBy[clause.Field.Name] = struct{}{}
+		if clause.Field.AliasPrefix != "" {
+			inOrderBy[clause.Field.AliasPrefix+"."+clause.Field.Name] = struct{}{}
+		}
+	}
+	extended := make([]OrderBy, len(orderBy), len(orderBy)+len(requestedFields))
+	copy(extended, orderBy)
+	for _, f := range requestedFields {
+		if f.Expr != nil {
+			continue
+		}
+		key := f.Name
+		if _, ok := inOrderBy[key]; ok {
+			continue
+		}
+		if f.AliasPrefix != "" {
+			qualified := f.AliasPrefix + "." + f.Name
+			if _, ok := inOrderBy[qualified]; ok {
+				continue
+			}
+		}
+		extended = append(extended, OrderBy{Field: f, Direction: Asc})
+		inOrderBy[f.Name] = struct{}{}
+	}
+	return extended
 }
 
 func (t *Table) sequentialScan(ctx context.Context, scan Scan, selectedFields []Field, out func(Row) error) error {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -816,7 +816,6 @@ type groupByAccumulator struct {
 	fieldToGroupByIdx []int
 	groupMap          map[string]int32
 	groupEntries      []groupEntry
-	groupOrder        []string
 	aggStatePool      []groupAggState
 	groupValPool      []OptionalValue
 	keyBuf            []byte
@@ -943,7 +942,6 @@ func newGroupByAccumulator(stmt Statement, t *Table, estRows int) *groupByAccumu
 		fieldToGroupByIdx: fieldToGroupByIdx,
 		groupMap:          make(map[string]int32, estGroups),
 		groupEntries:      make([]groupEntry, 0, estGroups),
-		groupOrder:        make([]string, 0, estGroups),
 		aggStatePool:      make([]groupAggState, 0, estGroups*numAggs),
 		groupValPool:      make([]OptionalValue, 0, estGroups*numGroupBy),
 		minMaxPool:        minMaxPool,
@@ -958,10 +956,10 @@ func newGroupByAccumulator(stmt Statement, t *Table, estRows int) *groupByAccumu
 func (acc *groupByAccumulator) process(row Row) {
 	acc.keyBuf = buildGroupKey(acc.keyBuf[:0], row, acc.groupByColIdx)
 
+	// Use string(acc.keyBuf) only for the map lookup — the compiler elides the
+	// allocation when the string is used solely as a map key (no escape).
 	gsIdx, exists := acc.groupMap[string(acc.keyBuf)]
 	if !exists {
-		key := string(acc.keyBuf) // one alloc per new group
-
 		aggStart := int32(len(acc.aggStatePool))
 		for i := range len(acc.aggregates) {
 			acc.aggStatePool = append(acc.aggStatePool, groupAggState{useIntSum: acc.useIntSum[i]})
@@ -990,8 +988,7 @@ func (acc *groupByAccumulator) process(row Row) {
 			groupValStart: gvStart,
 			minMaxStart:   mmStart,
 		})
-		acc.groupMap[key] = gsIdx
-		acc.groupOrder = append(acc.groupOrder, key)
+		acc.groupMap[string(acc.keyBuf)] = gsIdx
 	}
 
 	aggBase := int(acc.groupEntries[gsIdx].aggStateStart)
@@ -1067,8 +1064,6 @@ func (acc *groupByAccumulator) processView(view RowView) error {
 
 	gsIdx, exists := acc.groupMap[string(acc.keyBuf)]
 	if !exists {
-		key := string(acc.keyBuf) // one alloc per new group
-
 		aggStart := int32(len(acc.aggStatePool))
 		for i := range len(acc.aggregates) {
 			acc.aggStatePool = append(acc.aggStatePool, groupAggState{useIntSum: acc.useIntSum[i]})
@@ -1101,8 +1096,7 @@ func (acc *groupByAccumulator) processView(view RowView) error {
 			groupValStart: gvStart,
 			minMaxStart:   mmStart,
 		})
-		acc.groupMap[key] = gsIdx
-		acc.groupOrder = append(acc.groupOrder, key)
+		acc.groupMap[string(acc.keyBuf)] = gsIdx
 	}
 
 	aggBase := int(acc.groupEntries[gsIdx].aggStateStart)
@@ -1285,9 +1279,66 @@ func (t *Table) selectGroupByZeroAlloc(ctx context.Context, stmt Statement, scan
 	return acc.buildResult(stmt, t)
 }
 
+// computeGroupValues fills values[0:nFields] with the aggregate results for the
+// gi-th group (in insertion order). The caller must pre-allocate values.
+func (acc *groupByAccumulator) computeGroupValues(gi int, values []OptionalValue) {
+	entry := acc.groupEntries[gi]
+	aggBase := int(entry.aggStateStart)
+	gvBase := int(entry.groupValStart)
+	mmBase := int(entry.minMaxStart)
+	for i, agg := range acc.aggregates {
+		switch agg.Kind {
+		case 0:
+			if j := acc.fieldToGroupByIdx[i]; j >= 0 {
+				values[i] = acc.groupValPool[gvBase+j]
+			} else {
+				values[i] = OptionalValue{}
+			}
+		case AggregateCount:
+			values[i] = OptionalValue{Valid: true, Value: acc.aggStatePool[aggBase+i].count}
+		case AggregateSum:
+			st := acc.aggStatePool[aggBase+i]
+			if st.hasValue {
+				if st.useIntSum {
+					values[i] = OptionalValue{Valid: true, Value: st.sumI}
+				} else {
+					values[i] = OptionalValue{Valid: true, Value: st.sumF}
+				}
+			} else {
+				values[i] = OptionalValue{}
+			}
+		case AggregateAvg:
+			st := acc.aggStatePool[aggBase+i]
+			if st.hasValue && st.count > 0 {
+				if st.useIntSum {
+					values[i] = OptionalValue{Valid: true, Value: float64(st.sumI) / float64(st.count)}
+				} else {
+					values[i] = OptionalValue{Valid: true, Value: st.sumF / float64(st.count)}
+				}
+			} else {
+				values[i] = OptionalValue{}
+			}
+		case AggregateMin:
+			slot := mmBase + acc.minMaxAggSlot[i]
+			if acc.minMaxPool[slot].Valid {
+				values[i] = acc.minMaxPool[slot]
+			} else {
+				values[i] = OptionalValue{}
+			}
+		case AggregateMax:
+			slot := mmBase + acc.minMaxAggSlot[i]
+			if acc.minMaxPool[slot].Valid {
+				values[i] = acc.minMaxPool[slot]
+			} else {
+				values[i] = OptionalValue{}
+			}
+		}
+	}
+}
+
 func (acc *groupByAccumulator) buildResult(stmt Statement, t *Table) (StatementResult, error) {
 	nFields := len(stmt.Fields)
-	nGroups := len(acc.groupOrder)
+	nGroups := len(acc.groupEntries)
 
 	// Build result column metadata.
 	resultColumns := make([]Column, nFields)
@@ -1319,57 +1370,14 @@ func (acc *groupByAccumulator) buildResult(stmt Statement, t *Table) (StatementR
 	}
 
 	// Preallocate one flat block for all group values — one alloc covers every group.
-	// passedIndices tracks which group indices passed HAVING, using int32 (4 bytes each)
-	// instead of full Row structs (48 bytes each).
+	// passedIndices tracks which groups passed HAVING, using int32 (4 bytes each)
+	// instead of full Row structs.
 	allResultValues := make([]OptionalValue, nGroups*nFields)
 	passedIndices := make([]int32, 0, nGroups)
 
-	for gi, key := range acc.groupOrder {
-		gsIdx := acc.groupMap[key]
-		aggBase := int(acc.groupEntries[gsIdx].aggStateStart)
-		gvBase := int(acc.groupEntries[gsIdx].groupValStart)
-		mmBase := int(acc.groupEntries[gsIdx].minMaxStart)
-
+	for gi := range nGroups {
 		values := allResultValues[gi*nFields : (gi+1)*nFields]
-
-		for i, agg := range acc.aggregates {
-			switch agg.Kind {
-			case 0:
-				if j := acc.fieldToGroupByIdx[i]; j >= 0 {
-					values[i] = acc.groupValPool[gvBase+j]
-				}
-			case AggregateCount:
-				values[i] = OptionalValue{Valid: true, Value: acc.aggStatePool[aggBase+i].count}
-			case AggregateSum:
-				st := acc.aggStatePool[aggBase+i]
-				if st.hasValue {
-					if st.useIntSum {
-						values[i] = OptionalValue{Valid: true, Value: st.sumI}
-					} else {
-						values[i] = OptionalValue{Valid: true, Value: st.sumF}
-					}
-				}
-			case AggregateAvg:
-				st := acc.aggStatePool[aggBase+i]
-				if st.hasValue && st.count > 0 {
-					if st.useIntSum {
-						values[i] = OptionalValue{Valid: true, Value: float64(st.sumI) / float64(st.count)}
-					} else {
-						values[i] = OptionalValue{Valid: true, Value: st.sumF / float64(st.count)}
-					}
-				}
-			case AggregateMin:
-				slot := mmBase + acc.minMaxAggSlot[i]
-				if acc.minMaxPool[slot].Valid {
-					values[i] = acc.minMaxPool[slot]
-				}
-			case AggregateMax:
-				slot := mmBase + acc.minMaxAggSlot[i]
-				if acc.minMaxPool[slot].Valid {
-					values[i] = acc.minMaxPool[slot]
-				}
-			}
-		}
+		acc.computeGroupValues(gi, values)
 
 		// Apply HAVING filter against the computed aggregate row.
 		if len(stmt.Having) > 0 {

--- a/internal/minisql/select_helpers_test.go
+++ b/internal/minisql/select_helpers_test.go
@@ -334,6 +334,239 @@ func TestGroupByColumnIndex(t *testing.T) {
 	})
 }
 
+func TestDeduplicateSortedRows(t *testing.T) {
+	t.Parallel()
+
+	cols := []Column{
+		{Name: "name", Kind: Varchar, Size: MaxInlineVarchar},
+		{Name: "age", Kind: Int8, Size: 8},
+	}
+	nameField := Field{Name: "name"}
+	bothFields := []Field{{Name: "name"}, {Name: "age"}}
+
+	row := func(name string, age int64) Row {
+		return NewRowWithValues(cols, []OptionalValue{
+			{Value: NewTextPointer([]byte(name)), Valid: true},
+			{Value: age, Valid: true},
+		})
+	}
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		t.Parallel()
+		result := deduplicateSortedRows(nil, bothFields)
+		assert.Empty(t, result)
+	})
+
+	t.Run("single row returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{row("alice", 30)}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("no duplicates all preserved", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{row("alice", 30), row("bob", 25), row("carol", 40)}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("adjacent duplicates removed", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{row("alice", 30), row("alice", 30), row("bob", 25)}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("all identical rows collapsed to one", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{row("alice", 30), row("alice", 30), row("alice", 30)}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("runs of duplicates each collapsed", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{
+			row("alice", 30), row("alice", 30),
+			row("bob", 25), row("bob", 25), row("bob", 25),
+			row("carol", 40),
+		}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("dedup on single field ignores second column difference", func(t *testing.T) {
+		t.Parallel()
+		// same name, different age — when only comparing on name they look equal
+		rows := []Row{row("alice", 30), row("alice", 35)}
+		result := deduplicateSortedRows(rows, []Field{nameField})
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("in-place: modifies and sub-slices original backing array", func(t *testing.T) {
+		t.Parallel()
+		rows := []Row{row("a", 1), row("a", 1), row("b", 2)}
+		result := deduplicateSortedRows(rows, bothFields)
+		assert.Len(t, result, 2)
+		// result must be a sub-slice of the same backing array
+		assert.Equal(t, &rows[0], &result[0])
+	})
+}
+
+func TestDistinctExtendOrderBy(t *testing.T) {
+	t.Parallel()
+
+	emailField := Field{Name: "email"}
+	nameField := Field{Name: "name"}
+	ageField := Field{Name: "age"}
+	exprField := Field{Name: "lower_name", Expr: &Expr{FuncName: "LOWER"}}
+
+	orderByEmail := []OrderBy{{Field: emailField, Direction: Asc}}
+	orderByName := []OrderBy{{Field: nameField, Direction: Desc}}
+
+	t.Run("empty requestedFields returns orderBy unchanged", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(orderByEmail, nil)
+		assert.Equal(t, orderByEmail, result)
+	})
+
+	t.Run("all fields already in ORDER BY — no extension", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(orderByEmail, []Field{emailField})
+		assert.Len(t, result, 1)
+		assert.Equal(t, "email", result[0].Field.Name)
+	})
+
+	t.Run("missing field appended as ascending tiebreaker", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(orderByName, []Field{nameField, ageField})
+		assert.Len(t, result, 2)
+		assert.Equal(t, "name", result[0].Field.Name)
+		assert.Equal(t, Desc, result[0].Direction)
+		assert.Equal(t, "age", result[1].Field.Name)
+		assert.Equal(t, Asc, result[1].Direction)
+	})
+
+	t.Run("expression fields skipped", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(orderByName, []Field{nameField, exprField})
+		assert.Len(t, result, 1, "expr field must not be appended")
+	})
+
+	t.Run("alias-qualified ORDER BY field not re-appended", func(t *testing.T) {
+		t.Parallel()
+		qualified := Field{Name: "email", AliasPrefix: "u"}
+		orderBy := []OrderBy{{Field: qualified, Direction: Asc}}
+		// requestedField without alias but same name — should still be skipped
+		result := distinctExtendOrderBy(orderBy, []Field{emailField})
+		// email is already in ORDER BY (bare name lookup), so no extension
+		assert.Len(t, result, 1)
+	})
+
+	t.Run("multiple missing fields all appended", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(nil, []Field{nameField, ageField, emailField})
+		assert.Len(t, result, 3)
+		assert.Equal(t, Asc, result[0].Direction)
+		assert.Equal(t, Asc, result[1].Direction)
+		assert.Equal(t, Asc, result[2].Direction)
+	})
+
+	t.Run("original ORDER BY direction preserved", func(t *testing.T) {
+		t.Parallel()
+		result := distinctExtendOrderBy(orderByName, []Field{nameField, emailField})
+		assert.Equal(t, Desc, result[0].Direction)
+		assert.Equal(t, Asc, result[1].Direction)
+	})
+}
+
+func TestAllProjectedInOrderBy(t *testing.T) {
+	t.Parallel()
+
+	emailField := Field{Name: "email"}
+	nameField := Field{Name: "name"}
+	ageField := Field{Name: "age"}
+	exprField := Field{Name: "lower_name", Expr: &Expr{FuncName: "LOWER"}}
+
+	orderByEmail := []OrderBy{{Field: emailField, Direction: Asc}}
+	orderByBoth := []OrderBy{{Field: emailField, Direction: Asc}, {Field: nameField, Direction: Asc}}
+
+	t.Run("empty requestedFields returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, allProjectedInOrderBy(nil, orderByEmail))
+	})
+
+	t.Run("empty orderBy returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, allProjectedInOrderBy([]Field{emailField}, nil))
+	})
+
+	t.Run("all fields covered returns true", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, allProjectedInOrderBy([]Field{emailField}, orderByEmail))
+	})
+
+	t.Run("all fields covered multi-column returns true", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, allProjectedInOrderBy([]Field{emailField, nameField}, orderByBoth))
+	})
+
+	t.Run("uncovered field returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, allProjectedInOrderBy([]Field{emailField, ageField}, orderByEmail))
+	})
+
+	t.Run("expression field returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, allProjectedInOrderBy([]Field{exprField}, orderByEmail))
+	})
+
+	t.Run("alias-qualified ORDER BY covers bare requested field via bare-name entry", func(t *testing.T) {
+		t.Parallel()
+		qualifiedOB := []OrderBy{{Field: Field{Name: "email", AliasPrefix: "u"}, Direction: Asc}}
+		// The map stores both "email" (bare) and "u.email" (qualified) for the ORDER BY clause.
+		// A bare emailField lookup hits the bare-name entry → covered.
+		assert.True(t, allProjectedInOrderBy([]Field{emailField}, qualifiedOB))
+	})
+
+	t.Run("alias-qualified requested field matched by alias-qualified ORDER BY", func(t *testing.T) {
+		t.Parallel()
+		qualifiedField := Field{Name: "email", AliasPrefix: "u"}
+		qualifiedOB := []OrderBy{{Field: qualifiedField, Direction: Asc}}
+		assert.True(t, allProjectedInOrderBy([]Field{qualifiedField}, qualifiedOB))
+	})
+
+	t.Run("single field not in ORDER BY returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, allProjectedInOrderBy([]Field{ageField}, orderByEmail))
+	})
+}
+
+func TestDistinctSeenCapacityFromEstimate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero estimate returns zero", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, distinctSeenCapacityFromEstimate(0))
+	})
+
+	t.Run("negative estimate returns zero", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, distinctSeenCapacityFromEstimate(-1))
+	})
+
+	t.Run("small positive estimate returned as-is", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 100, distinctSeenCapacityFromEstimate(100))
+	})
+
+	t.Run("large estimate within int range returned as-is", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 10_000, distinctSeenCapacityFromEstimate(10_000))
+	})
+}
+
 func TestWhereCondColumns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/minisql/select_test.go
+++ b/internal/minisql/select_test.go
@@ -1180,6 +1180,113 @@ func TestTable_SelectAggregate(t *testing.T) {
 	})
 }
 
+// TestTable_Select_DistinctOrderByIndexedAdjacentDedup exercises the
+// streaming adjacent-compare dedup path (newDistinctAdjacentRowViewIteratorFactory)
+// which activates when an index delivers rows in ORDER BY order and all projected
+// fields are covered by ORDER BY.  Inserting rows with duplicate emails verifies
+// that duplicates are removed and unique rows are returned in sorted order.
+func TestTable_Select_DistinctOrderByIndexedAdjacentDedup(t *testing.T) {
+	pager, dbFile := initTest(t)
+
+	var (
+		ctx        = context.Background()
+		tablePager = pager.ForTable(testColumns[0:3])
+		txManager  = NewTransactionManager(zap.NewNop(), dbFile.Name(), mockPagerFactory(tablePager), pager, nil)
+		txPager    = NewTransactionalPager(tablePager, txManager, testTableName, "")
+		table      *Table
+		indexName  = "idx__test_adjacent_email"
+		indexCols  = testColumns[1:2] // email column
+	)
+
+	// Insert rows: three distinct emails, one duplicated so dedup is exercised.
+	insertRows := []Row{
+		NewRowWithValues(testColumns[0:3], []OptionalValue{
+			{Value: int64(1), Valid: true},
+			{Value: NewTextPointer([]byte("alice@example.com")), Valid: true},
+			{Value: int32(30), Valid: true},
+		}),
+		NewRowWithValues(testColumns[0:3], []OptionalValue{
+			{Value: int64(2), Valid: true},
+			{Value: NewTextPointer([]byte("bob@example.com")), Valid: true},
+			{Value: int32(25), Valid: true},
+		}),
+		NewRowWithValues(testColumns[0:3], []OptionalValue{
+			{Value: int64(3), Valid: true},
+			{Value: NewTextPointer([]byte("alice@example.com")), Valid: true}, // duplicate
+			{Value: int32(40), Valid: true},
+		}),
+		NewRowWithValues(testColumns[0:3], []OptionalValue{
+			{Value: int64(4), Valid: true},
+			{Value: NewTextPointer([]byte("carol@example.com")), Valid: true},
+			{Value: int32(20), Valid: true},
+		}),
+	}
+
+	err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+		freePage, err := txPager.GetFreePage(ctx)
+		if err != nil {
+			return err
+		}
+		freePage.LeafNode = NewLeafNode()
+		freePage.LeafNode.Header.IsRoot = true
+		table = NewTable(testLogger, txPager, txManager, testTableName, testColumns[0:3], freePage.Index, nil)
+
+		indexPager, err := pager.ForIndex(indexCols, false)
+		if err != nil {
+			return err
+		}
+		txIndexPager := NewTransactionalPager(indexPager, txManager, testTableName, indexName)
+		indexRoot, err := txIndexPager.GetFreePage(ctx)
+		if err != nil {
+			return err
+		}
+		idx, err := table.createBTreeIndex(txIndexPager, indexRoot, indexCols, indexName, false)
+		if err != nil {
+			return err
+		}
+		table.SetSecondaryIndex(SecondaryIndex{IndexInfo: IndexInfo{Name: indexName, Columns: indexCols}, Index: idx})
+
+		stmt := Statement{
+			Kind:    Insert,
+			Fields:  fieldsFromColumns(testColumns[0:3]...),
+			Inserts: make([][]OptionalValue, 0, len(insertRows)),
+		}
+		for _, row := range insertRows {
+			stmt.Inserts = append(stmt.Inserts, row.Values)
+		}
+		_, err = table.Insert(ctx, stmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	// SELECT DISTINCT email ORDER BY email — index delivers rows in email order,
+	// allProjectedInOrderBy is true → newDistinctAdjacentRowViewIteratorFactory used.
+	result, err := table.Select(ctx, Statement{
+		Kind:     Select,
+		Distinct: true,
+		Fields:   []Field{{Name: "email"}},
+		OrderBy:  []OrderBy{{Field: Field{Name: "email"}, Direction: Asc}},
+	})
+	require.NoError(t, err)
+
+	got := collectRows(ctx, result)
+	require.Len(t, got, 3) // alice, bob, carol — alice de-duplicated
+	emailStr := func(row Row) string {
+		v, _ := row.GetValue("email")
+		switch val := v.Value.(type) {
+		case TextPointer:
+			return val.String()
+		case string:
+			return val
+		default:
+			return ""
+		}
+	}
+	assert.Equal(t, "alice@example.com", emailStr(got[0]))
+	assert.Equal(t, "bob@example.com", emailStr(got[1]))
+	assert.Equal(t, "carol@example.com", emailStr(got[2]))
+}
+
 func collectRows(ctx context.Context, r StatementResult) []Row {
 	results := []Row{}
 	for r.Rows.Next(ctx) {


### PR DESCRIPTION
Remove the redundant groupOrder []string slice from groupByAccumulator. Group entries are appended to groupEntries in insertion order, so direct iteration over groupEntries already gives insertion order — the parallel string slice was pure overhead (~1.6 KB / benchmark op for the 100-group case, ~2 KB for HAVING).

Extract computeGroupValues to deduplicate the aggregate-result assembly logic shared between buildResult's Row and RowView paths. Also restore plain string(keyBuf) map assignment in process/processView — the arena interning approach was tested and found counterproductive (pre-sized arenas waste capacity; growing arenas accumulate old backing arrays via GC-retained map string references).