### PR TITLE
Extend disk-backed ORDER BY sort to all query paths

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -133,6 +133,6 @@ PRAGMA sort_mem_limit = 0;          -- disable disk spill
 ```
 
 !!! note
-    Disk spill only applies to the `selectWithSortRowView` fast path: sequential scans with no joins, no `LIMIT`, and no aggregate/GROUP BY. Queries that do not match this path sort in memory as before, regardless of `sort_mem_limit`.
+    Disk spill applies universally to all `ORDER BY` queries — sequential scans, joins, `DISTINCT`, and multi-column sorts — whenever the accumulated row data exceeds `sort_mem_limit`. The only exception is `ORDER BY` with `LIMIT` (and no `DISTINCT`), which uses a bounded min-heap sized to `OFFSET + LIMIT` rows and never needs to spill.
 
 Parallel scan is most beneficial for large tables on multi-core machines running filter-heavy queries. For small tables or single-CPU environments the overhead typically outweighs the benefit.

--- a/e2e_tests/sort_spill_test.go
+++ b/e2e_tests/sort_spill_test.go
@@ -13,10 +13,10 @@ import (
 	_ "github.com/RichardKnop/minisql"
 )
 
-// TestOrderBy_DiskSpill_DSN opens a fresh database with sort_mem_limit set low
-// enough that a 1 000-row ORDER BY query crosses the threshold and spills sorted
-// runs to disk. It verifies that the merged result is correctly ordered.
-func TestOrderBy_DiskSpill_DSN(t *testing.T) {
+// openSpillDB opens a temporary MiniSQL database with sort_mem_limit set to
+// limit bytes, registers cleanup, and returns the *sql.DB.
+func openSpillDB(t *testing.T, limit int) *sql.DB {
+	t.Helper()
 	f, err := os.CreateTemp("", "minisql_sort_spill_*.db")
 	require.NoError(t, err)
 	dbPath := f.Name()
@@ -26,15 +26,23 @@ func TestOrderBy_DiskSpill_DSN(t *testing.T) {
 		os.Remove(dbPath + "-wal")
 	})
 
-	// 64 KB limit — 1 000 rows × ~150 bytes each ≈ 150 KB, forcing at least two spills.
-	dsn := fmt.Sprintf("%s?sort_mem_limit=65536", dbPath)
+	dsn := fmt.Sprintf("%s?sort_mem_limit=%d", dbPath, limit)
 	db, err := sql.Open("minisql", dsn)
 	require.NoError(t, err)
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	t.Cleanup(func() { db.Close() })
+	return db
+}
 
-	_, err = db.Exec(`create table "items" (
+// TestOrderBy_DiskSpill_DSN opens a fresh database with sort_mem_limit set low
+// enough that a 1 000-row ORDER BY query crosses the threshold and spills sorted
+// runs to disk. It verifies that the merged result is correctly ordered.
+func TestOrderBy_DiskSpill_DSN(t *testing.T) {
+	// 64 KB limit — 1 000 rows × ~150 bytes each ≈ 150 KB, forcing at least two spills.
+	db := openSpillDB(t, 65536)
+
+	_, err := db.Exec(`create table "items" (
 		id   int8 primary key autoincrement,
 		name varchar(255)
 	)`)
@@ -112,4 +120,241 @@ func TestOrderBy_DiskSpill_DSN(t *testing.T) {
 	assert.True(t, strings.HasPrefix(offsetNames[0], "item_"),
 		"first offset row should be item_000501, got %q", offsetNames[0])
 	assert.Equal(t, "item_000501", offsetNames[0])
+}
+
+// TestOrderBy_DiskSpill_Join verifies that JOIN + ORDER BY queries spill to disk
+// correctly and produce a properly ordered result. This exercises the universal
+// spill path (selectWithSortSpill) rather than the sequential-scan fast path.
+func TestOrderBy_DiskSpill_Join(t *testing.T) {
+	// 8 KB limit forces spills even for a few hundred rows.
+	db := openSpillDB(t, 8192)
+
+	_, err := db.Exec(`create table "depts" (
+		id   int8 primary key,
+		name varchar(255)
+	)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`create table "emps" (
+		id      int8 primary key,
+		dept_id int8,
+		name    varchar(255),
+		salary  int8
+	)`)
+	require.NoError(t, err)
+
+	// Two departments.
+	_, err = db.Exec(`insert into "depts" (id, name) values (1, 'Engineering'), (2, 'Sales')`)
+	require.NoError(t, err)
+
+	// 200 employees across two departments, inserted in reverse salary order.
+	const n = 200
+	for i := n; i >= 1; i-- {
+		dept := 1 + (i % 2) // alternates 1 and 2
+		name := fmt.Sprintf("emp_%04d", i)
+		_, err = db.Exec(`insert into "emps" (id, dept_id, name, salary) values (?, ?, ?, ?)`,
+			int64(i), int64(dept), name, int64(i*100))
+		require.NoError(t, err)
+	}
+
+	// INNER JOIN ordered by salary ASC — all 200 employees have a matching dept.
+	rows, err := db.Query(`
+		select e.id, e.name, d.name, e.salary
+		from "emps" AS e
+		inner join "depts" AS d on e.dept_id = d.id
+		order by e.salary asc
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		empID  int64
+		emp    string
+		dept   string
+		salary int64
+	}
+	var results []row
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.empID, &r.emp, &r.dept, &r.salary))
+		results = append(results, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, results, n)
+
+	// Verify ascending salary order.
+	for i := 1; i < len(results); i++ {
+		assert.LessOrEqual(t, results[i-1].salary, results[i].salary,
+			"row %d: salary %d should be <= %d", i, results[i-1].salary, results[i].salary)
+	}
+	assert.Equal(t, int64(100), results[0].salary)
+	assert.Equal(t, int64(n*100), results[n-1].salary)
+}
+
+// TestOrderBy_DiskSpill_Distinct verifies that ORDER BY + DISTINCT with disk spill
+// produces a deduplicated, correctly ordered result set.
+func TestOrderBy_DiskSpill_Distinct(t *testing.T) {
+	// 4 KB limit forces spills for even small result sets.
+	db := openSpillDB(t, 4096)
+
+	_, err := db.Exec(`create table "scores" (
+		id    int8 primary key autoincrement,
+		level int4,
+		score int4
+	)`)
+	require.NoError(t, err)
+
+	// Insert 300 rows with only 10 distinct levels (each level repeated 30 times).
+	for level := 10; level >= 1; level-- {
+		for rep := 0; rep < 30; rep++ {
+			_, err = db.Exec(`insert into "scores" (level, score) values (?, ?)`,
+				int32(level), int32(level*10+rep))
+			require.NoError(t, err)
+		}
+	}
+
+	// SELECT DISTINCT level ORDER BY level ASC — should yield 10 unique levels.
+	rows, err := db.Query(`select distinct level from "scores" order by level asc`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var levels []int32
+	for rows.Next() {
+		var lvl int32
+		require.NoError(t, rows.Scan(&lvl))
+		levels = append(levels, lvl)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, levels, 10)
+
+	for i, lvl := range levels {
+		assert.Equal(t, int32(i+1), lvl, "level at position %d", i)
+	}
+}
+
+// TestOrderBy_DiskSpill_MultiColumn verifies multi-column ORDER BY with disk spill
+// produces results sorted by the primary key then tiebreaker in the correct order.
+func TestOrderBy_DiskSpill_MultiColumn(t *testing.T) {
+	// 4 KB limit forces spills for even a small table.
+	db := openSpillDB(t, 4096)
+
+	_, err := db.Exec(`create table "events" (
+		id       int8 primary key autoincrement,
+		category varchar(50),
+		priority int4,
+		label    varchar(255)
+	)`)
+	require.NoError(t, err)
+
+	// 150 rows with 3 categories and 5 priorities, inserted in scrambled order.
+	categories := []string{"C", "B", "A"}
+	for _, cat := range categories {
+		for p := 5; p >= 1; p-- {
+			for seq := 10; seq >= 1; seq-- {
+				label := fmt.Sprintf("%s_p%d_s%02d", cat, p, seq)
+				_, err = db.Exec(`insert into "events" (category, priority, label) values (?, ?, ?)`,
+					cat, int32(p), label)
+				require.NoError(t, err)
+			}
+		}
+	}
+
+	// ORDER BY category ASC, priority ASC.
+	rows, err := db.Query(`select category, priority from "events" order by category asc, priority asc`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type rec struct {
+		cat string
+		pri int32
+	}
+	var results []rec
+	for rows.Next() {
+		var r rec
+		require.NoError(t, rows.Scan(&r.cat, &r.pri))
+		results = append(results, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, results, 150)
+
+	for i := 1; i < len(results); i++ {
+		prev, cur := results[i-1], results[i]
+		if prev.cat == cur.cat {
+			assert.LessOrEqual(t, prev.pri, cur.pri,
+				"row %d: priority %d should be <= %d within category %q", i, prev.pri, cur.pri, cur.cat)
+		} else {
+			assert.LessOrEqual(t, prev.cat, cur.cat,
+				"row %d: category %q should come before %q", i, prev.cat, cur.cat)
+		}
+	}
+	// Spot-check: first row must be category A, priority 1.
+	assert.Equal(t, "A", results[0].cat)
+	assert.Equal(t, int32(1), results[0].pri)
+	// Last row must be category C, priority 5.
+	assert.Equal(t, "C", results[len(results)-1].cat)
+	assert.Equal(t, int32(5), results[len(results)-1].pri)
+}
+
+// TestOrderBy_DiskSpill_Join_Offset verifies JOIN + ORDER BY + OFFSET with disk
+// spill returns the correct tail of the sorted result.
+func TestOrderBy_DiskSpill_Join_Offset(t *testing.T) {
+	db := openSpillDB(t, 8192)
+
+	_, err := db.Exec(`create table "tags" (
+		id   int8 primary key,
+		name varchar(100)
+	)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`create table "items2" (
+		id     int8 primary key,
+		tag_id int8,
+		value  int8
+	)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`insert into "tags" (id, name) values (1, 'alpha'), (2, 'beta')`)
+	require.NoError(t, err)
+
+	// 100 items with alternating tags, inserted in reverse value order.
+	const n = 100
+	for i := n; i >= 1; i-- {
+		tag := 1 + (i % 2)
+		_, err = db.Exec(`insert into "items2" (id, tag_id, value) values (?, ?, ?)`,
+			int64(i), int64(tag), int64(i))
+		require.NoError(t, err)
+	}
+
+	// JOIN ordered by value ASC with OFFSET 50 — should return items 51..100 sorted.
+	rows, err := db.Query(`
+		select i.value, t.name
+		from "items2" AS i
+		inner join "tags" AS t on i.tag_id = t.id
+		order by i.value asc
+		offset 50
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	type row struct {
+		value int64
+		tag   string
+	}
+	var results []row
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.value, &r.tag))
+		results = append(results, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, results, n-50)
+
+	// First result after OFFSET 50 should be value 51 (the 51st in ascending order).
+	assert.Equal(t, int64(51), results[0].value)
+	assert.Equal(t, int64(n), results[len(results)-1].value)
+
+	for i := 1; i < len(results); i++ {
+		assert.LessOrEqual(t, results[i-1].value, results[i].value,
+			"row %d: value %d should be <= %d", i, results[i-1].value, results[i].value)
+	}
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -276,6 +276,17 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		return countResult(count), nil
 	}
 
+	// Universal ORDER BY spill: when sortMemLimit is set and this is a sort
+	// query that cannot be bounded by a heap (no LIMIT, or LIMIT+DISTINCT),
+	// stream rows through plan.Execute with periodic disk flushes to bound
+	// peak memory regardless of result cardinality.
+	// LIMIT+no-DISTINCT is excluded because selectJoinWithSortStreamingLimit
+	// already bounds memory to O(LIMIT), or the heap path in selectWithSort
+	// handles it in O(LIMIT) memory.
+	if plan.SortInMemory && t.sortMemLimit > 0 && (!stmt.Limit.Valid || stmt.Distinct) {
+		return t.selectWithSortSpill(ctx, stmt, plan, selectedFields, requestedFields)
+	}
+
 	// Materialising path: buffer every matching row, then dispatch.
 	// Reached for JOIN queries that require semi/anti-semi joins — where all
 	// rows must be collected before output can begin.
@@ -4165,6 +4176,140 @@ func (t *Table) selectWithSort(stmt Statement, plan QueryPlan, allRows []Row, re
 	return result, nil
 }
 
+// selectWithSortSpill is the universal ORDER BY path that streams rows through
+// plan.Execute and flushes sorted runs to disk when accumBytes exceeds
+// t.sortMemLimit, then N-way merges all runs — bounding peak heap memory
+// regardless of result cardinality.
+//
+// It is invoked for any plan.SortInMemory query where sortMemLimit > 0 and
+// the heap optimisation (LIMIT without DISTINCT) is not applicable.
+func (t *Table) selectWithSortSpill(
+	ctx context.Context,
+	stmt Statement,
+	plan QueryPlan,
+	selectedFields []Field,
+	requestedFields []Field,
+) (StatementResult, error) {
+	outputFields := orderByOutputFields(requestedFields)
+
+	var (
+		allRows      []Row
+		accumBytes   int64
+		tmpRuns      []string
+		spillColumns []Column
+	)
+
+	cleanupRuns := func() {
+		for _, p := range tmpRuns {
+			_ = os.Remove(p)
+		}
+	}
+
+	flushRun := func() error {
+		if len(allRows) == 0 {
+			return nil
+		}
+		if err := t.sortRows(allRows, plan.OrderBy); err != nil {
+			return err
+		}
+		w, err := newRunWriter()
+		if err != nil {
+			return err
+		}
+		for _, r := range allRows {
+			if wErr := w.writeRow(r); wErr != nil {
+				_ = w.close()
+				return wErr
+			}
+		}
+		path := w.filePath()
+		if err := w.close(); err != nil {
+			return err
+		}
+		tmpRuns = append(tmpRuns, path)
+		allRows = allRows[:0]
+		accumBytes = 0
+		return nil
+	}
+
+	err := plan.Execute(ctx, t.provider, selectedFields, func(row Row) error {
+		var err error
+		row, err = addOrderByOutputFieldsToRow(row, outputFields, plan.OrderBy)
+		if err != nil {
+			return err
+		}
+		if spillColumns == nil && len(row.Columns) > 0 {
+			spillColumns = row.Columns
+		}
+		accumBytes += int64(row.Size()) + 16
+		allRows = append(allRows, row)
+		if t.sortMemLimit > 0 && accumBytes >= t.sortMemLimit {
+			return flushRun()
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errLimitReached) {
+		cleanupRuns()
+		return StatementResult{}, err
+	}
+
+	if len(tmpRuns) > 0 {
+		if err := t.sortRows(allRows, plan.OrderBy); err != nil {
+			cleanupRuns()
+			return StatementResult{}, err
+		}
+		merged, err := t.externalSortMerge(tmpRuns, allRows, spillColumns, plan.OrderBy)
+		if err != nil {
+			return StatementResult{}, err
+		}
+		allRows = merged
+	} else {
+		if err := t.sortRows(allRows, plan.OrderBy); err != nil {
+			return StatementResult{}, err
+		}
+	}
+
+	if stmt.Distinct {
+		allRows = deduplicateRows(allRows, requestedFields)
+	}
+
+	offset := 0
+	if stmt.Offset.Valid {
+		offset = int(stmt.Offset.Value.(int64))
+	}
+	hasLimit := stmt.Limit.Valid
+	var limit int
+	if hasLimit {
+		limit = int(stmt.Limit.Value.(int64))
+	}
+
+	if offset >= len(allRows) {
+		allRows = nil
+	} else {
+		end := offset + limit
+		if hasLimit && end < len(allRows) {
+			allRows = allRows[offset:end]
+		} else {
+			allRows = allRows[offset:]
+		}
+	}
+
+	idx := 0
+	result := StatementResult{
+		Columns: t.selectResultColumns(stmt, requestedFields),
+	}
+	result.Rows = NewIterator(func(ctx context.Context) (Row, error) {
+		if idx >= len(allRows) {
+			return Row{}, ErrNoMoreRows
+		}
+		row := allRows[idx]
+		idx++
+		return projectRow(row, requestedFields)
+	})
+
+	return result, nil
+}
+
 func (t *Table) selectResultColumns(stmt Statement, requestedFields []Field) []Column {
 	columns := make([]Column, len(requestedFields))
 	for i, field := range requestedFields {
@@ -4259,6 +4404,7 @@ func addOrderByOutputFieldsToRow(row Row, outputFields map[string]Field, orderBy
 		}
 
 		var value OptionalValue
+		var extraCol Column
 		if field.Expr != nil {
 			result, err := field.Expr.Eval(updated)
 			if err != nil {
@@ -4267,19 +4413,53 @@ func addOrderByOutputFieldsToRow(row Row, outputFields map[string]Field, orderBy
 			if result != nil {
 				value = OptionalValue{Value: result, Valid: true}
 			}
+			// Derive column Kind from the evaluated value so rows can be serialized
+			// to disk during external sort without losing the sort key.
+			extraCol = Column{Name: field.OutputName(), Kind: kindFromValue(value.Value)}
 		} else {
+			sourceCol, _ := updated.getColumnQualified(field.AliasPrefix, field.Name)
 			existing, found := updated.getValueQualified(field.AliasPrefix, field.Name)
 			if !found {
 				continue
 			}
 			value = existing
+			// Preserve the source column's Kind so the extra sort key round-trips
+			// through external sort run files (Marshal/UnmarshalRow).
+			extraCol = Column{Name: field.OutputName(), Kind: sourceCol.Kind, Size: sourceCol.Size}
 		}
 
-		updated.Columns = append(updated.Columns, Column{Name: field.OutputName()})
+		updated.Columns = append(updated.Columns, extraCol)
 		updated.Values = append(updated.Values, value)
 	}
 
 	return updated, nil
+}
+
+// kindFromValue infers a ColumnKind from the Go type of a value returned by
+// expression evaluation. Used when adding extra ORDER BY output columns so that
+// the column carries a proper Kind for Marshal/UnmarshalRow round-trips during
+// external sort.
+func kindFromValue(v any) ColumnKind {
+	switch v.(type) {
+	case bool:
+		return Boolean
+	case int32:
+		return Int4
+	case int64:
+		return Int8
+	case float32:
+		return Real
+	case float64:
+		return Double
+	case string, TextPointer:
+		return Varchar
+	case TimestampMicros:
+		return Timestamp
+	case UUIDValue:
+		return UUID
+	default:
+		return 0
+	}
 }
 
 func (t *Table) indexedScanRow(


### PR DESCRIPTION
Previously sort_mem_limit only applied to the selectWithSortRowView fast path (sequential scans with no joins, no LIMIT, no aggregates). This left JOIN + ORDER BY, DISTINCT + ORDER BY, and queries with expression fields sorting entirely in memory regardless of result cardinality.

This commit makes spill-to-disk universal — consistent with how PostgreSQL work_mem and SQLite's VDBE sorter work:

- Add selectWithSortSpill: streams rows through plan.Execute applying addOrderByOutputFieldsToRow per-row, flushes sorted runs to disk when accumBytes >= sortMemLimit, then N-way merges all runs via externalSortMerge. LIMIT+no-DISTINCT is excluded because the existing heap path already bounds memory to O(LIMIT).

- Fix addOrderByOutputFieldsToRow to set proper ColumnKind on the extra sort-only columns it appends. Previously Kind was always 0, which silently broke Marshal/UnmarshalRow round-trips needed for run files. Non-expression columns now copy Kind+Size from the source column via getColumnQualified; expression columns infer Kind from the evaluated value's Go type via the new kindFromValue helper.

- Add four e2e tests covering the new universal path: JOIN + ORDER BY, DISTINCT + ORDER BY, multi-column ORDER BY, and JOIN + ORDER BY + OFFSET — all with a sort_mem_limit low enough to force at least one disk spill.

- Update docs/connection.md to remove the caveat that disk spill was limited to the sequential-scan fast path.