### PR TITLE
Add online backup API

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,41 @@
+package minisql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Backup creates a consistent, point-in-time copy of db at destPath.
+//
+// The database remains fully readable and writable during the backup.
+// Write transactions are blocked only for the brief moment needed to snapshot
+// the WAL index (typically microseconds); the page-copy phase runs concurrently
+// with normal database activity.
+//
+// The destination is a standalone file that can be opened directly:
+//
+//	if err := minisql.Backup(ctx, db, "/path/to/backup.db"); err != nil {
+//	    log.Fatal(err)
+//	}
+//	backup, err := sql.Open("minisql", "/path/to/backup.db")
+//
+// If the source database uses transparent encryption the backup is encrypted
+// with the same key.  The backup carries no WAL file.
+//
+// Backup must not be called from inside an explicit user transaction.
+func Backup(ctx context.Context, db *sql.DB, destPath string) error {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("minisql: Backup: acquire connection: %w", err)
+	}
+	defer conn.Close()
+
+	return conn.Raw(func(c any) error {
+		mc, ok := c.(*Conn)
+		if !ok {
+			return fmt.Errorf("minisql: Backup: unexpected connection type %T", c)
+		}
+		return mc.db.Backup(ctx, destPath)
+	})
+}

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,106 @@
+# Online Backup
+
+MiniSQL supports online backup — creating a consistent, point-in-time copy of the database while it continues to serve reads and writes.
+
+---
+
+## How it works
+
+The algorithm mirrors SQLite's WAL-mode online backup:
+
+1. **Begin a read-only snapshot transaction** — `CheckpointWAL` checks for active snapshot readers before acquiring `walWriteMu`. Any checkpoint that starts after this point is turned away with `ErrCheckpointBlockedByReaders`, freezing the main DB file for the duration of the backup.
+2. **Snapshot the WAL index** — `walWriteMu` is held for the minimum time needed to deep-copy the WAL index (page index → raw committed bytes) and record the page count. Write transactions are blocked only during this window, typically **microseconds**.
+3. **Release `walWriteMu`** — writers immediately resume.
+4. **Copy pages** — for each page 0..N-1:
+   - If the page has an entry in the WAL snapshot (committed but not yet checkpointed), those bytes are written to the destination.
+   - Otherwise the page is read directly from the main DB file.
+5. **Release the snapshot transaction** — checkpoints may proceed again.
+
+**Why the read-only snapshot is necessary:** WAL commits write to the WAL file only; the main DB file is updated exclusively by checkpoints. Without the snapshot transaction blocking checkpoints, a post-snapshot write transaction could commit, trigger an auto-checkpoint, and flush its pages into the DB file before the backup loop reads them — producing a backup that mixes pre- and post-snapshot data. The read-only snapshot prevents this entirely: any checkpoint attempt during the copy phase is rejected, so every `ReadAt` call sees the DB file at its pre-snapshot state.
+
+The destination is a self-contained database file with no associated WAL file.
+
+---
+
+## Usage
+
+```go
+import (
+    "context"
+    "database/sql"
+    "github.com/RichardKnop/minisql"
+    _ "github.com/RichardKnop/minisql"
+)
+
+db, err := sql.Open("minisql", "./production.db")
+// ...
+db.SetMaxOpenConns(1)
+db.SetMaxIdleConns(1)
+
+if err := minisql.Backup(ctx, db, "./backup.db"); err != nil {
+    log.Fatal(err)
+}
+```
+
+The backup file can be opened immediately:
+
+```go
+backup, err := sql.Open("minisql", "./backup.db")
+if err != nil {
+    log.Fatal(err)
+}
+backup.SetMaxOpenConns(1)
+backup.SetMaxIdleConns(1)
+defer backup.Close()
+
+rows, err := backup.QueryContext(ctx, `select count(*) from "orders"`)
+```
+
+---
+
+## Behaviour
+
+| Property | Detail |
+|----------|--------|
+| Writer blocking | Microseconds (WAL index snapshot only) |
+| Reader blocking | None |
+| Consistency point | State at the moment the WAL snapshot is taken |
+| WAL file created | No — destination is a clean standalone file |
+| Encryption | Backup is encrypted with the same key as the source |
+| Constraint | Must not be called inside an explicit `BEGIN` transaction |
+
+---
+
+## Periodic backups
+
+```go
+func scheduleBackups(ctx context.Context, db *sql.DB, dir string, interval time.Duration) {
+    ticker := time.NewTicker(interval)
+    defer ticker.Stop()
+    for {
+        select {
+        case t := <-ticker.C:
+            path := filepath.Join(dir, fmt.Sprintf("backup-%s.db", t.Format("20060102-150405")))
+            if err := minisql.Backup(ctx, db, path); err != nil {
+                log.Printf("backup failed: %v", err)
+            } else {
+                log.Printf("backup written to %s", path)
+            }
+        case <-ctx.Done():
+            return
+        }
+    }
+}
+```
+
+---
+
+## Comparison with VACUUM
+
+| | `Backup` | `VACUUM` |
+|-|----------|---------|
+| Purpose | Off-site copy | Compaction in-place |
+| Writers blocked | ~microseconds | Full duration |
+| Readers blocked | None | Full duration |
+| Output | New file at `destPath` | Replaces current DB file |
+| Preserves source | Yes | Yes (atomic swap) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ for rows.Next() {
 | [Vector Search](vector-search.md) | VECTOR type and HNSW ANN search |
 | [Encryption](encryption.md) | Transparent AES-256-CTR encryption |
 | [Metrics](metrics.md) | Native engine statistics API |
+| [Backup](backup.md) | Online backup while the database is live |
 | [Constraints](constraints.md) | CHECK, FK, NOT NULL, UNIQUE |
 | [System Table](system-table.md) | `minisql_schema` structure |
 | [Limitations](limitations.md) | Known limitations and workarounds |

--- a/e2e_tests/backup_test.go
+++ b/e2e_tests/backup_test.go
@@ -1,0 +1,250 @@
+package e2etests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/RichardKnop/minisql"
+)
+
+func openBackupDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	f, err := os.CreateTemp("", "minisql_backup_src_*.db")
+	require.NoError(t, err)
+	dbPath := f.Name()
+	f.Close()
+	t.Cleanup(func() {
+		os.Remove(dbPath)
+		os.Remove(dbPath + "-wal")
+	})
+	db, err := sql.Open("minisql", dbPath)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db, dbPath
+}
+
+func tempBackupPath(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "minisql_backup_dst_*.db")
+	require.NoError(t, err)
+	path := f.Name()
+	f.Close()
+	os.Remove(path) // Backup creates the file itself
+	t.Cleanup(func() {
+		os.Remove(path)
+		os.Remove(path + "-wal")
+	})
+	return path
+}
+
+func openReadOnly(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("minisql", path)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// TestBackup_Basic verifies that Backup produces a complete, readable copy
+// of the database with all rows intact.
+func TestBackup_Basic(t *testing.T) {
+	ctx := context.Background()
+	src, _ := openBackupDB(t)
+	destPath := tempBackupPath(t)
+
+	_, err := src.ExecContext(ctx, `create table "items" (id int8 primary key autoincrement, name varchar(255))`)
+	require.NoError(t, err)
+
+	const rowCount = 100
+	for i := 0; i < rowCount; i++ {
+		_, err = src.ExecContext(ctx, `insert into "items" (name) values (?)`, fmt.Sprintf("item_%04d", i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, minisql.Backup(ctx, src, destPath))
+
+	dst := openReadOnly(t, destPath)
+	rows, err := dst.QueryContext(ctx, `select id, name from "items" order by id asc`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var id int64
+		var name string
+		require.NoError(t, rows.Scan(&id, &name))
+		got = append(got, name)
+	}
+	require.NoError(t, rows.Err())
+	assert.Len(t, got, rowCount)
+	assert.Equal(t, "item_0000", got[0])
+	assert.Equal(t, fmt.Sprintf("item_%04d", rowCount-1), got[len(got)-1])
+}
+
+// TestBackup_WithPendingWALFrames verifies that Backup captures committed WAL
+// frames that have not yet been checkpointed to the main DB file.
+func TestBackup_WithPendingWALFrames(t *testing.T) {
+	ctx := context.Background()
+	// Use a high checkpoint threshold so no automatic checkpoint fires.
+	f, err := os.CreateTemp("", "minisql_backup_wal_*.db")
+	require.NoError(t, err)
+	srcPath := f.Name()
+	f.Close()
+	t.Cleanup(func() {
+		os.Remove(srcPath)
+		os.Remove(srcPath + "-wal")
+	})
+	src, err := sql.Open("minisql", fmt.Sprintf("%s?wal_checkpoint_threshold=100000", srcPath))
+	require.NoError(t, err)
+	src.SetMaxOpenConns(1)
+	src.SetMaxIdleConns(1)
+	t.Cleanup(func() { src.Close() })
+
+	destPath := tempBackupPath(t)
+
+	_, err = src.ExecContext(ctx, `create table "vals" (id int8 primary key autoincrement, v int8)`)
+	require.NoError(t, err)
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		_, err = src.ExecContext(ctx, `insert into "vals" (v) values (?)`, i*2)
+		require.NoError(t, err)
+	}
+
+	// Verify WAL has frames before backup (checkpoint threshold is very high).
+	m, err := minisql.ReadMetrics(ctx, src)
+	require.NoError(t, err)
+	assert.Positive(t, m.WALCurrentFrames, "expected pending WAL frames before backup")
+
+	require.NoError(t, minisql.Backup(ctx, src, destPath))
+
+	dst := openReadOnly(t, destPath)
+	var count int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select count(*) from "vals"`).Scan(&count))
+	assert.Equal(t, int64(n), count)
+
+	var sum int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select sum(v) from "vals"`).Scan(&sum))
+	// sum of 0,2,4,...,98 = n*(n-1) = 50*49 = 2450 ... actually 2*sum(0..49) = 2*(49*50/2) = 2450
+	assert.Equal(t, int64(n*(n-1)), sum)
+}
+
+// TestBackup_MultipleTables verifies that Backup captures all tables and their
+// indexes correctly.
+func TestBackup_MultipleTables(t *testing.T) {
+	ctx := context.Background()
+	src, _ := openBackupDB(t)
+	destPath := tempBackupPath(t)
+
+	_, err := src.ExecContext(ctx, `create table "users" (id int8 primary key autoincrement, email varchar(255) unique)`)
+	require.NoError(t, err)
+	_, err = src.ExecContext(ctx, `create table "posts" (id int8 primary key autoincrement, user_id int8, title varchar(255))`)
+	require.NoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		_, err = src.ExecContext(ctx, `insert into "users" (email) values (?)`, fmt.Sprintf("user%d@example.com", i))
+		require.NoError(t, err)
+	}
+	for i := 0; i < 40; i++ {
+		_, err = src.ExecContext(ctx, `insert into "posts" (user_id, title) values (?, ?)`, (i%20)+1, fmt.Sprintf("Post %d", i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, minisql.Backup(ctx, src, destPath))
+
+	dst := openReadOnly(t, destPath)
+
+	var userCount, postCount int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select count(*) from "users"`).Scan(&userCount))
+	require.NoError(t, dst.QueryRowContext(ctx, `select count(*) from "posts"`).Scan(&postCount))
+	assert.Equal(t, int64(20), userCount)
+	assert.Equal(t, int64(40), postCount)
+}
+
+// TestBackup_ConcurrentWrites verifies that Backup produces a consistent
+// snapshot even when write transactions are committing concurrently.
+func TestBackup_ConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+	src, _ := openBackupDB(t)
+	destPath := tempBackupPath(t)
+
+	_, err := src.ExecContext(ctx, `create table "counters" (id int8 primary key autoincrement, v int8)`)
+	require.NoError(t, err)
+
+	// Seed some initial rows so the backup has something to copy.
+	const seedRows = 30
+	for i := 0; i < seedRows; i++ {
+		_, err = src.ExecContext(ctx, `insert into "counters" (v) values (?)`, i)
+		require.NoError(t, err)
+	}
+
+	// Run concurrent inserts while the backup executes.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Best-effort inserts; ignore errors (driver may queue behind backup).
+				_, _ = src.ExecContext(ctx, `insert into "counters" (v) values (1)`)
+			}
+		}
+	}()
+
+	require.NoError(t, minisql.Backup(ctx, src, destPath))
+	close(stop)
+	wg.Wait()
+
+	// The backup must be a valid, openable database with at least the seed rows.
+	dst := openReadOnly(t, destPath)
+	var count int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select count(*) from "counters"`).Scan(&count))
+	assert.GreaterOrEqual(t, count, int64(seedRows), "backup must contain at least the seeded rows")
+}
+
+// TestBackup_IsIndependent verifies that writes to the source after the backup
+// do not affect the backup file.
+func TestBackup_IsIndependent(t *testing.T) {
+	ctx := context.Background()
+	src, _ := openBackupDB(t)
+	destPath := tempBackupPath(t)
+
+	_, err := src.ExecContext(ctx, `create table "data" (id int8 primary key autoincrement, x int8)`)
+	require.NoError(t, err)
+	_, err = src.ExecContext(ctx, `insert into "data" (x) values (1), (2), (3)`)
+	require.NoError(t, err)
+
+	require.NoError(t, minisql.Backup(ctx, src, destPath))
+
+	// Mutate the source after backup.
+	_, err = src.ExecContext(ctx, `insert into "data" (x) values (4), (5)`)
+	require.NoError(t, err)
+	_, err = src.ExecContext(ctx, `delete from "data" where x = 1`)
+	require.NoError(t, err)
+
+	// Source now has rows 2,3,4,5 (4 rows). Backup must still have 1,2,3 (3 rows).
+	dst := openReadOnly(t, destPath)
+	var count int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select count(*) from "data"`).Scan(&count))
+	assert.Equal(t, int64(3), count)
+
+	var minX, maxX int64
+	require.NoError(t, dst.QueryRowContext(ctx, `select min(x), max(x) from "data"`).Scan(&minX, &maxX))
+	assert.Equal(t, int64(1), minX)
+	assert.Equal(t, int64(3), maxX)
+}

--- a/internal/minisql/backup.go
+++ b/internal/minisql/backup.go
@@ -84,6 +84,12 @@ func (d *Database) Backup(_ context.Context, destPath string) (retErr error) {
 		}
 	}()
 
+	// backupHook is nil in production; tests inject concurrent operations here
+	// to verify the checkpoint-blocking invariant.
+	if d.backupHook != nil {
+		d.backupHook()
+	}
+
 	// --- PHASE 4: Copy pages (writers unblocked, checkpoints blocked). ---
 	// WAL snapshot bytes take priority.  Pages absent from the snapshot are read
 	// from the DB file — safe because no checkpoint can flush post-snapshot WAL

--- a/internal/minisql/backup.go
+++ b/internal/minisql/backup.go
@@ -1,0 +1,114 @@
+package minisql
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Backup writes a consistent, point-in-time copy of the database to destPath.
+//
+// The algorithm mirrors SQLite's WAL-mode online backup:
+//
+//  1. Begin a read-only snapshot transaction.  CheckpointWAL checks
+//     hasActiveSnapshotReadersLocked before acquiring walWriteMu, so any
+//     checkpoint that starts after this point will be turned away with
+//     ErrCheckpointBlockedByReaders.  This freezes the main DB file from
+//     checkpoint's perspective for the lifetime of the backup.
+//
+//  2. Hold walWriteMu briefly to deep-copy the WAL index (raw page bytes) and
+//     record the current page count.  The deep-copy is necessary because
+//     WALIndex.Reset (called during checkpoint) returns those slices to
+//     pageDataPool; any read after walWriteMu is released would race with reuse.
+//
+//  3. Release walWriteMu — writers proceed immediately.
+//
+//  4. For every page index 0..N-1:
+//     - If the page has an entry in the WAL snapshot use those bytes
+//       (committed but not yet checkpointed at snapshot time).
+//     - Otherwise read directly from the main DB file.
+//     Because checkpoints are blocked by step 1, the DB file cannot be
+//     modified by post-snapshot transactions during this phase.
+//
+//  5. Release the read-only snapshot, sync, and close the destination.
+//
+// The destination is a standalone database file that can be opened directly
+// with sql.Open("minisql", destPath).  It carries no WAL file.  If the source
+// is encrypted the backup is encrypted with the same key.
+//
+// Backup must not be called from inside an explicit user transaction.
+func (d *Database) Backup(_ context.Context, destPath string) (retErr error) {
+	if d.walDBFile == nil || d.walIndex == nil {
+		return fmt.Errorf("backup: database is not in WAL mode")
+	}
+
+	// --- PHASE 1: Begin a read-only snapshot to block checkpoints. ---
+	// A checkpoint that starts after this point will see an active snapshot
+	// reader and return ErrCheckpointBlockedByReaders without modifying the DB
+	// file.  This guarantees that all ReadAt calls in phase 4 see DB file pages
+	// at their pre-snapshot versions, even if writers commit and trigger
+	// auto-checkpoint attempts during the copy.
+	snapCtx := context.Background()
+	snapTx := d.txManager.BeginReadOnlyTransaction(snapCtx)
+	snapCtx = WithTransaction(snapCtx, snapTx)
+	defer func() {
+		d.txManager.RollbackTransaction(snapCtx, snapTx)
+	}()
+
+	// --- PHASE 2: Snapshot WAL index and page count under walWriteMu. ---
+	// If a checkpoint is already in progress (holding walWriteMu) we block here
+	// until it completes.  Subsequent checkpoint attempts are blocked by phase 1.
+	d.txManager.walWriteMu.Lock()
+	rawSnapshot := d.walIndex.SnapshotSorted()
+	walMap := make(map[PageIndex][]byte, len(rawSnapshot))
+	for _, p := range rawSnapshot {
+		buf := make([]byte, len(p.Data))
+		copy(buf, p.Data)
+		walMap[p.Index] = buf
+	}
+	totalPages := d.saver.TotalPages()
+	d.txManager.walWriteMu.Unlock()
+
+	if totalPages == 0 {
+		return fmt.Errorf("backup: database is empty")
+	}
+
+	// --- PHASE 3: Open destination file. ---
+	destFile, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("backup: create destination: %w", err)
+	}
+	defer func() {
+		if cerr := destFile.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("backup: close destination: %w", cerr)
+		}
+	}()
+
+	// --- PHASE 4: Copy pages (writers unblocked, checkpoints blocked). ---
+	// WAL snapshot bytes take priority.  Pages absent from the snapshot are read
+	// from the DB file — safe because no checkpoint can flush post-snapshot WAL
+	// frames to the DB file while the snapshot transaction is active.
+	readBuf := make([]byte, PageSize)
+	for idx := PageIndex(0); idx < PageIndex(totalPages); idx++ {
+		offset := int64(idx) * int64(PageSize)
+		if data, ok := walMap[idx]; ok {
+			if _, err = destFile.WriteAt(data, offset); err != nil {
+				return fmt.Errorf("backup: write WAL page %d: %w", idx, err)
+			}
+		} else {
+			if _, err = d.walDBFile.ReadAt(readBuf, offset); err != nil {
+				return fmt.Errorf("backup: read DB page %d: %w", idx, err)
+			}
+			if _, err = destFile.WriteAt(readBuf, offset); err != nil {
+				return fmt.Errorf("backup: write DB page %d: %w", idx, err)
+			}
+		}
+	}
+
+	// --- PHASE 5: Sync destination and release snapshot (deferred above). ---
+	if err = destFile.Sync(); err != nil {
+		return fmt.Errorf("backup: sync destination: %w", err)
+	}
+
+	return nil
+}

--- a/internal/minisql/backup_test.go
+++ b/internal/minisql/backup_test.go
@@ -45,7 +45,7 @@ func newBackupTestDB(t *testing.T) (*Database, string) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		db.Close()
+		require.NoError(t, db.Close())
 		os.Remove(dbPath)
 		os.Remove(dbPath + "-wal")
 	})
@@ -199,7 +199,7 @@ func TestBackup_CheckpointBlockedDuringCopy(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer func() {
-		backupDB.Close()
+		require.NoError(t, backupDB.Close())
 		os.Remove(destPath + "-wal")
 	}()
 

--- a/internal/minisql/backup_test.go
+++ b/internal/minisql/backup_test.go
@@ -1,0 +1,215 @@
+package minisql
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// backupColumns is a minimal two-column schema for backup tests.
+var backupColumns = []Column{
+	{Kind: Int8, Size: 8, Name: "id"},
+	{Kind: Int8, Size: 8, Name: "v"},
+}
+
+// newBackupTestDB creates a WAL-enabled temp database and returns the
+// Database, its file path, and the WAL file path (for cleanup).
+func newBackupTestDB(t *testing.T) (*Database, string) {
+	t.Helper()
+
+	dbFile, err := os.CreateTemp("", "backup_test_*.db")
+	require.NoError(t, err)
+	dbPath := dbFile.Name()
+
+	walIndex := NewWALIndex()
+	wal, _, err := OpenWALAndRebuildIndex(dbPath, PageSize, walIndex)
+	require.NoError(t, err)
+
+	pager, err := NewPager(dbFile, PageSize, PageCacheSize)
+	require.NoError(t, err)
+
+	db, err := NewDatabase(
+		context.Background(), testLogger, dbPath, nil, pager, pager,
+		&WALConfig{
+			WAL:                 wal,
+			Index:               walIndex,
+			DBFile:              dbFile,
+			CheckpointThreshold: 10000, // high threshold: no auto-checkpoint
+		},
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(dbPath)
+		os.Remove(dbPath + "-wal")
+	})
+
+	return db, dbPath
+}
+
+// insertBackupRows inserts n rows with v = startVal, startVal+1, ... into tbl.
+func insertBackupRows(t *testing.T, db *Database, tbl *Table, n, startVal int) {
+	t.Helper()
+	ctx := context.Background()
+	fields := fieldsFromColumns(tbl.Columns...)
+	err := db.txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+		for i := 0; i < n; i++ {
+			row := []OptionalValue{
+				{Value: int64(startVal + i)},
+				{Value: int64(startVal + i)},
+			}
+			if _, err := tbl.Insert(txCtx, Statement{
+				Kind:    Insert,
+				Fields:  fields,
+				Inserts: [][]OptionalValue{row},
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// countBackupRows returns the row count in tbl via a direct table scan.
+func countBackupRows(t *testing.T, db *Database, tbl *Table) int {
+	t.Helper()
+	ctx := context.Background()
+	count := 0
+	err := db.txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+		result, err := tbl.Select(txCtx, Statement{
+			Kind:   Select,
+			Fields: fieldsFromColumns(tbl.Columns...),
+		})
+		if err != nil {
+			return err
+		}
+		for result.Rows.Next(txCtx) {
+			count++
+		}
+		return result.Rows.Err()
+	})
+	require.NoError(t, err)
+	return count
+}
+
+// TestBackup_CheckpointBlockedDuringCopy is the targeted test for the
+// correctness edge case: a write transaction that commits after the WAL
+// snapshot must not appear in the backup, even when it triggers a checkpoint
+// that would otherwise flush its pages into the main DB file.
+//
+// The backupHook fires after the WAL snapshot is taken and walWriteMu is
+// released — exactly the window where a checkpoint could contaminate the DB
+// file if the backup did not hold a read-only snapshot transaction.
+//
+// The test verifies two things:
+//  1. The checkpoint attempt INSIDE the hook is rejected with
+//     ErrCheckpointBlockedByReaders — proving the backup's snapshot
+//     transaction is live and correctly blocking checkpoints.
+//  2. The backup file contains only the data committed before the snapshot,
+//     not the data written by the hook.
+func TestBackup_CheckpointBlockedDuringCopy(t *testing.T) {
+	ctx := context.Background()
+	db, dbPath := newBackupTestDB(t)
+
+	// Create the test table.
+	createStmt := Statement{
+		Kind:      CreateTable,
+		TableName: "items",
+		Columns:   append([]Column{}, backupColumns...),
+	}
+	err := db.txManager.ExecuteInTransaction(ctx, func(txCtx context.Context) error {
+		_, err := db.ExecuteStatement(txCtx, createStmt)
+		return err
+	})
+	require.NoError(t, err)
+
+	tbl, ok := db.tables["items"]
+	require.True(t, ok)
+
+	// Write 10 pre-snapshot rows. These must appear in the backup.
+	insertBackupRows(t, db, tbl, 10, 1)
+
+	// Force a checkpoint so the pre-snapshot rows are in the DB file and the
+	// WAL is empty before we take the backup snapshot.
+	require.NoError(t, db.Checkpoint(ctx))
+
+	// Write 5 more rows to the WAL (not yet checkpointed).
+	// These are also pre-snapshot and must appear in the backup.
+	insertBackupRows(t, db, tbl, 5, 100)
+
+	// Verify the live database has 15 rows before backup.
+	assert.Equal(t, 15, countBackupRows(t, db, tbl))
+
+	// Install the hook. It fires after the backup has taken its WAL snapshot
+	// and released walWriteMu but before the page-copy loop starts.
+	var (
+		hookFired          bool
+		checkpointBlocked  bool
+	)
+	db.backupHook = func() {
+		hookFired = true
+
+		// Write 5 post-snapshot rows. These must NOT appear in the backup.
+		insertBackupRows(t, db, tbl, 5, 200)
+
+		// Attempt a manual checkpoint. The backup holds a read-only snapshot
+		// transaction, so this must be rejected.
+		checkpointErr := db.Checkpoint(ctx)
+		checkpointBlocked = errors.Is(checkpointErr, ErrCheckpointBlockedByReaders)
+	}
+
+	destPath := dbPath + ".backup"
+	t.Cleanup(func() {
+		os.Remove(destPath)
+		os.Remove(destPath + "-wal")
+	})
+
+	require.NoError(t, db.Backup(ctx, destPath))
+
+	// The hook must have fired and the checkpoint must have been blocked.
+	assert.True(t, hookFired, "backupHook did not fire")
+	assert.True(t, checkpointBlocked,
+		"checkpoint should have been blocked by the backup's snapshot transaction")
+
+	// Open the backup as a fresh database and count its rows.
+	// MockParser is required so initTable can parse the stored DDL for "items".
+	backupParser := new(MockParser)
+	backupParser.On("Parse", mock.Anything, createStmt.DDL()).Return([]Statement{createStmt}, nil)
+
+	backupFile, err := os.OpenFile(destPath, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+
+	backupWALIndex := NewWALIndex()
+	backupWAL, _, err := OpenWALAndRebuildIndex(destPath, PageSize, backupWALIndex)
+	require.NoError(t, err)
+
+	backupPager, err := NewPager(backupFile, PageSize, PageCacheSize)
+	require.NoError(t, err)
+
+	backupDB, err := NewDatabase(
+		ctx, testLogger, destPath, backupParser, backupPager, backupPager,
+		&WALConfig{WAL: backupWAL, Index: backupWALIndex, DBFile: backupFile},
+	)
+	require.NoError(t, err)
+	defer func() {
+		backupDB.Close()
+		os.Remove(destPath + "-wal")
+	}()
+
+	backupTbl, ok := backupDB.tables["items"]
+	require.True(t, ok, "backup database must have the 'items' table")
+
+	backupCount := countBackupRows(t, backupDB, backupTbl)
+
+	// Backup must contain the 10 DB-file rows + 5 WAL-snapshot rows = 15.
+	// The 5 rows written by the hook (post-snapshot) must NOT be present.
+	assert.Equal(t, 15, backupCount,
+		"backup should contain exactly 15 rows (10 checkpointed + 5 from WAL snapshot), not the 5 post-snapshot rows written during the hook")
+}

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -73,6 +73,10 @@ type Database struct {
 	// sortMemLimit is the maximum bytes of row data accumulated in memory before
 	// spilling a sorted run to disk during ORDER BY. 0 disables external sort.
 	sortMemLimit int64
+	// backupHook is called by Backup after the WAL snapshot is taken and
+	// walWriteMu is released, just before the page-copy loop begins.
+	// Nil in production; set by tests to inject concurrent operations.
+	backupHook func()
 }
 
 type clock func() Time


### PR DESCRIPTION
minisql.Backup(ctx, db, destPath) creates a consistent point-in-time copy of the database while it remains fully readable and writable.

Algorithm mirrors SQLite's WAL-mode online backup: walWriteMu is held only long enough to deep-copy the WAL index and record the page count (microseconds), then released so writers proceed immediately. The page-copy loop reads WAL snapshot bytes for uncommitted-to-disk pages and ReadAt from the main DB file for the rest. Deep-copying the WAL index bytes before releasing walWriteMu is the key correctness detail — WALIndex.Reset() during a concurrent checkpoint returns those slices to pageDataPool, so the backup must own its copies first.

Five e2e tests: basic round-trip, pending WAL frames (high checkpoint threshold), multiple tables, concurrent writes, and post-backup source independence.