### PR TITLE
Add input validation bounds for VECTOR dims and connection parameters

### DIFF
--- a/connection_string.go
+++ b/connection_string.go
@@ -113,11 +113,14 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 		config.WALCheckpointThreshold = thresh
 	}
 
-	// Parse wal_write_buffer_size parameter
+	// Parse wal_write_buffer_size parameter (0 = flush every commit; max 256 MiB)
 	if bufSizeStr := queryParams.Get("wal_write_buffer_size"); bufSizeStr != "" {
 		bufSize, err := strconv.Atoi(bufSizeStr)
 		if err != nil || bufSize < 0 {
 			return nil, fmt.Errorf("invalid wal_write_buffer_size parameter: must be a non-negative integer, got %q", bufSizeStr)
+		}
+		if bufSize > 256*1024*1024 {
+			return nil, fmt.Errorf("invalid wal_write_buffer_size parameter: %d exceeds maximum of 256 MiB", bufSize)
 		}
 		config.WALWriteBufferSize = bufSize
 	}
@@ -133,14 +136,11 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 		}
 	}
 
-	// Parse max_cached_pages parameter
+	// Parse max_cached_pages parameter (0 = use default)
 	if maxPagesStr := queryParams.Get("max_cached_pages"); maxPagesStr != "" {
 		maxPages, err := strconv.Atoi(maxPagesStr)
-		if err != nil {
-			return nil, fmt.Errorf("invalid max_cached_pages parameter: must be a positive integer, got %q", maxPagesStr)
-		}
-		if maxPages < 0 {
-			return nil, fmt.Errorf("invalid max_cached_pages parameter: must be non-negative, got %d", maxPages)
+		if err != nil || maxPages < 0 {
+			return nil, fmt.Errorf("invalid max_cached_pages parameter: must be a non-negative integer (0 = use default), got %q", maxPagesStr)
 		}
 		config.MaxCachedPages = maxPages
 	}
@@ -180,23 +180,26 @@ func ParseConnectionString(connStr string) (*ConnectionConfig, error) {
 		}
 	}
 
