### PR TITLE
Add Homebrew tap auto-update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,25 @@ signs:
     artifacts: checksum
     output: true
 
+brews:
+  - name: minisql
+    ids: [minisql]
+    repository:
+      owner: RichardKnop
+      name: homebrew-minisql
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore: update minisql formula to {{ .Tag }}"
+    homepage: "https://github.com/RichardKnop/minisql"
+    description: "Embedded single-file SQL database in pure Go — faster than SQLite on latency benchmarks."
+    license: "Apache-2.0"
+    install: |
+      bin.install "minisql"
+    test: |
+      system "#{bin}/minisql", "-version"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
GoReleaser will push an updated Formula/minisql.rb to RichardKnop/homebrew-minisql after each tagged release. Requires HOMEBREW_TAP_GITHUB_TOKEN secret in repo settings (PAT with write access to the tap repo).

After setup, users can install via:
  brew install richardknop/minisql/minisql