### PR TITLE
Add package godoc, and fix stale driver boilerplate

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,86 @@
+// Package minisql is an embedded, single-file SQL database written in pure Go.
+//
+// # Quick start
+//
+// MiniSQL registers itself as a [database/sql] driver under the name "minisql".
+// Import the package for its side effects and open the database with
+// [database/sql.Open]:
+//
+//	import (
+//	    "database/sql"
+//	    _ "github.com/RichardKnop/minisql"
+//	)
+//
+//	db, err := sql.Open("minisql", "./app.db")
+//	if err != nil { log.Fatal(err) }
+//
+//	// MiniSQL requires exactly one connection per file.
+//	db.SetMaxOpenConns(1)
+//	db.SetMaxIdleConns(1)
+//	defer db.Close()
+//
+// # Connection string
+//
+// The data source name is a file path with optional query parameters:
+//
+//	./app.db
+//	./app.db?wal_checkpoint_threshold=500
+//	./app.db?log_level=debug&max_cached_pages=4000
+//	./app.db?encryption_key=<hex-encoded-32-byte-key>
+//
+// See [ParseConnectionString] for the full parameter reference.
+//
+// # Storage model
+//
+// The database is a sequence of 4 096-byte pages stored in a single file.
+// Every page ends with a CRC32-IEEE checksum; a mismatch returns an error
+// immediately. Tables and indexes are each stored as independent B+ trees.
+// Text and JSON values longer than 512 bytes spill onto overflow pages chained
+// by next-page pointers. All vector data lives on overflow pages.
+//
+// # Write-Ahead Log (WAL)
+//
+// All commits write modified pages to a WAL file ({dbpath}-wal) before the
+// main database file is touched. The WAL is replayed automatically on startup
+// after a crash. An automatic checkpoint copies WAL pages back to the main file
+// after wal_checkpoint_threshold frames (default 1 000).
+//
+// # Concurrency
+//
+// Write transactions use Optimistic Concurrency Control (OCC): page versions
+// are recorded at read time and verified at commit. A conflict returns
+// [github.com/RichardKnop/minisql/pkg/errors.ErrTxConflict]; callers should
+// retry.
+//
+// Read-only SELECT statements run under MVCC snapshot isolation: each reader
+// sees a consistent point-in-time view regardless of concurrent writers.
+// Readers never block writers; writers never block readers.
+//
+// # Supported SQL
+//
+// SELECT (with WHERE, JOIN, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET,
+// DISTINCT, UNION, CTEs, window functions, subqueries), INSERT, UPDATE,
+// DELETE, CREATE TABLE, ALTER TABLE, DROP TABLE, CREATE INDEX, DROP INDEX,
+// EXPLAIN, EXPLAIN ANALYZE, ANALYZE, VACUUM, PRAGMA.
+//
+// Data types: BOOLEAN, INT4, INT8, REAL, DOUBLE, VARCHAR(n), TEXT, TIMESTAMP,
+// JSON, UUID, VECTOR(n).
+//
+// # Index types
+//
+// B-tree (primary key, unique, secondary, composite, partial, expression),
+// full-text BM25 inverted index, JSON inverted index, HNSW approximate
+// nearest-neighbour vector index.
+//
+// # Encryption
+//
+// Pass an encryption_key in the connection string (or [ConnectionConfig]) to
+// enable transparent AES-256-CTR page encryption with HKDF key derivation.
+// Key rotation is available via PRAGMA rekey or the Go API on the internal
+// Database type.
+//
+// # Utilities
+//
+// [Backup] — online backup while the database remains live.
+// [ReadMetrics] — point-in-time engine statistics snapshot.
+package minisql

--- a/docs/blog/minisql-1.0.md
+++ b/docs/blog/minisql-1.0.md
@@ -227,6 +227,8 @@ go install github.com/RichardKnop/minisql/cmd/minisql@latest
 brew install minisql
 ```
 
-Source and full documentation: [github.com/RichardKnop/minisql](https://github.com/RichardKnop/minisql) · [richardknop.github.io/minisql](https://richardknop.github.io/minisql/)
+Source and full documentation: 
+- [github.com/RichardKnop/minisql](https://github.com/RichardKnop/minisql)
+- [richardknop.github.io/minisql](https://richardknop.github.io/minisql/)
 
 Feedback, bug reports, and contributions are welcome — the project is in active development.

--- a/minisql.go
+++ b/minisql.go
@@ -173,17 +173,9 @@ func (c *Conn) Ping(ctx context.Context) error {
 	return nil
 }
 
-// Close invalidates and potentially stops any current
-// prepared statements and transactions, marking this
-// connection as no longer in use.
-//
-// Because the sql package maintains a free pool of
-// connections and only calls Close when there's a surplus of
-// idle connections, it shouldn't be necessary for drivers to
-// do their own connection caching.
-//
-// Drivers must ensure all network calls made by Close
-// do not block indefinitely (e.g. apply a timeout).
+// Close flushes the WAL write-buffer, releases the page cache, and marks
+// the database file as available for a new connection. It is called
+// automatically by database/sql when the connection is returned to the pool.
 func (c *Conn) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/rows.go
+++ b/rows.go
@@ -10,8 +10,9 @@ import (
 )
 
 // Rows is a database/sql/driver.Rows implementation that iterates over the
-// results of a SELECT query. It supports both the materialised row iterator
-// path and the zero-copy RowView path used by covering-index scans.
+// results of a SELECT query. It is returned by QueryContext and
+// Stmt.QueryContext; callers interact with it through the database/sql API
+// rather than directly.
 type Rows struct {
 	columns             []minisql.Column
 	rowViewFieldIndexes []int

--- a/stmt.go
+++ b/stmt.go
@@ -20,13 +20,8 @@ type Stmt struct {
 	statement minisql.Statement
 }
 
-// Close closes the statement.
-//
-// As of Go 1.1, a Stmt will not be closed if it's in use
-// by any queries.
-//
-// Drivers must ensure all network calls made by Close
-// do not block indefinitely (e.g. apply a timeout).
+// Close releases resources associated with the prepared statement.
+// MiniSQL statements hold no persistent server-side state, so this is a no-op.
 func (s Stmt) Close() error {
 	return nil
 }


### PR DESCRIPTION
- minisql.go: replace copy-pasted driver boilerplate on Conn.Close() with accurate description (no "network calls" in an embedded engine)
- rows.go: remove internal RowView implementation detail from public doc
- stmt.go: replace driver boilerplate on Stmt.Close() with accurate note