### PR TITLE
Add native engine metrics API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
         - (*database/sql.Rows).Close
         - (*database/sql.Stmt).Close
         - (*database/sql.DB).Close
+        - (*database/sql.Conn).Close
         - os.Remove
         # Print functions: ignoring write errors is conventional.
         - fmt.Fprint

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ for rows.Next() {
 | [JSON](json.md) | JSON type, operators, inverted index |
 | [Vector Search](vector-search.md) | VECTOR type and HNSW ANN search |
 | [Encryption](encryption.md) | Transparent AES-256-CTR encryption |
+| [Metrics](metrics.md) | Native engine statistics API |
 | [Constraints](constraints.md) | CHECK, FK, NOT NULL, UNIQUE |
 | [System Table](system-table.md) | `minisql_schema` structure |
 | [Limitations](limitations.md) | Known limitations and workarounds |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,146 @@
+# Metrics
+
+MiniSQL exposes a native Go metrics API that returns a point-in-time snapshot of engine statistics. All counters are cumulative since the database was opened; gauges reflect instantaneous state.
+
+---
+
+## Reading metrics
+
+```go
+import (
+    "context"
+    "database/sql"
+    "github.com/RichardKnop/minisql"
+    _ "github.com/RichardKnop/minisql"
+)
+
+db, err := sql.Open("minisql", "./my.db")
+// ...
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+
+m, err := minisql.ReadMetrics(context.Background(), db)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("cache hit rate: %.2f%%\n",
+    100*float64(m.PageCacheHits)/float64(m.PageCacheHits+m.PageCacheMisses))
+fmt.Printf("tx commits: %d  rollbacks: %d\n", m.TxCommits, m.TxRollbacks)
+fmt.Printf("queries total: %d  slow: %d\n", m.QueriesTotal, m.QueriesSlow)
+```
+
+`ReadMetrics` acquires the engine's connection briefly to copy the counters; it does not block query execution.
+
+---
+
+## Fields
+
+### Page cache
+
+| Field | Kind | Description |
+|-------|------|-------------|
+| `PageCacheHits` | counter | Requests served from the in-memory LRU cache |
+| `PageCacheMisses` | counter | Requests that required a WAL or disk read |
+| `PageCacheEvictions` | counter | Pages removed to make room for incoming pages |
+| `PageCacheSize` | gauge | Pages currently held in the cache |
+| `PageCacheCapacity` | gauge | Maximum pages the cache can hold (`max_cached_pages` setting) |
+
+The cache hit rate is `PageCacheHits / (PageCacheHits + PageCacheMisses)`. A rate below ~95% on a read-heavy workload is a signal to raise `max_cached_pages`.
+
+### WAL
+
+| Field | Kind | Description |
+|-------|------|-------------|
+| `WALFramesWritten` | counter | Cumulative frames written to the WAL since open |
+| `WALCheckpoints` | counter | Cumulative checkpoint runs (automatic + `PRAGMA wal_checkpoint`) |
+| `WALCurrentFrames` | gauge | Frames currently in the WAL; resets to 0 after each checkpoint and truncate |
+
+`WALCurrentFrames` approaching the `wal_checkpoint_threshold` (default 1000) means a checkpoint will run soon.
+
+### Transactions
+
+| Field | Kind | Description |
+|-------|------|-------------|
+| `TxCommits` | counter | Write transactions successfully committed |
+| `TxRollbacks` | counter | Transactions rolled back (explicit or due to error) |
+
+Read-only transactions are not counted — they produce no WAL frames and have zero commit overhead.
+
+### Queries
+
+| Field | Kind | Description |
+|-------|------|-------------|
+| `QueriesTotal` | counter | Total calls to `ExecContext` and `QueryContext` since open |
+| `QueriesSlow` | counter | Calls that met or exceeded `slow_query_threshold` |
+
+`QueriesSlow` is only meaningful when `slow_query_threshold` is set in the DSN. See [Connection](connection.md#parameters).
+
+### Sort
+
+| Field | Kind | Description |
+|-------|------|-------------|
+| `SortsInMemory` | counter | `ORDER BY` queries completed entirely in memory |
+| `SortSpillRuns` | counter | Sorted run files written to disk for external merge sort |
+| `SortSpillBytes` | counter | Cumulative bytes written to disk run files |
+
+`SortSpillRuns > 0` means at least one `ORDER BY` query exceeded `sort_mem_limit`. Raise the limit or investigate query result sizes. See [Disk-backed sort](connection.md#disk-backed-sort).
+
+---
+
+## Periodic polling
+
+Metrics are in-process counters — there is no background thread accumulating them. Poll on your own schedule:
+
+```go
+func reportMetrics(ctx context.Context, db *sql.DB, interval time.Duration) {
+    ticker := time.NewTicker(interval)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ticker.C:
+            m, err := minisql.ReadMetrics(ctx, db)
+            if err != nil {
+                log.Printf("metrics error: %v", err)
+                continue
+            }
+            log.Printf("cache=%.1f%% wal_frames=%d commits=%d slow_queries=%d spill_runs=%d",
+                100*float64(m.PageCacheHits)/float64(max(m.PageCacheHits+m.PageCacheMisses, 1)),
+                m.WALCurrentFrames,
+                m.TxCommits,
+                m.QueriesSlow,
+                m.SortSpillRuns,
+            )
+        case <-ctx.Done():
+            return
+        }
+    }
+}
+```
+
+---
+
+## Prometheus integration
+
+There is no built-in Prometheus exporter. To expose metrics via Prometheus, wrap `ReadMetrics` in a custom collector:
+
+```go
+type miniSQLCollector struct {
+    db           *sql.DB
+    cacheHits    *prometheus.Desc
+    cacheMisses  *prometheus.Desc
+    txCommits    *prometheus.Desc
+    // ... one Desc per field
+}
+
+func (c *miniSQLCollector) Collect(ch chan<- prometheus.Metric) {
+    m, err := minisql.ReadMetrics(context.Background(), c.db)
+    if err != nil {
+        return
+    }
+    ch <- prometheus.MustNewConstMetric(c.cacheHits, prometheus.CounterValue, float64(m.PageCacheHits))
+    ch <- prometheus.MustNewConstMetric(c.cacheMisses, prometheus.CounterValue, float64(m.PageCacheMisses))
+    ch <- prometheus.MustNewConstMetric(c.txCommits, prometheus.CounterValue, float64(m.TxCommits))
+    // ...
+}
+```

--- a/e2e_tests/metrics_test.go
+++ b/e2e_tests/metrics_test.go
@@ -1,0 +1,152 @@
+package e2etests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql"
+)
+
+func openMetricsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	f, err := os.CreateTemp("", "minisql_metrics_*.db")
+	require.NoError(t, err)
+	dbPath := f.Name()
+	f.Close()
+	t.Cleanup(func() {
+		os.Remove(dbPath)
+		os.Remove(dbPath + "-wal")
+	})
+	db, err := sql.Open("minisql", dbPath)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// TestReadMetrics_Basic verifies that ReadMetrics returns a valid snapshot
+// and that the counters reflect observable activity.
+func TestReadMetrics_Basic(t *testing.T) {
+	ctx := context.Background()
+	db := openMetricsDB(t)
+
+	// Schema + data setup.
+	_, err := db.ExecContext(ctx, `create table "things" (id int8 primary key autoincrement, name varchar(255))`)
+	require.NoError(t, err)
+
+	const rowCount = 50
+	for i := 0; i < rowCount; i++ {
+		_, err = db.ExecContext(ctx, `insert into "things" (name) values (?)`, fmt.Sprintf("thing_%03d", i))
+		require.NoError(t, err)
+	}
+
+	// Run a SELECT to produce cache activity and a sort.
+	rows, err := db.QueryContext(ctx, `select id, name from "things" order by name asc`)
+	require.NoError(t, err)
+	n := 0
+	for rows.Next() {
+		var id int64
+		var name string
+		require.NoError(t, rows.Scan(&id, &name))
+		n++
+	}
+	require.NoError(t, rows.Err())
+	rows.Close()
+	assert.Equal(t, rowCount, n)
+
+	m, err := minisql.ReadMetrics(ctx, db)
+	require.NoError(t, err)
+
+	// Page cache: at least some hits and misses since we read pages.
+	assert.Positive(t, m.PageCacheHits+m.PageCacheMisses, "expected some page cache activity")
+	assert.Positive(t, m.PageCacheCapacity, "capacity should reflect max_cached_pages")
+
+	// WAL: at least one frame per write transaction (CREATE TABLE + inserts).
+	assert.Positive(t, m.WALFramesWritten, "expected WAL frames from writes")
+
+	// Transactions: CREATE TABLE + each INSERT = at least rowCount+1 commits.
+	assert.GreaterOrEqual(t, m.TxCommits, int64(rowCount+1))
+	assert.Zero(t, m.TxRollbacks, "no rollbacks expected")
+
+	// Queries: CREATE TABLE + inserts + the SELECT above = at least rowCount+2.
+	assert.GreaterOrEqual(t, m.QueriesTotal, int64(rowCount+2))
+
+	// Sort: the ORDER BY select should have produced an in-memory sort (50 rows << 4MB limit).
+	assert.Positive(t, m.SortsInMemory, "expected at least one in-memory sort")
+	assert.Zero(t, m.SortSpillRuns, "no disk spill expected for 50 rows")
+}
+
+// TestReadMetrics_SpillCounters verifies that SortSpillRuns and SortSpillBytes
+// are incremented when an ORDER BY query exceeds sort_mem_limit.
+func TestReadMetrics_SpillCounters(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a very low sort_mem_limit so even a handful of rows trigger a spill.
+	f, err := os.CreateTemp("", "minisql_metrics_spill_*.db")
+	require.NoError(t, err)
+	dbPath := f.Name()
+	f.Close()
+	t.Cleanup(func() {
+		os.Remove(dbPath)
+		os.Remove(dbPath + "-wal")
+	})
+
+	db, err := sql.Open("minisql", fmt.Sprintf("%s?sort_mem_limit=4096", dbPath))
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.ExecContext(ctx, `create table "vals" (id int8 primary key autoincrement, v varchar(255))`)
+	require.NoError(t, err)
+
+	const n = 200
+	for i := n; i >= 1; i-- {
+		_, err = db.ExecContext(ctx, `insert into "vals" (v) values (?)`, fmt.Sprintf("val_%05d", i))
+		require.NoError(t, err)
+	}
+
+	rows, err := db.QueryContext(ctx, `select v from "vals" order by v asc`)
+	require.NoError(t, err)
+	for rows.Next() {
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+
+	m, err := minisql.ReadMetrics(ctx, db)
+	require.NoError(t, err)
+
+	assert.Positive(t, m.SortSpillRuns, "expected at least one spill run")
+	assert.Positive(t, m.SortSpillBytes, "expected non-zero spill bytes")
+	assert.Zero(t, m.SortsInMemory, "all sorts should have spilled")
+}
+
+// TestReadMetrics_WALCheckpoint verifies that WALCheckpoints is incremented
+// after an explicit PRAGMA wal_checkpoint.
+func TestReadMetrics_WALCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	db := openMetricsDB(t)
+
+	_, err := db.ExecContext(ctx, `create table "cp" (id int8 primary key)`)
+	require.NoError(t, err)
+
+	before, err := minisql.ReadMetrics(ctx, db)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `PRAGMA wal_checkpoint`)
+	require.NoError(t, err)
+
+	after, err := minisql.ReadMetrics(ctx, db)
+	require.NoError(t, err)
+
+	assert.Greater(t, after.WALCheckpoints, before.WALCheckpoints,
+		"WALCheckpoints should increase after explicit checkpoint")
+	assert.GreaterOrEqual(t, after.QueriesTotal, before.QueriesTotal+1)
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -50,6 +50,7 @@ type Database struct {
 	planCache      LRUCache[string]
 	tables         map[string]*Table
 	txManager      *TransactionManager
+	metrics        *engineMetrics
 	dbLock         *sync.RWMutex
 	walIndex       *WALIndex
 	clock          clock
@@ -109,9 +110,18 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 	}
 	db.lockedProvider = &lockedTableProvider{db: db}
 
+	db.metrics = &engineMetrics{}
+	// Wire metrics into subsystems that live in the same package.
+	// pagerImpl is always the concrete type for saver in production; the type
+	// assertion is a no-op for test doubles that use a different PageSaver.
+	if p, ok := saver.(*pagerImpl); ok {
+		p.SetMetrics(db.metrics)
+	}
+
 	db.txManager = NewTransactionManager(logger, dbFilePath, db.pagerFactory, saver, db)
 	db.txManager.SetRowCountApplier(db.applyRowCountDeltas)
 	db.txManager.SetRowCountDeltaApplier(db.applyRowCountDelta)
+	db.txManager.SetMetrics(db.metrics)
 
 	if walCfg != nil {
 		db.wal = walCfg.WAL
@@ -127,6 +137,7 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 		if walCfg.WAL != nil {
 			walCfg.WAL.SetSynchronous(walCfg.Synchronous)
 			walCfg.WAL.SetWriteBufferSize(walCfg.WALWriteBufferSize)
+			walCfg.WAL.SetMetrics(db.metrics)
 		}
 	}
 
@@ -145,6 +156,22 @@ func NewDatabase(ctx context.Context, logger *zap.Logger, dbFilePath string, par
 	}
 
 	return db, nil
+}
+
+// RecordQuery increments the query counters. Called by the driver layer after
+// each ExecContext or QueryContext call completes.
+func (d *Database) RecordQuery(slow bool) {
+	if m := d.metrics; m != nil {
+		m.recordQuery(slow)
+	}
+}
+
+// ReadEngineMetrics returns a point-in-time snapshot of engine-level counters.
+func (d *Database) ReadEngineMetrics() EngineSnapshot {
+	if d.metrics == nil {
+		return EngineSnapshot{}
+	}
+	return d.metrics.snapshot()
 }
 
 // GetTable retrieves a table by name in a thread-safe manner.
@@ -930,6 +957,7 @@ func (d *Database) tableFromSQL(ctx context.Context, schema Schema) (*Table, err
 
 	opts = append(opts, WithParallelScan(d.parallelScan))
 	opts = append(opts, withSortMemLimit(d.sortMemLimit))
+	opts = append(opts, withMetrics(d.metrics))
 
 	if len(stmt.ForeignKeys) > 0 {
 		opts = append(opts, WithForeignKeys(stmt.ForeignKeys))
@@ -1476,6 +1504,7 @@ func (d *Database) createTable(ctx context.Context, stmt Statement) (*Table, err
 
 	opts = append(opts, WithParallelScan(d.parallelScan))
 	opts = append(opts, withSortMemLimit(d.sortMemLimit))
+	opts = append(opts, withMetrics(d.metrics))
 
 	if len(stmt.ForeignKeys) > 0 {
 		opts = append(opts, WithForeignKeys(stmt.ForeignKeys))

--- a/internal/minisql/metrics.go
+++ b/internal/minisql/metrics.go
@@ -1,0 +1,81 @@
+package minisql
+
+import "sync/atomic"
+
+// EngineSnapshot is a point-in-time copy of all engine-level counters and gauges.
+// Counter fields are cumulative since the database was opened.
+// Gauge fields (PageCacheSize, WALCurrentFrames) reflect instantaneous state.
+type EngineSnapshot struct {
+	PageCacheHits      int64
+	PageCacheMisses    int64
+	PageCacheEvictions int64
+	PageCacheSize      int64
+	PageCacheCapacity  int64
+	WALFramesWritten   int64
+	WALCheckpoints     int64
+	WALCurrentFrames   int64
+	TxCommits          int64
+	TxRollbacks        int64
+	QueriesTotal       int64
+	QueriesSlow        int64
+	SortsInMemory      int64
+	SortSpillRuns      int64
+	SortSpillBytes     int64
+}
+
+// engineMetrics holds all engine-level performance counters and gauges.
+// Every field is updated atomically so the struct is safe to read and write
+// from concurrent goroutines without additional locking.
+type engineMetrics struct {
+	// Page cache
+	pageCacheHits      atomic.Int64
+	pageCacheMisses    atomic.Int64
+	pageCacheEvictions atomic.Int64
+	pageCacheSize      atomic.Int64 // gauge: pages currently held in LRU cache
+	pageCacheCapacity  int64        // const after init: max_cached_pages setting
+
+	// WAL
+	walFramesWritten atomic.Int64 // cumulative frames written by AppendTransaction
+	walCheckpoints   atomic.Int64 // cumulative Checkpoint calls
+	walCurrentFrames atomic.Int64 // gauge: frames currently in the WAL
+
+	// Transactions
+	txCommits   atomic.Int64 // write transactions successfully committed
+	txRollbacks atomic.Int64 // transactions rolled back
+
+	// Queries
+	queriesTotal atomic.Int64
+	queriesSlow  atomic.Int64
+
+	// Sort
+	sortsInMemory  atomic.Int64 // ORDER BY completed without spilling to disk
+	sortSpillRuns  atomic.Int64 // cumulative run files written to disk
+	sortSpillBytes atomic.Int64 // cumulative bytes written to run files
+}
+
+func (m *engineMetrics) recordQuery(slow bool) {
+	m.queriesTotal.Add(1)
+	if slow {
+		m.queriesSlow.Add(1)
+	}
+}
+
+func (m *engineMetrics) snapshot() EngineSnapshot {
+	return EngineSnapshot{
+		PageCacheHits:      m.pageCacheHits.Load(),
+		PageCacheMisses:    m.pageCacheMisses.Load(),
+		PageCacheEvictions: m.pageCacheEvictions.Load(),
+		PageCacheSize:      m.pageCacheSize.Load(),
+		PageCacheCapacity:  m.pageCacheCapacity,
+		WALFramesWritten:   m.walFramesWritten.Load(),
+		WALCheckpoints:     m.walCheckpoints.Load(),
+		WALCurrentFrames:   m.walCurrentFrames.Load(),
+		TxCommits:          m.txCommits.Load(),
+		TxRollbacks:        m.txRollbacks.Load(),
+		QueriesTotal:       m.queriesTotal.Load(),
+		QueriesSlow:        m.queriesSlow.Load(),
+		SortsInMemory:      m.sortsInMemory.Load(),
+		SortSpillRuns:      m.sortSpillRuns.Load(),
+		SortSpillBytes:     m.sortSpillBytes.Load(),
+	}
+}

--- a/internal/minisql/pager.go
+++ b/internal/minisql/pager.go
@@ -37,6 +37,7 @@ type pagerImpl struct {
 	bufferPool     *sync.Pool
 	walIndex       *WALIndex
 	cipher         *pkgcrypto.PageCipher // nil when encryption is disabled
+	metrics        *engineMetrics        // nil when metrics are not wired
 	pages          []*Page
 	pageSize       int
 	maxCachedPages int
@@ -98,6 +99,15 @@ func NewPager(file DBFile, pageSize, maxCachedPages int) (*pagerImpl, error) {
 	return pager, nil
 }
 
+// SetMetrics wires an engineMetrics counter store into the pager so that
+// cache hits, misses, evictions, and current size are tracked automatically.
+func (p *pagerImpl) SetMetrics(m *engineMetrics) {
+	p.metrics = m
+	if m != nil {
+		m.pageCacheCapacity = int64(p.maxCachedPages)
+	}
+}
+
 // SetWALIndex wires a WAL index into the pager.  Once set, cache misses in
 // GetPage check the index before falling back to a DB-file read.
 //
@@ -153,12 +163,18 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 		if pageIdx == 0 {
 			p.lruCache.GetAndPromote(pageIdx)
 		}
-		// No LRU update needed for cache hits - Get() already incremented access count
+		if m := p.metrics; m != nil {
+			m.pageCacheHits.Add(1)
+		}
 		return page, nil
 	}
 	totalPages := p.totalPages
 	wi := p.walIndex
 	p.mu.RUnlock()
+
+	if m := p.metrics; m != nil {
+		m.pageCacheMisses.Add(1)
+	}
 
 	// WAL check: on a cache miss, look up the WAL index before touching the DB
 	// file.  WAL pages may not yet be on disk (checkpoint pending), so this check
@@ -213,6 +229,10 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 			evictedIdx, evicted := p.lruCache.EvictIfNeeded()
 			if evicted {
 				p.pages[evictedIdx] = nil
+				if m := p.metrics; m != nil {
+					m.pageCacheEvictions.Add(1)
+					m.pageCacheSize.Add(-1)
+				}
 			}
 
 			if len(p.pages) < int(pageIdx)+1 {
@@ -228,6 +248,9 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 			}
 
 			p.lruCache.Put(pageIdx, struct{}{}, false)
+			if m := p.metrics; m != nil {
+				m.pageCacheSize.Add(1)
+			}
 			return p.pages[pageIdx], nil
 		}
 	}
@@ -292,6 +315,10 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 	evickedIdx, evicted := p.lruCache.EvictIfNeeded()
 	if evicted {
 		p.pages[evickedIdx] = nil
+		if m := p.metrics; m != nil {
+			m.pageCacheEvictions.Add(1)
+			m.pageCacheSize.Add(-1)
+		}
 	}
 
 	// Extend sparse array if needed
@@ -311,6 +338,9 @@ func (p *pagerImpl) GetPage(ctx context.Context, pageIdx PageIndex, unmarshaler 
 
 	// Track this page access
 	p.lruCache.Put(pageIdx, struct{}{}, false)
+	if m := p.metrics; m != nil {
+		m.pageCacheSize.Add(1)
+	}
 
 	return p.pages[pageIdx], nil
 }

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -3897,6 +3897,10 @@ func (t *Table) selectWithSortRowView(
 			return err
 		}
 		tmpRuns = append(tmpRuns, path)
+		if m := t.metrics; m != nil {
+			m.sortSpillRuns.Add(1)
+			m.sortSpillBytes.Add(accumBytes)
+		}
 		allRows = allRows[:0]
 		accumBytes = 0
 		return nil
@@ -3933,6 +3937,9 @@ func (t *Table) selectWithSortRowView(
 	} else {
 		if err := t.sortRows(allRows, effectiveOrderBy); err != nil {
 			return StatementResult{}, true, err
+		}
+		if m := t.metrics; m != nil {
+			m.sortsInMemory.Add(1)
 		}
 	}
 
@@ -4227,6 +4234,10 @@ func (t *Table) selectWithSortSpill(
 			return err
 		}
 		tmpRuns = append(tmpRuns, path)
+		if m := t.metrics; m != nil {
+			m.sortSpillRuns.Add(1)
+			m.sortSpillBytes.Add(accumBytes)
+		}
 		allRows = allRows[:0]
 		accumBytes = 0
 		return nil
@@ -4266,6 +4277,9 @@ func (t *Table) selectWithSortSpill(
 	} else {
 		if err := t.sortRows(allRows, plan.OrderBy); err != nil {
 			return StatementResult{}, err
+		}
+		if m := t.metrics; m != nil {
+			m.sortsInMemory.Add(1)
 		}
 	}
 

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -56,6 +56,8 @@ type Table struct {
 	// checks here first and stores results after planning. Nil for system tables
 	// and virtual tables created for derived-table subqueries.
 	planCache LRUCache[string]
+	// metrics is the shared engine counter store. nil when not wired (unit tests).
+	metrics *engineMetrics
 	// allFields, overflow masks, textOverflowCols, and vectorOverflowCols are derived from Columns at
 	// construction time and reused across calls to avoid per-call allocations.
 	allFields          []Field

--- a/internal/minisql/table_options.go
+++ b/internal/minisql/table_options.go
@@ -42,6 +42,12 @@ func withSortMemLimit(n int64) TableOption {
 	}
 }
 
+// withMetrics wires the shared engine counter store into the table so that
+// sort metrics (in-memory vs spill) are tracked automatically.
+func withMetrics(m *engineMetrics) TableOption {
+	return func(t *Table) { t.metrics = m }
+}
+
 // WithForeignKeys sets the outgoing FK constraints on the table.
 func WithForeignKeys(fks []ForeignKey) TableOption {
 	return func(t *Table) {

--- a/internal/minisql/transaction_manager.go
+++ b/internal/minisql/transaction_manager.go
@@ -44,6 +44,7 @@ type TransactionManager struct {
 	rowCountDeltaApplier func(string, int64)
 	logger               *zap.Logger
 	cipher               *pkgcrypto.PageCipher // nil when encryption is disabled
+	metrics              *engineMetrics         // nil when metrics are not wired
 	pageLastCommittedSeq map[PageIndex]uint64
 	pageVersionHistory   map[PageIndex][]pageVersion
 	commitHook           func(commitPhase)
@@ -86,6 +87,10 @@ func NewTransactionManager(logger *zap.Logger, dbFilePath string, factory TxPage
 		ddlSaver:             ddlSaver,
 	}
 }
+
+// SetMetrics wires an engineMetrics counter store into the transaction manager
+// so that commits and rollbacks are tracked automatically.
+func (tm *TransactionManager) SetMetrics(m *engineMetrics) { tm.metrics = m }
 
 // SetCipher wires an AES-256-CTR cipher into the transaction manager so that
 // WAL frames are encrypted before being written and decrypted after being read.
@@ -145,6 +150,10 @@ func (tm *TransactionManager) CheckpointWAL(dbFile DBFile) error {
 
 	tm.walWriteMu.Lock()
 	defer tm.walWriteMu.Unlock()
+
+	if m := tm.metrics; m != nil {
+		m.walCheckpoints.Add(1)
+	}
 
 	framesBefore := tm.wal.FrameCount()
 
@@ -487,6 +496,9 @@ func (tm *TransactionManager) commitDirect(ctx context.Context, tx *Transaction)
 	tm.applyRowCountDeltas(tx)
 	tx.Commit()
 	delete(tm.transactions, tx.ID)
+	if m := tm.metrics; m != nil {
+		m.txCommits.Add(1)
+	}
 	if ce := tm.logger.Check(zap.DebugLevel, "commit transaction"); ce != nil {
 		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
 	}
@@ -608,6 +620,9 @@ func (tm *TransactionManager) commitWithWAL(ctx context.Context, tx *Transaction
 		}
 	}
 
+	if m := tm.metrics; m != nil {
+		m.txCommits.Add(1)
+	}
 	if ce := tm.logger.Check(zap.DebugLevel, "commit transaction (WAL)"); ce != nil {
 		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
 	}
@@ -797,6 +812,9 @@ func (tm *TransactionManager) RollbackTransaction(ctx context.Context, tx *Trans
 	tm.trimPageVersionHistoryLocked()
 	tm.mu.Unlock()
 
+	if m := tm.metrics; m != nil {
+		m.txRollbacks.Add(1)
+	}
 	if ce := tm.logger.Check(zap.DebugLevel, "rollback transaction"); ce != nil {
 		ce.Write(zap.Uint64("tx_id", uint64(tx.ID)))
 	}

--- a/internal/minisql/wal.go
+++ b/internal/minisql/wal.go
@@ -97,15 +97,20 @@ type WALReadFrame struct {
 type WAL struct {
 	file           *os.File
 	filepath       string
-	pendingBuf     []byte // write-buffer accumulating frames not yet sent to the OS
-	pendingLen     int    // valid bytes in pendingBuf
-	flushThreshold int    // flush when pendingLen >= this; 0 = flush every commit
+	metrics        *engineMetrics // nil when metrics are not wired
+	pendingBuf     []byte         // write-buffer accumulating frames not yet sent to the OS
+	pendingLen     int            // valid bytes in pendingBuf
+	flushThreshold int            // flush when pendingLen >= this; 0 = flush every commit
 	nextOffset     int64
 	pageSize       uint32
 	salt1          uint32
 	salt2          uint32
 	synchronous    atomic.Int32 // SynchronousMode; default SynchronousNormal
 }
+
+// SetMetrics wires an engineMetrics counter store into the WAL so that
+// frame writes, checkpoints, and current WAL size are tracked automatically.
+func (w *WAL) SetMetrics(m *engineMetrics) { w.metrics = m }
 
 // Synchronous returns the current synchronous mode.
 func (w *WAL) Synchronous() SynchronousMode {
@@ -278,6 +283,10 @@ func (w *WAL) AppendTransaction(pages []WALPage) error {
 				return fmt.Errorf("sync WAL after append: %w", err)
 			}
 		}
+	}
+	if m := w.metrics; m != nil {
+		m.walFramesWritten.Add(int64(len(pages)))
+		m.walCurrentFrames.Store(w.FrameCount())
 	}
 	return nil
 }
@@ -539,6 +548,9 @@ func (w *WAL) Truncate() error {
 	}
 
 	w.nextOffset = WALFileHeaderSize
+	if m := w.metrics; m != nil {
+		m.walCurrentFrames.Store(0)
+	}
 	return nil
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,88 @@
+package minisql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Metrics is a point-in-time snapshot of MiniSQL engine statistics.
+// Counter fields are cumulative since the database was opened.
+// Gauge fields (Size, CurrentFrames) reflect the instantaneous state.
+type Metrics struct {
+	// PageCache reflects the LRU page cache (controlled by max_cached_pages).
+	// HitRate = PageCacheHits / (PageCacheHits + PageCacheMisses).
+	PageCacheHits      int64 // requests served from cache
+	PageCacheMisses    int64 // requests that required a WAL or disk read
+	PageCacheEvictions int64 // pages removed to make room for new ones
+	PageCacheSize      int64 // pages currently held in cache
+	PageCacheCapacity  int64 // configured maximum (max_cached_pages × PageSize bytes each)
+
+	// WAL reflects the Write-Ahead Log.
+	WALFramesWritten int64 // cumulative frames written since open
+	WALCheckpoints   int64 // cumulative checkpoint runs since open
+	WALCurrentFrames int64 // frames currently in the WAL (resets to 0 after each checkpoint+truncate)
+
+	// Tx reflects write transaction lifecycle.
+	// Read-only transactions are not counted (they produce no WAL frames).
+	TxCommits   int64 // write transactions successfully committed
+	TxRollbacks int64 // transactions rolled back (explicit or due to error)
+
+	// Queries reflects overall query volume across ExecContext and QueryContext.
+	QueriesTotal int64 // cumulative calls since open
+	QueriesSlow  int64 // calls that exceeded slow_query_threshold
+
+	// Sort reflects ORDER BY behaviour.
+	SortsInMemory  int64 // ORDER BY completed entirely in memory
+	SortSpillRuns  int64 // cumulative run files written to disk for external merge sort
+	SortSpillBytes int64 // cumulative bytes written to run files
+}
+
+// ReadMetrics returns a point-in-time snapshot of engine statistics for db.
+// db must have been opened with sql.Open("minisql", dsn).
+//
+// Example:
+//
+//	m, err := minisql.ReadMetrics(ctx, db)
+//	if err != nil { ... }
+//	hitRate := float64(m.PageCacheHits) / float64(m.PageCacheHits + m.PageCacheMisses)
+func ReadMetrics(ctx context.Context, db *sql.DB) (Metrics, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return Metrics{}, fmt.Errorf("minisql: ReadMetrics: acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	var m Metrics
+	err = conn.Raw(func(c any) error {
+		mc, ok := c.(*Conn)
+		if !ok {
+			return fmt.Errorf("minisql: ReadMetrics: unexpected connection type %T", c)
+		}
+		m = mc.readMetrics()
+		return nil
+	})
+	return m, err
+}
+
+// readMetrics takes a snapshot from the engine metrics store.
+func (c *Conn) readMetrics() Metrics {
+	s := c.db.ReadEngineMetrics()
+	return Metrics{
+		PageCacheHits:      s.PageCacheHits,
+		PageCacheMisses:    s.PageCacheMisses,
+		PageCacheEvictions: s.PageCacheEvictions,
+		PageCacheSize:      s.PageCacheSize,
+		PageCacheCapacity:  s.PageCacheCapacity,
+		WALFramesWritten:   s.WALFramesWritten,
+		WALCheckpoints:     s.WALCheckpoints,
+		WALCurrentFrames:   s.WALCurrentFrames,
+		TxCommits:          s.TxCommits,
+		TxRollbacks:        s.TxRollbacks,
+		QueriesTotal:       s.QueriesTotal,
+		QueriesSlow:        s.QueriesSlow,
+		SortsInMemory:      s.SortsInMemory,
+		SortSpillRuns:      s.SortSpillRuns,
+		SortSpillBytes:     s.SortSpillBytes,
+	}
+}

--- a/minisql.go
+++ b/minisql.go
@@ -253,7 +253,12 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, e
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (result driver.Result, err error) {
 	start := time.Now()
 	defer func() {
-		c.logSlowQuery(query, time.Since(start), err)
+		elapsed := time.Since(start)
+		slow := c.slowQueryThreshold > 0 && elapsed >= c.slowQueryThreshold
+		c.db.RecordQuery(slow)
+		if slow {
+			c.logSlowQuery(query, elapsed, err)
+		}
 	}()
 
 	statements, err := c.parser.Parse(ctx, query)
@@ -297,7 +302,12 @@ func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.Name
 func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (rows driver.Rows, err error) {
 	start := time.Now()
 	defer func() {
-		c.logSlowQuery(query, time.Since(start), err)
+		elapsed := time.Since(start)
+		slow := c.slowQueryThreshold > 0 && elapsed >= c.slowQueryThreshold
+		c.db.RecordQuery(slow)
+		if slow {
+			c.logSlowQuery(query, elapsed, err)
+		}
 	}()
 
 	statements, err := c.parser.Parse(ctx, query)


### PR DESCRIPTION
Exposes engine-level counters via minisql.ReadMetrics(ctx, *sql.DB), returning a Metrics snapshot with 15 fields across five categories:

  Page cache: hits, misses, evictions, current size, capacity
  WAL:        frames written, checkpoints, current frame count
  Transactions: commits, rollbacks
  Queries:    total, slow (above slow_query_threshold)
  Sort:       in-memory completions, spill run count, spill bytes

Counters are atomic.Int64 fields on a shared engineMetrics struct wired into the pager, WAL, transaction manager, and table during NewDatabase. The public API uses sql.Conn.Raw() so no new DB wrapper type is needed.