-	// Parse encryption_key parameter (hex-encoded)
+	// Parse encryption_key parameter (hex-encoded, minimum 16 bytes / 32 hex chars)
 	if keyHex := queryParams.Get("encryption_key"); keyHex != "" {
 		key, err := hex.DecodeString(keyHex)
 		if err != nil {
 			return nil, fmt.Errorf("invalid encryption_key parameter: must be a hex-encoded string: %w", err)
 		}
-		if len(key) == 0 {
-			return nil, fmt.Errorf("invalid encryption_key parameter: key must not be empty")
+		if len(key) < 16 {
+			return nil, fmt.Errorf("invalid encryption_key parameter: key too short (%d bytes), minimum is 16 bytes (32 hex chars)", len(key))
 		}
 		config.EncryptionKey = key
 	}
 
-	// Parse sort_mem_limit parameter (bytes; 0 = disable external sort)
+	// Parse sort_mem_limit parameter (bytes; 0 = disable external sort; max 2 GiB)
 	if limitStr := queryParams.Get("sort_mem_limit"); limitStr != "" {
 		limit, err := strconv.ParseInt(limitStr, 10, 64)
 		if err != nil || limit < 0 {
 			return nil, fmt.Errorf("invalid sort_mem_limit parameter: must be a non-negative integer (bytes), got %q", limitStr)
+		}
+		if limit > 2*1024*1024*1024 {
+			return nil, fmt.Errorf("invalid sort_mem_limit parameter: %d exceeds maximum of 2 GiB", limit)
 		}
 		config.SortMemLimit = limit
 	}

--- a/connection_string_test.go
+++ b/connection_string_test.go
@@ -203,13 +203,13 @@ func TestParseConnectionString(t *testing.T) {
 			name:        "invalid max_cached_pages - negative",
 			connStr:     "./test.db?max_cached_pages=-100",
 			wantErr:     true,
-			errContains: "must be non-negative",
+			errContains: "must be a non-negative integer",
 		},
 		{
 			name:        "invalid max_cached_pages - not a number",
 			connStr:     "./test.db?max_cached_pages=abc",
 			wantErr:     true,
-			errContains: "must be a positive integer",
+			errContains: "must be a non-negative integer",
 		},
 		{
 			name:        "invalid log level",
@@ -331,6 +331,24 @@ func TestParseConnectionString(t *testing.T) {
 			connStr:     "./test.db?sort_mem_limit=big",
 			wantErr:     true,
 			errContains: "invalid sort_mem_limit parameter",
+		},
+		{
+			name:        "sort_mem_limit exceeds maximum",
+			connStr:     "./test.db?sort_mem_limit=3221225472",
+			wantErr:     true,
+			errContains: "exceeds maximum of 2 GiB",
+		},
+		{
+			name:        "wal_write_buffer_size exceeds maximum",
+			connStr:     "./test.db?wal_write_buffer_size=268435457",
+			wantErr:     true,
+			errContains: "exceeds maximum of 256 MiB",
+		},
+		{
+			name:        "encryption_key too short",
+			connStr:     "./test.db?encryption_key=" + hex.EncodeToString([]byte("tooshort")),
+			wantErr:     true,
+			errContains: "key too short",
 		},
 	}
 

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -1601,6 +1601,14 @@ func (s Statement) validateCreateTable() error {
 		if col.Name == "" {
 			return errors.New("column name cannot be empty")
 		}
+		if col.Kind == Vector {
+			if col.Size == 0 {
+				return fmt.Errorf("column %q: VECTOR dimension must be a positive integer", col.Name)
+			}
+			if col.Size > MaxVectorDims {
+				return fmt.Errorf("column %q: VECTOR dimension %d exceeds maximum of %d", col.Name, col.Size, MaxVectorDims)
+			}
+		}
 		nameMap[col.Name] = struct{}{}
 	}
 

--- a/internal/minisql/vector.go
+++ b/internal/minisql/vector.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// MaxVectorDims is the maximum number of dimensions a VECTOR(n) column may
+// have. 16 384 covers every current embedding model with comfortable headroom
+// while preventing make([]float32, n) from attempting multi-gigabyte
+// allocations on malformed or adversarial input.
+const MaxVectorDims = 16384
+
 // VectorPointer is stored in the leaf cell for a VECTOR(n) column.
 // The 8-byte inline representation holds the dimension count and the first
 // overflow page index; actual float32 data lives on overflow pages.

--- a/internal/parser/table.go
+++ b/internal/parser/table.go
@@ -112,6 +112,9 @@ func (p *parserItem) doParseCreateTable() error {
 		if dims == 0 {
 			return p.errorf("at CREATE TABLE: vector dimension must be a positive integer")
 		}
+		if dims > uint64(minisql.MaxVectorDims) {
+			return p.errorf("at CREATE TABLE: vector dimension %d exceeds maximum of %d", dims, minisql.MaxVectorDims)
+		}
 		p.pop()
 		p.Columns[len(p.Columns)-1].Size = uint32(dims)
 		closingParens := p.peek()

--- a/internal/parser/vector_test.go
+++ b/internal/parser/vector_test.go
@@ -71,6 +71,30 @@ func TestParse_VectorColumn(t *testing.T) {
 	}
 }
 
+func TestParse_VectorColumnDimensionBounds(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero dimension rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New().Parse(context.Background(), "CREATE TABLE t (id int8 primary key, v vector(0));")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dimension")
+	})
+
+	t.Run("max dimension accepted", func(t *testing.T) {
+		t.Parallel()
+		_, err := New().Parse(context.Background(), "CREATE TABLE t (id int8 primary key, v vector(16384));")
+		require.NoError(t, err)
+	})
+
+	t.Run("dimension exceeding max rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := New().Parse(context.Background(), "CREATE TABLE t (id int8 primary key, v vector(16385));")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum")
+	})
+}
+
 func TestParse_VecL2Function(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- MaxVectorDims=16384 constant guards against multi-GB allocations from adversarial VECTOR(n) column declarations; enforced in parser and Validate()
- Encryption key minimum raised to 16 bytes (128-bit) from zero
- wal_write_buffer_size capped at 256 MiB; sort_mem_limit capped at 2 GiB
- max_cached_pages error message unified to non-negative integer wording
- Connection string tests updated and three new bound-check cases added