### PR TITLE
Add cross-platform release workflow with cosign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # create GitHub release and upload assets
+  id-token: write   # cosign keyless signing via OIDC
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # goreleaser needs full history for changelog
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: sigstore/cosign-installer@v3
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,72 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: minisql
+    main: ./cmd/minisql
+    binary: minisql
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    # skip arm64 on Windows — no native runner and very rare in practice.
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - id: minisql
+    ids: [minisql]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: RichardKnop
+    name: minisql
+  draft: false
+  prerelease: auto
+  name_template: "{{.ProjectName}} {{.Tag}}"

--- a/cmd/minisql/main.go
+++ b/cmd/minisql/main.go
@@ -9,6 +9,13 @@ import (
 	_ "github.com/RichardKnop/minisql"
 )
 
+// Set by goreleaser via -ldflags at release time.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 const usage = `Usage: minisql [options] <database-file>
 
 Opens (or creates) a MiniSQL database and starts an interactive SQL shell.
@@ -16,10 +23,11 @@ SQL statements must be terminated with a semicolon (;).
 Enter ".help" for dot command reference.
 
 Options:
-  -c <query>   Execute a single SQL statement and exit (no shell).
-               May be specified multiple times to run several statements.
-  -csv         Set output mode to CSV (default: table).
-  -h, --help   Show this message.
+  -c <query>      Execute a single SQL statement and exit (no shell).
+                  May be specified multiple times to run several statements.
+  -csv            Set output mode to CSV (default: table).
+  -version        Print version information and exit.
+  -h, --help      Show this message.
 
 Examples:
   minisql my.db
@@ -30,13 +38,20 @@ Examples:
 
 func main() {
 	var (
-		queries multiFlag
-		csvMode bool
+		queries     multiFlag
+		csvMode     bool
+		showVersion bool
 	)
 	flag.Var(&queries, "c", "SQL statement to execute (may be repeated)")
 	flag.BoolVar(&csvMode, "csv", false, "output in CSV format")
+	flag.BoolVar(&showVersion, "version", false, "print version and exit")
 	flag.Usage = func() { fmt.Fprint(os.Stderr, usage) }
 	flag.Parse()
+
+	if showVersion {
+		fmt.Printf("minisql %s (commit %s, built %s)\n", version, commit, date)
+		return
+	}
 
 	if flag.NArg() != 1 {
 		fmt.Fprint(os.Stderr, usage)


### PR DESCRIPTION
- .goreleaser.yaml: builds minisql CLI for linux/darwin/windows on amd64 and arm64 (arm64 excluded on Windows). Archives include LICENSE and README.md; checksums.txt is signed keylessly via cosign/Sigstore. ldflags inject version, commit, and date at build time.
- .github/workflows/release.yml: triggered on v* tags; runs GoReleaser v2 with cosign installed for keyless OIDC signing.
- cmd/minisql/main.go: add version/commit/date vars (set by ldflags) and a -version flag that prints them.