### PR TITLE
Raise inline text threshold to 512 and encode overflow flag in bit31

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Page layout (4 096 bytes)
 └── CRC32 checksum — last 4 bytes
 ```
 
-Usable inline cell space per non-root page is **~4 061 bytes**. Large values (TEXT/JSON > 255 bytes, all VECTOR data) spill onto **overflow pages** chained via next-page pointers, bypassing the per-page limit.
+Usable inline cell space per non-root page is **~4 061 bytes**. Large values (TEXT/JSON > 512 bytes, all VECTOR data) spill onto **overflow pages** chained via next-page pointers, bypassing the per-page limit.
 
 ### B+ Tree
 

--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -9,8 +9,8 @@
 | `INT8` | 8 bytes | −9 223 372 036 854 775 808 … 9 223 372 036 854 775 807 | `int64` | 64-bit signed integer; required for `AUTOINCREMENT` |
 | `REAL` | 4 bytes | IEEE 754 single-precision | `float32` | |
 | `DOUBLE` | 8 bytes | IEEE 754 double-precision | `float64` | |
-| `VARCHAR(n)` | Variable, ≤ 255 bytes inline | At most *n* bytes | `string` | Inline storage up to 255 bytes; overflow pages for larger values |
-| `TEXT` | Variable, unlimited | UTF-8 text | `string` | Always uses overflow pages for values > 255 bytes |
+| `VARCHAR(n)` | Variable, ≤ 512 bytes inline | At most *n* bytes | `string` | Inline storage up to 512 bytes; overflow pages for larger values |
+| `TEXT` | Variable, unlimited | UTF-8 text | `string` | Always uses overflow pages for values > 512 bytes |
 | `TIMESTAMP` | 8 bytes | 4713 BC … 294 276 AD | `time.Time` | Microseconds since 2000-01-01 (PostgreSQL epoch); timezone-naive |
 | `JSON` | Variable, unlimited | Valid UTF-8 JSON text | `string` | Validated on insert/update; overflow pages for large values |
 | `UUID` | 16 bytes (fixed) | Hyphenated string `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` | `string` | Stored as inline binary; output is lowercase |
@@ -62,8 +62,8 @@ CREATE TABLE users (
 );
 ```
 
-- Values up to 255 bytes are stored **inline** in the leaf cell.
-- Values longer than 255 bytes spill onto overflow pages (VARCHAR effectively becomes TEXT for large values).
+- Values up to 512 bytes are stored **inline** in the leaf cell.
+- Values longer than 512 bytes spill onto overflow pages (VARCHAR effectively becomes TEXT for large values).
 - Can be used as primary key or unique key columns (up to 255 bytes).
 
 ### TEXT

