### PR TITLE
Add fuzz targets for execute path, inverted index, and B-tree write path

### DIFF
--- a/fuzz_execute_test.go
+++ b/fuzz_execute_test.go
@@ -1,0 +1,134 @@
+package minisql
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+)
+
+// FuzzExecute feeds arbitrary SQL through the full parse + execute stack against
+// a real temp-file database via the registered database/sql driver.  The only
+// invariant enforced is no-panic: errors at any stage are expected and fine;
+// crashes are bugs.
+//
+// This goes beyond FuzzParser (which only checks the parser) by exercising
+// plan building, index selection, expression evaluation, and row encoding.
+//
+// Run for a fixed duration during development:
+//
+//	go test -fuzz=FuzzExecute -fuzztime=60s .
+//
+// Seeds are replayed as ordinary unit tests on every `go test` invocation.
+func FuzzExecute(f *testing.F) {
+	seeds := []string{
+		// SELECT shapes
+		`select * from "t"`,
+		`select id, name from "t"`,
+		`select id from "t" where id = 1`,
+		`select id from "t" where id > 0 and id < 100`,
+		`select count(*) from "t"`,
+		`select id from "t" order by id asc`,
+		`select id from "t" order by id desc limit 5`,
+		`select id from "t" limit 10 offset 5`,
+		`select distinct name from "t"`,
+		`select distinct name from "t" order by name`,
+		`select id from "t" where name like 'a%'`,
+		`select id from "t" where name ilike 'A%'`,
+		`select id from "t" where name is null`,
+		`select id from "t" where name is not null`,
+		`select id from "t" where id between 1 and 10`,
+		`select id from "t" where id in (1, 2, 3)`,
+		`select id from "t" where id not in (1, 2, 3)`,
+		`select id from "t" where id = ?`,
+
+		// Aggregates and GROUP BY / HAVING
+		`select name, count(*) from "t" group by name`,
+		`select name, sum(id) from "t" group by name`,
+		`select name, count(*) from "t" group by name having count(*) > 1`,
+		`select name, min(id), max(id) from "t" group by name`,
+
+		// INSERT
+		`insert into "t" (name) values ('hello')`,
+		`insert into "t" (id, name) values (99, 'fuzz')`,
+		`insert into "t" (id, name) values (1, 'a'), (2, 'b')`,
+		`insert into "t" (name) values (null)`,
+		`insert into "t" (id, name) values (1, 'x') on conflict do nothing`,
+		`insert into "t" (id, name) values (1, 'x') on conflict do update set name = excluded.name`,
+		`insert into "t" (name) values ('ret') returning id`,
+
+		// UPDATE
+		`update "t" set name = 'updated' where id = 1`,
+		`update "t" set name = null where id = 2`,
+		`update "t" set id = id + 1 where id < 5`,
+		`update "t" set name = 'x' where id = 1 returning id, name`,
+
+		// DELETE
+		`delete from "t" where id = 1`,
+		`delete from "t" where id > 50`,
+		`delete from "t"`,
+		`delete from "t" where id = 1 returning id`,
+
+		// Subqueries / CTEs
+		`select id from "t" where id in (select id from "t" where id < 5)`,
+		`with c as (select id from "t" where id < 3) select id from c`,
+
+		// EXPLAIN
+		`explain select * from "t" where id = 1`,
+		`explain analyze select * from "t" where id = 1`,
+
+		// Edge / degenerate inputs
+		``,
+		`select`,
+		`select *`,
+		`select * from`,
+		`insert into`,
+		`update`,
+		`delete`,
+		`;`,
+		`' OR '1'='1`,
+		`AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`,
+		`select * from "t"; drop table "t"`,
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		tmp, err := os.CreateTemp("", "fuzz_execute_*.db")
+		if err != nil {
+			return
+		}
+		name := tmp.Name()
+		tmp.Close()
+		defer os.Remove(name)
+		defer os.Remove(name + "-wal")
+
+		db, err := sql.Open("minisql", name)
+		if err != nil {
+			return
+		}
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		defer db.Close()
+
+		// Create a simple table with a few rows so most query shapes have data to work with.
+		if _, err = db.Exec(`create table "t" (id int8 primary key autoincrement, name varchar(255))`); err != nil {
+			return
+		}
+		if _, err = db.Exec(`insert into "t" (name) values ('alpha'), ('beta'), ('gamma')`); err != nil {
+			return
+		}
+
+		// Execute the fuzz input. Errors are fine; panics are bugs.
+		rows, err := db.Query(query)
+		if err != nil {
+			return
+		}
+		// Drain the result set — execution is lazy; bugs may surface during iteration.
+		for rows.Next() {
+		}
+		_ = rows.Close()
+		_ = rows.Err()
+	})
+}

