### PR TITLE
Fix Windows build: split sync_file.go into platform-specific files

### DIFF
--- a/internal/minisql/sync_file_unix.go
+++ b/internal/minisql/sync_file_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package minisql
 
 import (

--- a/internal/minisql/sync_file_windows.go
+++ b/internal/minisql/sync_file_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package minisql
+
+import "os"
+
+// syscallFsync on Windows delegates to f.Sync(), which calls FlushFileBuffers.
+// The POSIX fsync(2) bypass in sync_file_unix.go is macOS-specific (avoiding
+// F_FULLFSYNC); it does not apply on Windows.
+func syscallFsync(f *os.File) error {
+	return f.Sync()
+}
+
+// fastSync calls syscallFsync when the DBFile is a plain *os.File, and falls
+// back to the interface's Sync() method for any other implementation (mocks,
+// in-memory files used in tests, etc.).
+func fastSync(f DBFile) error {
+	if osf, ok := f.(*os.File); ok {
+		return syscallFsync(osf)
+	}
+	return f.Sync()
+}


### PR DESCRIPTION
syscall.Fsync on Windows takes syscall.Handle (uintptr), not int — the original file would not compile for GOOS=windows. The POSIX fsync(2) bypass is macOS-specific (avoiding F_FULLFSYNC); on Windows f.Sync() correctly calls FlushFileBuffers, so the Windows stub just delegates to that.