--- a/internal/minisql/insert_test.go
+++ b/internal/minisql/insert_test.go
@@ -329,7 +329,7 @@ func TestTable_Insert_Overflow(t *testing.T) {
 		assert.NotNil(t, pager.pages[0].LeafNode)
 		assert.NotNil(t, pager.pages[1].OverflowPage)
 		assert.Equal(t, 0, int(pager.pages[1].OverflowPage.Header.NextPage))
-		assert.Equal(t, 355, int(pager.pages[1].OverflowPage.Header.DataSize))
+		assert.Equal(t, int(MaxInlineVarchar+100), int(pager.pages[1].OverflowPage.Header.DataSize))
 	})
 
 	t.Run("Now insert a text that will overflow to a 2 pages", func(t *testing.T) {

--- a/internal/minisql/integrity_check_test.go
+++ b/internal/minisql/integrity_check_test.go
@@ -523,7 +523,7 @@ func addQuickCheckTestTableWithSecondaryIndex(db *Database, pager *pagerImpl, ta
 		},
 		{
 			Kind:     Varchar,
-			Size:     MaxInlineVarchar,
+			Size:     MaxIndexKeySize,
 			Name:     "email",
 			Nullable: true,
 		},

--- a/internal/minisql/intersect_test.go
+++ b/internal/minisql/intersect_test.go
@@ -133,8 +133,8 @@ func intersectTestTable(t *testing.T) (*Table, *TransactionManager) {
 	const tblName = "events"
 	cols := []Column{
 		{Kind: Int8, Size: 8, Name: "id"},
-		{Kind: Varchar, Size: MaxInlineVarchar, Name: "cat"},
-		{Kind: Varchar, Size: MaxInlineVarchar, Name: "status"},
+		{Kind: Varchar, Size: MaxIndexKeySize, Name: "cat"},
+		{Kind: Varchar, Size: MaxIndexKeySize, Name: "status"},
 	}
 
 	createStmt := Statement{

--- a/internal/minisql/minisql_test.go
+++ b/internal/minisql/minisql_test.go
@@ -35,7 +35,7 @@ var (
 		},
 		{
 			Kind:     Varchar,
-			Size:     MaxInlineVarchar,
+			Size:     MaxIndexKeySize,
 			Name:     "email",
 			Nullable: true,
 		},
@@ -66,9 +66,9 @@ var (
 			DefaultValue: OptionalValue{Value: MustParseTimestampMicros("0001-01-01 00:00:00.000000"), Valid: true},
 		},
 	}
-	testRowSize = uint64(8 + 4 + 255 + 4 + 1 + 4 + 8) // calculated size of testColumns
+	testRowSize = uint64(8 + (varcharLengthPrefixSize + MaxIndexKeySize) + 4 + 1 + 4 + 8) // calculated size of testColumns
 
-	mediumRowBaseSize = uint32(8 + (varcharLengthPrefixSize + MaxInlineVarchar) + 4 + 1 + 4 + 8)
+	mediumRowBaseSize = uint32(8 + (varcharLengthPrefixSize + MaxIndexKeySize) + 4 + 1 + 4 + 8)
 	// Append varchars until row size is so that 5 of these full rows can fit into a page
 	testMediumColumns = appendUntilSize(
 		[]Column{
@@ -79,7 +79,7 @@ var (
 			},
 			{
 				Kind:     Varchar,
-				Size:     MaxInlineVarchar,
+				Size:     MaxIndexKeySize,
 				Name:     "email",
 				Nullable: true,
 			},
@@ -121,7 +121,7 @@ var (
 			5*mediumRowBaseSize)/5),
 	)
 
-	bigRowBaseSize = uint32(8 + (varcharLengthPrefixSize + MaxInlineVarchar) + 4 + 1 + 4 + 8)
+	bigRowBaseSize = uint32(8 + (varcharLengthPrefixSize + MaxIndexKeySize) + 4 + 1 + 4 + 8)
 	// Append varcharts until row size is so that one full row fills en entire page
 	testBigColumns = appendUntilSize(
 		[]Column{
@@ -132,7 +132,7 @@ var (
 			},
 			{
 				Kind:     Varchar,
-				Size:     MaxInlineVarchar,
+				Size:     MaxIndexKeySize,
 				Name:     "email",
 				Nullable: true,
 			},
@@ -241,7 +241,7 @@ func (g *dataGen) Row() Row {
 
 func (g *dataGen) paddedEmail() TextPointer {
 	email := g.Email()
-	paddingLength := MaxInlineVarchar - len(email)
+	paddingLength := MaxIndexKeySize - len(email)
 	parts := strings.Split(email, "@")
 	parts[0] += "+"
 	for i := 0; i < paddingLength-1; i++ {

--- a/internal/minisql/overflow_page.go
+++ b/internal/minisql/overflow_page.go
@@ -7,7 +7,7 @@ import (
 const (
 	// MaxInlineVarchar is the maximum number of bytes stored directly inside a
 	// leaf cell before the value is spilled to overflow pages.
-	MaxInlineVarchar = 255 // Store up to 255 bytes inline
+	MaxInlineVarchar = 512 // Store up to 512 bytes inline
 	// MaxOverflowPageData is the maximum number of data bytes that fit in a
 	// single overflow page (page size − type byte − header − 4-byte checksum).
 	MaxOverflowPageData = PageSize - 1 - 8 - pageChecksumSize

--- a/internal/minisql/row_test.go
+++ b/internal/minisql/row_test.go
@@ -52,7 +52,7 @@ func TestRow_Marshal(t *testing.T) {
 		// 1 for boolean
 		// 4 for real
 		// 8 for timestamp
-		assert.Equal(t, uint64(8+(varcharLengthPrefixSize+MaxInlineVarchar)+4+1+4+8), row.Size())
+		assert.Equal(t, uint64(8+(varcharLengthPrefixSize+MaxIndexKeySize)+4+1+4+8), row.Size())
 
 		data, err := row.Marshal()
 		require.NoError(t, err)

--- a/internal/minisql/stmt_test.go
+++ b/internal/minisql/stmt_test.go
@@ -583,7 +583,7 @@ func TestStatement_Validate(t *testing.T) {
 			{
 				Name: "id",
 				Kind: Varchar,
-				Size: MaxInlineVarchar,
+				Size: MaxIndexKeySize,
 			},
 		}
 		stmt := Statement{
@@ -916,14 +916,14 @@ func TestStatement_Validate(t *testing.T) {
 			Inserts: [][]OptionalValue{
 				{
 					{Value: int32(1), Valid: true},
-					{Value: NewTextPointer(bytes.Repeat([]byte{'a'}, 256)), Valid: true},
+					{Value: NewTextPointer(bytes.Repeat([]byte{'a'}, MaxInlineVarchar+1)), Valid: true},
 				},
 			},
 		}
 
 		err := stmt.Validate(table)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, `field "email" exceeds maximum VARCHAR length of 255`)
+		assert.ErrorContains(t, err, fmt.Sprintf(`field "email" exceeds maximum VARCHAR length of %d`, MaxInlineVarchar))
 	})
 
 	t.Run("UPDATE with unknown field should fail", func(t *testing.T) {
@@ -1512,7 +1512,7 @@ func TestStatement_DDL(t *testing.T) {
 			},
 			{
 				Kind: Varchar,
-				Size: MaxInlineVarchar,
+				Size: 255,
 				Name: "c",
 			},
 			{

--- a/internal/minisql/text_pointer.go
+++ b/internal/minisql/text_pointer.go
@@ -6,6 +6,11 @@ import (
 	"fmt"
 )
 
+// textOverflowFlag occupies bit 31 of the on-disk uint32 length field.
+// When set the value is stored on overflow pages; when clear the value is inline.
+// The lower 31 bits always hold the actual byte length, so text up to 2 GiB is supported.
+const textOverflowFlag uint32 = 1 << 31
+
 // TextPointer is stored in the main row; text of length <= MaxInlineVarchar is stored inline,
 // otherwise it points to an overflow page.
 type TextPointer struct {
@@ -50,55 +55,55 @@ func (tp TextPointer) NumberOfPages() uint32 {
 	return tp.Length/MaxOverflowPageData + 1
 }
 
-// Marshal serialises the pointer into buf at offset i: a 4-byte length prefix
-// followed by either the inline data or the first overflow page index.
+// Marshal serialises the pointer into buf at offset i.
+// Inline:   [uint32 length (bit31=0)][length bytes of data]
+// Overflow: [uint32 length | textOverflowFlag (bit31=1)][uint32 first_page_index]
 func (tp *TextPointer) Marshal(buf []byte, i uint64) error {
-	// Write length prefix
-	marshalUint32(buf, tp.Length, i)
-	i += 4
-
 	if tp.IsInline() {
-		// Write actual text
-		n := copy(buf[i:i+uint64(tp.Length)], tp.Data)
-		i += uint64(n)
+		marshalUint32(buf, tp.Length, i) // bit31 = 0: inline
+		i += 4
+		copy(buf[i:i+uint64(tp.Length)], tp.Data)
 		return nil
 	}
 
-	// Write first overflow page index
-	marshalUint32(buf, uint32(tp.FirstPage), i)
+	marshalUint32(buf, tp.Length|textOverflowFlag, i) // bit31 = 1: overflow
 	i += 4
-
+	marshalUint32(buf, uint32(tp.FirstPage), i)
 	return nil
 }
 
 // Unmarshal reads a text pointer from buf at offset i. For inline text, Data
 // is sub-sliced directly into the page buffer (zero-copy). For overflow text,
 // only FirstPage is set; actual data is loaded later by readOverflowTexts.
+//
+// The on-disk format uses bit 31 of the uint32 length field as an overflow flag
+// (textOverflowFlag) so the inline/overflow distinction is stored on disk and
+// does not depend on the value of MaxInlineVarchar at read time.
 func (tp *TextPointer) Unmarshal(buf []byte, i uint64) error {
 	if i+4 > uint64(len(buf)) {
 		return fmt.Errorf("text pointer unmarshal: buffer too short for length prefix at offset %d (have %d bytes)", i, len(buf))
 	}
-	// Read length prefix
-	tp.Length = unmarshalUint32(buf, i)
+	stored := unmarshalUint32(buf, i)
 	i += 4
 
-	if tp.IsInline() {
-		if i+uint64(tp.Length) > uint64(len(buf)) {
-			return fmt.Errorf("text pointer unmarshal: buffer too short for inline data (need %d bytes at offset %d, have %d)", tp.Length, i, len(buf))
+	if stored&textOverflowFlag != 0 {
+		// Overflow: actual length is stored in bits 0–30.
+		tp.Length = stored &^ textOverflowFlag
+		if i+4 > uint64(len(buf)) {
+			return fmt.Errorf("text pointer unmarshal: buffer too short for overflow page index at offset %d (have %d bytes)", i, len(buf))
 		}
-		// Sub-slice page buffer directly — zero allocation, zero copy.
-		// Inline text is read-only after unmarshal; Marshal copies it out via copy().
-		tp.Data = buf[i : i+uint64(tp.Length)]
-		i += uint64(tp.Length)
+		tp.FirstPage = PageIndex(unmarshalUint32(buf, i))
 		return nil
 	}
 
-	// Read first overflow page index
-	if i+4 > uint64(len(buf)) {
-		return fmt.Errorf("text pointer unmarshal: buffer too short for overflow page index at offset %d (have %d bytes)", i, len(buf))
+	// Inline: stored value is the actual length (bit31 = 0).
+	tp.Length = stored
+	if i+uint64(tp.Length) > uint64(len(buf)) {
+		return fmt.Errorf("text pointer unmarshal: buffer too short for inline data (need %d bytes at offset %d, have %d)", tp.Length, i, len(buf))
 	}
-	tp.FirstPage = PageIndex(unmarshalUint32(buf, i))
-	i += 4
+	// Sub-slice page buffer directly — zero allocation, zero copy.
+	// Inline text is read-only after unmarshal; Marshal copies it out via copy().
+	tp.Data = buf[i : i+uint64(tp.Length)]
 	return nil
 }
 

--- a/internal/minisql/update_test.go
+++ b/internal/minisql/update_test.go
@@ -268,7 +268,7 @@ func TestTable_Update_Overflow(t *testing.T) {
 
 		assert.Equal(t, MaxOverflowPageData, int(pager.pages[2].OverflowPage.Header.DataSize))
 		assert.Equal(t, 100, int(pager.pages[3].OverflowPage.Header.DataSize))
-		assert.Equal(t, 455, int(pager.pages[4].OverflowPage.Header.DataSize))
+		assert.Equal(t, int(MaxInlineVarchar+200), int(pager.pages[4].OverflowPage.Header.DataSize))
 	})
 
 	t.Run("Update overflow text to inline text", func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestTable_Update_Overflow(t *testing.T) {
 
 		assert.Equal(t, MaxOverflowPageData, int(pager.pages[2].OverflowPage.Header.DataSize))
 		assert.Equal(t, 100, int(pager.pages[3].OverflowPage.Header.DataSize))
-		assert.Equal(t, 455, int(pager.pages[4].OverflowPage.Header.DataSize))
+		assert.Equal(t, int(MaxInlineVarchar+200), int(pager.pages[4].OverflowPage.Header.DataSize))
 
 		assertFreePages(t, tablePager, []PageIndex{1})
 	})
@@ -371,7 +371,7 @@ func TestTable_Update_Overflow(t *testing.T) {
 		assert.Equal(t, 0, int(pager.pages[4].OverflowPage.Header.NextPage))
 
 		assert.Equal(t, MaxOverflowPageData-100, int(pager.pages[3].OverflowPage.Header.DataSize))
-		assert.Equal(t, 455, int(pager.pages[4].OverflowPage.Header.DataSize))
+		assert.Equal(t, int(MaxInlineVarchar+200), int(pager.pages[4].OverflowPage.Header.DataSize))
 
 		assertFreePages(t, tablePager, []PageIndex{2, 1})
 	})

--- a/internal/parser/table_test.go
+++ b/internal/parser/table_test.go
@@ -21,7 +21,7 @@ func TestParse_CreateTable(t *testing.T) {
 	emailColumn := minisql.Column{
 		Name:     "email",
 		Kind:     minisql.Varchar,
-		Size:     minisql.MaxInlineVarchar,
+		Size:     255,
 		Nullable: true,
 	}
 
@@ -194,7 +194,7 @@ func TestParse_CreateTable(t *testing.T) {
 						{
 							Name:     "bar",
 							Kind:     minisql.Varchar,
-							Size:     minisql.MaxInlineVarchar,
+							Size:     255,
 							Nullable: true,
 						},
 					},
@@ -305,7 +305,7 @@ func TestParse_CreateTable(t *testing.T) {
 						{
 							Name:     "sit",
 							Kind:     minisql.Varchar,
-							Size:     minisql.MaxInlineVarchar,
+							Size:     255,
 							Nullable: true,
 						},
 					},
@@ -368,7 +368,7 @@ func TestParse_CreateTable(t *testing.T) {
 						{
 							Name:     "bar",
 							Kind:     minisql.Varchar,
-							Size:     minisql.MaxInlineVarchar,
+							Size:     255,
 							Nullable: true,
 						},
 					},


### PR DESCRIPTION
MaxInlineVarchar is raised from 255 to 512 to reduce overflow page allocations for typical medium-length text fields. The inline/overflow distinction is now encoded in bit 31 of the on-disk uint32 length prefix (textOverflowFlag = 1 << 31) so the threshold can be changed freely in future without corrupting existing data.

Test columns used as index keys are updated to MaxIndexKeySize (255) since the inline storage limit and the B-tree key size limit are now independent constants.