--- a/internal/minisql/fuzz_btree_test.go
+++ b/internal/minisql/fuzz_btree_test.go
@@ -1,0 +1,116 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+)
+
+// FuzzBTreeWrite stresses the B-tree insert/delete write path with arbitrary
+// operation sequences and key orderings, exercising leaf and internal node
+// splits and merges. The only invariant enforced is no-panic: errors at any
+// stage are expected and fine; crashes are bugs.
+//
+// Run for a fixed duration during development:
+//
+//	go test -fuzz=FuzzBTreeWrite -fuzztime=60s ./internal/minisql/
+//
+// Seeds are replayed as ordinary unit tests on every `go test` invocation.
+func FuzzBTreeWrite(f *testing.F) {
+	// Each byte in ops encodes: bit 0 = op (0=insert, 1=delete), bits 1-7 = id (0-127).
+	// This gives 128 distinct key values — enough to cause multiple page splits.
+	f.Add([]byte{0, 2, 4, 6, 8, 10, 12, 14, 16, 18})        // ascending inserts
+	f.Add([]byte{20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0})    // descending inserts
+	f.Add([]byte{0, 2, 4, 6, 8, 3, 5, 7, 1, 9})             // mixed ascending with gaps
+	f.Add([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}) // many inserts → splits
+	f.Add([]byte{0, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9})         // insert then delete alternating
+	f.Add([]byte{0, 2, 4, 6, 1, 3, 5, 7})                   // inserts then deletes
+	f.Add([]byte{1, 3, 5, 7})                                // all deletes on empty table
+	f.Add([]byte{0})                                         // single insert
+	f.Add([]byte{0, 1})                                      // insert then delete
+	// Interleaved inserts and deletes designed to trigger merges after splits
+	f.Add([]byte{0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15})
+
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		if len(ops) == 0 || len(ops) > 128 {
+			return
+		}
+
+		columns := []Column{
+			{Kind: Int8, Size: 8, Name: "id"},
+		}
+		table, txManager, _ := newTestTable(t, columns)
+		ctx := context.Background()
+
+		// Track ids inserted but not yet deleted so we can verify them afterward.
+		liveIDs := make(map[int64]struct{}, len(ops))
+
+		for _, op := range ops {
+			id := int64(op >> 1) // 0–127
+			isDelete := op&1 == 1
+
+			if isDelete {
+				_ = txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+					_, err := table.Delete(txCtx, Statement{
+						Kind: Delete,
+						Conditions: OneOrMore{{
+							FieldIsEqual(Field{Name: "id"}, OperandInteger, id),
+						}},
+					})
+					return err
+				})
+				delete(liveIDs, id)
+			} else {
+				if _, dup := liveIDs[id]; dup {
+					// Skip duplicate inserts — the interesting path is new keys.
+					continue
+				}
+				err := txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+					_, err := table.Insert(txCtx, Statement{
+						Kind:    Insert,
+						Fields:  fieldsFromColumns(columns...),
+						Inserts: [][]OptionalValue{{{Value: id, Valid: true}}},
+					})
+					return err
+				})
+				if err == nil {
+					liveIDs[id] = struct{}{}
+				}
+			}
+		}
+
+		// Full scan must not panic and must drain without error.
+		_ = txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+			result, err := table.Select(txCtx, Statement{
+				Kind:   Select,
+				Fields: fieldsFromColumns(columns...),
+			})
+			if err != nil {
+				return nil
+			}
+			for result.Rows.Next(txCtx) {
+				_ = result.Rows.Row()
+			}
+			return nil
+		})
+
+		// Point-lookup for each live id must not panic.
+		for id := range liveIDs {
+			_ = txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+				result, err := table.Select(txCtx, Statement{
+					Kind:   Select,
+					Fields: fieldsFromColumns(columns...),
+					Conditions: OneOrMore{{
+						FieldIsEqual(Field{Name: "id"}, OperandInteger, id),
+					}},
+				})
+				if err != nil {
+					return nil
+				}
+				for result.Rows.Next(txCtx) {
+					_ = result.Rows.Row()
+				}
+				return nil
+			})
+		}
+	})
+}

--- a/internal/minisql/fuzz_btree_test.go
+++ b/internal/minisql/fuzz_btree_test.go
@@ -80,15 +80,13 @@ func FuzzBTreeWrite(f *testing.F) {
 
 		// Full scan must not panic and must drain without error.
 		_ = txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
-			result, err := table.Select(txCtx, Statement{
+			if result, err := table.Select(txCtx, Statement{
 				Kind:   Select,
 				Fields: fieldsFromColumns(columns...),
-			})
-			if err != nil {
-				return nil
-			}
-			for result.Rows.Next(txCtx) {
-				_ = result.Rows.Row()
+			}); err == nil {
+				for result.Rows.Next(txCtx) {
+					_ = result.Rows.Row()
+				}
 			}
 			return nil
 		})
@@ -96,18 +94,16 @@ func FuzzBTreeWrite(f *testing.F) {
 		// Point-lookup for each live id must not panic.
 		for id := range liveIDs {
 			_ = txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
-				result, err := table.Select(txCtx, Statement{
+				if result, err := table.Select(txCtx, Statement{
 					Kind:   Select,
 					Fields: fieldsFromColumns(columns...),
 					Conditions: OneOrMore{{
 						FieldIsEqual(Field{Name: "id"}, OperandInteger, id),
 					}},
-				})
-				if err != nil {
-					return nil
-				}
-				for result.Rows.Next(txCtx) {
-					_ = result.Rows.Row()
+				}); err == nil {
+					for result.Rows.Next(txCtx) {
+						_ = result.Rows.Row()
+					}
 				}
 				return nil
 			})

--- a/internal/minisql/fuzz_inverted_index_test.go
+++ b/internal/minisql/fuzz_inverted_index_test.go
@@ -1,0 +1,178 @@
+package minisql
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// FuzzInvertedIndex verifies that the log-structured inverted index never panics
+// on arbitrary term strings and row IDs.  The fuzzer exercises Insert, Lookup,
+// and ForEachRowID — the three paths most likely to panic on malformed input.
+// Delete and batch operations are included to stress the merge path.
+//
+// The only invariant enforced is no-panic: errors are expected and fine.
+//
+// Run for a fixed duration during development:
+//
+//	go test -fuzz=FuzzInvertedIndex -fuzztime=60s ./internal/minisql/
+//
+// Seeds are replayed as ordinary unit tests on every `go test` invocation.
+func FuzzInvertedIndex(f *testing.F) {
+	// Seeds: (term, rowID)
+	// Cover common full-text and JSON inverted index term shapes.
+	seeds := [][2]any{
+		{"hello", int64(1)},
+		{"world", int64(2)},
+		{"", int64(0)},
+		{"a", int64(1)},
+		// JSON inverted index key shapes
+		{`kv:type:s:"click"`, int64(7)},
+		{`kv:active:b:true`, int64(3)},
+		{`kv:count:i:42`, int64(5)},
+		// Very long term
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", int64(99)},
+		// Special characters
+		{"\x00\x01\x02", int64(10)},
+		{"term with spaces", int64(11)},
+		{"term\twith\ttabs", int64(12)},
+		{"term\nwith\nnewlines", int64(13)},
+		// Unicode
+		{"日本語テスト", int64(20)},
+		{"émoji 🚀", int64(21)},
+		// Boundary row IDs
+		{"boundary", int64(-1)},
+		{"boundary", int64(0)},
+	}
+	for _, seed := range seeds {
+		f.Add(seed[0].(string), seed[1].(int64))
+	}
+
+	f.Fuzz(func(t *testing.T, term string, rowID int64) {
+		ctx := context.Background()
+		pager, tempFile := initTest(t)
+		basePager := pager.ForInvertedIndex()
+		txManager := NewTransactionManager(zap.NewNop(), tempFile.Name(), mockPagerFactory(basePager), pager, nil)
+		txPager := NewTransactionalPager(basePager, txManager, "fuzz_table", "fuzz_idx")
+
+		var metaRoot PageIndex
+		err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			metaPage, err := txPager.GetFreePage(ctx)
+			if err != nil {
+				return err
+			}
+			basePage, err := txPager.GetFreePage(ctx)
+			if err != nil {
+				return err
+			}
+			metaRoot = metaPage.Index
+			index, err := NewLogStructuredInvertedIndex(
+				ctx, "fuzz_idx", invertedIndexPostingModeRowIDs, txPager, metaPage.Index, basePage.Index,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Insert the fuzz term.
+			_ = index.Insert(ctx, term, invertedPosting{RowID: RowID(rowID)})
+
+			// Insert a second term to stress the merge path.
+			_ = index.Insert(ctx, term+"_2", invertedPosting{RowID: RowID(rowID + 1)})
+
+			// Delete must not panic even if the term was never inserted.
+			_ = index.Delete(ctx, term, invertedPosting{RowID: RowID(rowID)})
+
+			return nil
+		})
+		if err != nil {
+			return
+		}
+
+		// Lookup and iterate must not panic on any term.
+		_ = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			opened, err := OpenInvertedIndex(ctx, "fuzz_idx", invertedIndexPostingModeRowIDs, txPager, metaRoot)
+			if err != nil {
+				return nil
+			}
+
+			iter, err := opened.Lookup(ctx, term)
+			if err != nil {
+				return nil
+			}
+			// Drain the iterator.
+			for {
+				_, ok, err := iter.NextBlock(ctx)
+				if err != nil || !ok {
+					break
+				}
+			}
+
+			// ForEachRowID must not panic.
+			if scanner, ok := opened.(invertedRowIDScanner); ok {
+				_ = scanner.ForEachRowID(ctx, term, func(_ RowID) error {
+					return nil
+				})
+			}
+
+			return nil
+		})
+	})
+}
+
+// FuzzInvertedIndexBatch stresses the ApplyBatch path with sequences of
+// inserts and deletes for a small set of terms, exercising segment merges.
+func FuzzInvertedIndexBatch(f *testing.F) {
+	// Seed: two terms and an operation byte (0=insert, 1=delete)
+	f.Add("foo", "bar", []byte{0, 0, 1, 0, 1, 1})
+	f.Add("hello world", "go fuzz", []byte{0, 1, 0, 0, 1})
+	f.Add("", "x", []byte{0})
+	f.Add("a", "b", []byte{0, 0, 0, 1, 1, 1, 0, 0})
+
+	f.Fuzz(func(t *testing.T, term1, term2 string, ops []byte) {
+		if len(ops) == 0 || len(ops) > 64 {
+			return
+		}
+
+		ctx := context.Background()
+		pager, tempFile := initTest(t)
+		basePager := pager.ForInvertedIndex()
+		txManager := NewTransactionManager(zap.NewNop(), tempFile.Name(), mockPagerFactory(basePager), pager, nil)
+		txPager := NewTransactionalPager(basePager, txManager, "fuzz_table", "fuzz_batch_idx")
+
+		terms := []string{term1, term2}
+
+		err := txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
+			metaPage, err := txPager.GetFreePage(ctx)
+			if err != nil {
+				return err
+			}
+			basePage, err := txPager.GetFreePage(ctx)
+			if err != nil {
+				return err
+			}
+			index, err := NewLogStructuredInvertedIndex(
+				ctx, "fuzz_batch_idx", invertedIndexPostingModeRowIDs, txPager, metaPage.Index, basePage.Index,
+			)
+			if err != nil {
+				return err
+			}
+
+			// Apply a batch derived from ops bytes: each byte picks a term (bit 1)
+			// and an operation (bit 0: insert vs delete).
+			batch := newInvertedIndexMutationBatch(invertedIndexPostingModeRowIDs)
+			for i, op := range ops {
+				term := terms[int(op>>1)%len(terms)]
+				rowID := RowID(i + 1)
+				if op&1 == 0 {
+					batch.Insert(term, invertedPosting{RowID: rowID})
+				} else {
+					batch.Delete(term, invertedPosting{RowID: rowID})
+				}
+			}
+			_ = index.ApplyBatch(ctx, batch)
+			return nil
+		})
+		_ = err
+	})
+}

--- a/internal/minisql/fuzz_inverted_index_test.go
+++ b/internal/minisql/fuzz_inverted_index_test.go
@@ -91,30 +91,22 @@ func FuzzInvertedIndex(f *testing.F) {
 
 		// Lookup and iterate must not panic on any term.
 		_ = txManager.ExecuteInTransaction(ctx, func(ctx context.Context) error {
-			opened, err := OpenInvertedIndex(ctx, "fuzz_idx", invertedIndexPostingModeRowIDs, txPager, metaRoot)
-			if err != nil {
-				return nil
-			}
-
-			iter, err := opened.Lookup(ctx, term)
-			if err != nil {
-				return nil
-			}
-			// Drain the iterator.
-			for {
-				_, ok, err := iter.NextBlock(ctx)
-				if err != nil || !ok {
-					break
+			opened, openErr := OpenInvertedIndex(ctx, "fuzz_idx", invertedIndexPostingModeRowIDs, txPager, metaRoot)
+			if openErr == nil {
+				if iter, lookupErr := opened.Lookup(ctx, term); lookupErr == nil {
+					for {
+						_, ok, err := iter.NextBlock(ctx)
+						if err != nil || !ok {
+							break
+						}
+					}
+				}
+				if scanner, ok := opened.(invertedRowIDScanner); ok {
+					_ = scanner.ForEachRowID(ctx, term, func(_ RowID) error {
+						return nil
+					})
 				}
 			}
-
-			// ForEachRowID must not panic.
-			if scanner, ok := opened.(invertedRowIDScanner); ok {
-				_ = scanner.ForEachRowID(ctx, term, func(_ RowID) error {
-					return nil
-				})
-			}
-
 			return nil
 		})
 	})

--- a/internal/minisql/stmt_result.go
+++ b/internal/minisql/stmt_result.go
@@ -183,7 +183,7 @@ func (i *Iterator) Next(ctx context.Context) bool {
 	if i.err != nil {
 		return false
 	}
-	if i.end {
+	if i.end || i.rowFunc == nil {
 		return false
 	}
 	row, err := i.rowFunc(ctx)


### PR DESCRIPTION
Three new fuzz targets covering previously unfuzzed code paths:

- FuzzExecute (root package): drives arbitrary SQL through the full parse+execute stack via the database/sql driver; drains result sets to exercise lazy execution paths.

- FuzzInvertedIndex / FuzzInvertedIndexBatch (internal/minisql): stress the log-structured inverted index Insert, Delete, Lookup, ForEachRowID, and ApplyBatch paths against arbitrary terms and row IDs.

- FuzzBTreeWrite (internal/minisql): exercises B-tree leaf and internal node splits and merges with arbitrary key orderings and insert/delete sequences; verifies post-operation full scan and point-lookup stability.

Also fixes a nil-pointer dereference in Iterator.Next when db.Query is called with a non-SELECT statement (e.g. INSERT) — rowFunc was nil in that case, causing a panic on the first rows.Next() call.