### PR TITLE
Tier-1 query allocation optimisations: -31% ns/op on point scans

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -4,16 +4,18 @@
 
 **Platform:** Apple M1 Max · darwin/arm64 · Go 1.26.3  
 **Branch:** `main`  
-**Command:** `go test -tags bench ./benchmarks/ -run='^$' -bench='...' -benchmem -count=3` for each family; HNSW rows from a previous run (unchanged — HNSW build takes 50+ s per sub-benchmark). All other rows refreshed 2026-06-07.  
+**Command:** `go test -tags bench ./benchmarks/ -run='^$' -bench='...' -benchmem -count=3` for each family; HNSW rows from a previous run (unchanged — HNSW build takes 50+ s per sub-benchmark). All other rows refreshed 2026-06-11.  
 **GOMAXPROCS:** 10
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`) median of 3 runs; memory figures are heap allocations reported by the Go runtime.
 
-This file was refreshed after the GROUP BY + JOIN support addition, the `groupOrder` slice removal from `groupByAccumulator`, and the `computeGroupValues` refactor. The GROUP BY / HAVING memory is modestly improved (was 35.5 / 27.4 KiB, now 33.6 / 25.6 KiB) after eliminating the redundant per-group string copy in `groupOrder`. A new `DISTINCT + ORDER BY indexed` row was added (2026-06-07) to capture the streaming adjacent-compare dedup path that activates when an index covers the ORDER BY columns.
+This file was refreshed after Tier-1 point-scan optimizations (2026-06-11): `Statement.Clone()` now shares the Fields slice instead of deep-copying it when SELECT field expressions contain no placeholders; `cachedSelectedFields` is precomputed once at `PrepareStatement` time; and `QueryPlan.CachedFieldIndexes`/`CachedResultColumns` cache the `rowViewProjectionPlan` result for prepared statements. Combined effect: point scan −31% time, −33% heap (47 → 42 allocs/op, 3.7 KiB → 2.5 KiB/op, ratio vs SQLite 1.5× → 1.3×).
+
+Prior milestone (2026-06-07): GROUP BY + JOIN support addition, `groupOrder` slice removal from `groupByAccumulator`, `computeGroupValues` refactor. GROUP BY / HAVING memory improved (was 35.5 / 27.4 KiB, then 33.6 / 25.6 KiB) after eliminating the redundant per-group string copy. Added `DISTINCT + ORDER BY indexed` row to capture the streaming adjacent-compare dedup path.
 
 ---
 
-## 2026-06-07 — Current Baseline
+## 2026-06-11 — Tier-1 Optimization
 
 The results are grouped by benchmark family so each table can be read without horizontal scrolling. In comparison tables, a time ratio below `1.0×` means MiniSQL is faster than SQLite; above `1.0×` means slower.
 
@@ -21,9 +23,9 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Point scan | 6.39 µs | 4.15 µs | 1.5× | 3.7 KiB | 679 B | 47 / 26 |
+| Point scan | 4.40 µs | 3.40 µs | 1.3× | 2.5 KiB | 679 B | 42 / 26 |
 | Limit | 8.77 µs | 9.66 µs | 0.9× | 3.8 KiB | 1.7 KiB | 97 / 104 |
-| Full scan | 4.42 ms | 6.12 ms | 0.7× | 1.23 MiB | 1.29 MiB | 79,823 / 99,758 |
+| Full scan | 3.60 ms | 5.00 ms | 0.7× | 1.29 MiB | 1.36 MiB | 79,822 / 99,758 |
 | Count star | 7.65 µs | 10.93 µs | 0.7× | 2.6 KiB | 400 B | 27 / 13 |
 | Index range scan | 1.11 ms | 879.6 µs | 1.3× | 83.8 KiB | 85.9 KiB | 5,539 / 6,581 |
 | Secondary index, low selectivity | 2.01 ms | 3.14 ms | 0.6× | 315.0 KiB | 313.0 KiB | 24,920 / 29,886 |
@@ -34,12 +36,12 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Insert single row | 12.67 µs | 54.64 µs | 0.2× | 2.1 KiB | 311 B | 31 / 12 |
-| Insert batch | 437.0 µs | 309.3 µs | 1.4× | 133.6 KiB | 31.0 KiB | 2,632 / 1,299 |
-| Insert prepared batch | 402.6 µs | 249.8 µs | 1.6× | 132.4 KiB | 31.0 KiB | 2,633 / 1,299 |
-| Insert multi-values | 219.5 µs | 193.3 µs | 1.1× | 109.5 KiB | 25.2 KiB | 1,756 / 616 |
+| Insert single row | 15.0 µs | 66.0 µs | 0.2× | 2.1 KiB | 311 B | 31 / 12 |
+| Insert batch | 430 µs | 291 µs | 1.5× | 133.6 KiB | 31.0 KiB | 2,632 / 1,299 |
+| Insert prepared batch | 420 µs | 284 µs | 1.5× | 132.4 KiB | 31.0 KiB | 2,633 / 1,299 |
+| Insert multi-values | 226 µs | 210 µs | 1.1× | 109.5 KiB | 25.2 KiB | 1,756 / 616 |
 | Update by PK | 9.81 µs | 47.98 µs | 0.2× | 3.8 KiB | 263 B | 40 / 10 |
-| Delete by PK | 18.48 µs | 103.2 µs | 0.2× | 3.3 KiB | 447 B | 55 / 19 |
+| Delete by PK | 20.5 µs | 129 µs | 0.2× | 3.3 KiB | 447 B | 55 / 19 |
 | ON CONFLICT DO UPDATE | 9.08 µs | 43.20 µs | 0.2× | 1.6 KiB | 259 B | 31 / 10 |
 | Foreign key insert | 12.28 µs | 57.78 µs | 0.2× | 1.9 KiB | 191 B | 28 / 8 |
 | Foreign key delete cascade | 51.50 µs | 83.25 µs | 0.6× | 7.2 KiB | 128 B | 111 / 5 |
@@ -48,11 +50,11 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| GROUP BY aggregate | 987.1 µs | 2.31 ms | 0.4× | 33.6 KiB | 3.5 KiB | 458 / 309 |
-| HAVING filter | 822.4 µs | 2.10 ms | 0.4× | 25.6 KiB | 1.9 KiB | 263 / 111 |
-| DISTINCT high cardinality | 3.17 ms | 6.39 ms | 0.5× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
-| DISTINCT + ORDER BY high cardinality | 4.46 ms | 5.79 ms | 0.8× | 4.53 MiB | 586.3 KiB | 90,097 / 40,010 |
-| DISTINCT + ORDER BY indexed | 3.99 ms | 3.81 ms | 1.0× | 4.59 MiB | 586.3 KiB | 60,079 / 40,010 |
+| GROUP BY aggregate | 979 µs | 2.50 ms | 0.4× | 34.4 KiB | 3.6 KiB | 458 / 309 |
+| HAVING filter | 808 µs | 2.17 ms | 0.4× | 26.2 KiB | 2.0 KiB | 263 / 111 |
+| DISTINCT high cardinality | 3.40 ms | 6.70 ms | 0.5× | 1.27 MiB | 586.3 KiB | 40,093 / 40,010 |
+| DISTINCT + ORDER BY high cardinality | 4.50 ms | 6.10 ms | 0.7× | 4.53 MiB | 586.3 KiB | 90,097 / 40,010 |
+| DISTINCT + ORDER BY indexed | 4.00 ms | 4.10 ms | 1.0× | 4.59 MiB | 586.3 KiB | 60,079 / 40,010 |
 | CTE materialise | 380.4 µs | 502.0 µs | 0.8× | 6.6 KiB | 400 B | 89 / 13 |
 | Subquery IN list | 2.90 ms | 4.10 ms | 0.7× | 559.0 KiB | 234.7 KiB | 15,197 / 20,010 |
 
@@ -60,9 +62,9 @@ The results are grouped by benchmark family so each table can be read without ho
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Inner join, small-large | 6.56 ms | 5.98 ms | 1.1× | 1.00 MiB | 1.07 MiB | 79,855 / 99,757 |
-| Inner join, low selectivity | 129.6 µs | 860.9 µs | 0.15× | 21.0 KiB | 11.3 KiB | 1,198 / 1,009 |
-| Left join, unmatched rows | 4.38 ms | 5.19 ms | 0.8× | 869.0 KiB | 708.2 KiB | 79,643 / 70,157 |
+| Inner join, small-large | 6.60 ms | 5.80 ms | 1.1× | 1.03 MiB | 1.07 MiB | 79,855 / 99,757 |
+| Inner join, low selectivity | 128 µs | 808 µs | 0.16× | 21.5 KiB | 11.6 KiB | 1,198 / 1,009 |
+| Left join, unmatched rows | 4.30 ms | 4.90 ms | 0.9× | 890 KiB | 708.2 KiB | 79,643 / 70,157 |
 
 ### ORDER BY Disk Spill
 
@@ -101,24 +103,24 @@ and is the primary target for future optimisation (e.g. buffered I/O, larger def
 
 | Benchmark | Time | Memory | Allocs |
 |---|---|---|---|
-| Build index | 3.55 ms | 1.25 MiB | 26,674 |
-| Insert with index | 66.64 µs | 48.1 KiB | 144 |
-| Contains after deletes | 75.47 µs | 19.2 KiB | 77 |
-| Update with index | 9.30 µs | 4.2 KiB | 46 |
-| Delete with index | 134.9 µs | 26.6 KiB | 150 |
+| Build index | 2.90 ms | 1.31 MiB | 26,670 |
+| Insert with index | 62 µs | 47 KiB | 144 |
+| Contains after deletes | 73 µs | 19.6 KiB | 76 |
+| Update with index | 7.90 µs | 4.3 KiB | 46 |
+| Delete with index | 139 µs | 27.3 KiB | 150 |
 
 ### JSON Contains Comparisons
 
 | Predicate | MiniSQL indexed | MiniSQL sequential | SQLite JSON scan | SQLite expression index |
 |---|---|---|---|---|
-| Key/value | 21.82 µs / 7.8 KiB | 3.62 ms / 1.94 MiB | 858.0 µs / 424 B | 30.48 µs / 424 B |
-| Object subset | 33.52 µs / 8.8 KiB | 3.58 ms / 1.94 MiB | 830.6 µs / 424 B | 140.7 µs / 424 B |
+| Key/value | 20.7 µs / 7.9 KiB | 3.62 ms / 1.94 MiB | 858.0 µs / 424 B | 30.48 µs / 424 B |
+| Object subset | 33.4 µs / 9.0 KiB | 3.58 ms / 1.94 MiB | 830.6 µs / 424 B | 140.7 µs / 424 B |
 
 ### Maintenance and Explain
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| VACUUM small | 2.15 ms | 583.7 µs | 3.7× | 752.5 KiB | 91 B | 6,982 / 4 |
+| VACUUM small | 2.15 ms | 583.7 µs | 3.7× | 769 KiB | 91 B | 6,977 / 4 |
 | WAL checkpoint | 357.0 µs | 171.8 µs | 2.1× | 3.3 KiB | 441 B | 37 / 12 |
 | EXPLAIN | 7.45 µs | 1.75 µs | 4.3× | 6.0 KiB | 680 B | 55 / 18 |
 
@@ -176,11 +178,11 @@ and is the primary target for future optimisation (e.g. buffered I/O, larger def
 | Full-text | Build index | 1.43 MiB |
 | DISTINCT | High-cardinality distinct (no ORDER BY) | 1.27 MiB |
 | DISTINCT | High-cardinality distinct + ORDER BY | 4.53 MiB |
-| JSON inverted | Build index | 1.25 MiB |
-| SELECT | Full scan | 1.23 MiB |
-| Join | Inner join, small-large | 1.00 MiB |
-| Join | Left join, unmatched rows | 869.0 KiB |
-| Maintenance | VACUUM small | 752.5 KiB |
+| JSON inverted | Build index | 1.31 MiB |
+| SELECT | Full scan | 1.29 MiB |
+| Join | Inner join, small-large | 1.03 MiB |
+| Join | Left join, unmatched rows | 890 KiB |
+| Maintenance | VACUUM small | 769 KiB |
 | Subquery | IN list | 559.0 KiB |
 
 ### Good Next Optimisation Targets

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -250,6 +250,10 @@ func (d *Database) PrepareStatement(ctx context.Context, query string) (Statemen
 		stmt.insertCache = &insertPrepCache{}
 	}
 
+	// Precompute the selected-fields slice for simple SELECT statements so that
+	// repeated executions of the prepared statement avoid recomputing it each time.
+	stmt.precomputeSelectedFields()
+
 	// Cache the parsed statement
 	d.stmtCache.Put(query, stmt, true)
 

--- a/internal/minisql/query_plan.go
+++ b/internal/minisql/query_plan.go
@@ -131,6 +131,14 @@ type QueryPlan struct {
 	OrderBy      []OrderBy
 	SortInMemory bool
 	SortReverse  bool
+
+	// CachedFieldIndexes and CachedResultColumns are the precomputed output of
+	// rowViewProjectionPlan for simple SELECT statements (no GROUP BY, no
+	// aggregates, no JOINs). Populated by PlanQuery before storing the plan in
+	// the plan cache so that selectStreamingDirectRowView can skip the per-call
+	// allocation on every cache hit. Both nil means not cached.
+	CachedFieldIndexes  []int
+	CachedResultColumns []Column
 }
 
 // Scan describes a single table or index scan operation within a QueryPlan.
@@ -256,6 +264,20 @@ func (t *Table) PlanQuery(ctx context.Context, stmt Statement) (QueryPlan, error
 	plan, err := t.planQueryUncached(ctx, stmt)
 	if err != nil {
 		return QueryPlan{}, err
+	}
+
+	// Precompute the row-view projection for simple SELECT statements so that
+	// selectStreamingDirectRowView can reuse it without allocating on every call.
+	// The projection depends only on t.Columns and stmt.Fields, both of which are
+	// stable for the lifetime of the cached plan (ALTER TABLE invalidates the cache).
+	// Only done when the plan itself is cacheable — ad-hoc queries without a CacheKey
+	// are one-shot and don't benefit.
+	if canCache && stmt.Kind == Select && !stmt.IsSelectCountAll() && !stmt.IsSelectGroupBy() &&
+		!stmt.IsSelectAggregate() && len(stmt.Joins) == 0 {
+		if fi, rc, ok := rowViewProjectionPlan(t.Columns, stmt.Fields, stmt.TableName, stmt.TableAlias); ok {
+			plan.CachedFieldIndexes = fi
+			plan.CachedResultColumns = rc
+		}
 	}
 
 	if canCache && (!hasConditions || planIsCacheableWithConditions(plan)) {

--- a/internal/minisql/select.go
+++ b/internal/minisql/select.go
@@ -112,26 +112,37 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 	default:
 		if !stmt.IsSelectCountAll() {
 			requestedFields = stmt.Fields
-			// For selectedFields, replace computed expression fields with the
-			// underlying column references they read from (so the scan fetches
-			// the right data from disk).  Plain column fields pass through
-			// unchanged.
-			selectedFields = exprSourceFields(requestedFields)
 		}
-
-		// Pre-allocate for WHERE condition fields (estimate: 2 operands per condition)
-		conditionFieldsEstimate := 0
-		for _, conditions := range stmt.Conditions {
-			conditionFieldsEstimate += len(conditions) * 2
-		}
-		if cap(selectedFields) == 0 && conditionFieldsEstimate > 0 {
-			selectedFields = make([]Field, 0, conditionFieldsEstimate)
-		}
-
-		for _, conditions := range stmt.Conditions {
-			for _, cond := range conditions {
-				selectedFields = appendOperandSourceFields(selectedFields, cond.Operand1)
-				selectedFields = appendOperandSourceFields(selectedFields, cond.Operand2)
+		// For simple streaming queries (no GROUP BY, no aggregates, no in-memory sort,
+		// no JOINs, no window functions), selectedFields is computed lazily just before
+		// selectStreamingDirect — the fast paths (covering-index, row-view) use only
+		// requestedFields and don't need it at all.
+		// For slow-path queries and COUNT(*) with WHERE filters, compute eagerly now.
+		isSimpleStreaming := !stmt.IsSelectCountAll() && !stmt.IsSelectGroupBy() &&
+			!stmt.IsSelectAggregate() && !plan.SortInMemory && len(plan.Joins) == 0 &&
+			!stmt.HasWindowFuncs()
+		if !isSimpleStreaming {
+			if !stmt.IsSelectCountAll() {
+				if stmt.cachedSelectedFields != nil {
+					selectedFields = stmt.cachedSelectedFields
+				} else {
+					selectedFields = exprSourceFields(requestedFields)
+				}
+			}
+			// Always append condition operand fields — needed for COUNT(*) sequential
+			// scan filters to read the right column data.
+			conditionFieldsEstimate := 0
+			for _, conditions := range stmt.Conditions {
+				conditionFieldsEstimate += len(conditions) * 2
+			}
+			if cap(selectedFields) == 0 && conditionFieldsEstimate > 0 {
+				selectedFields = make([]Field, 0, conditionFieldsEstimate)
+			}
+			for _, conditions := range stmt.Conditions {
+				for _, cond := range conditions {
+					selectedFields = appendOperandSourceFields(selectedFields, cond.Operand1)
+					selectedFields = appendOperandSourceFields(selectedFields, cond.Operand2)
+				}
 			}
 		}
 	}
@@ -174,6 +185,26 @@ func (t *Table) Select(ctx context.Context, stmt Statement) (StatementResult, er
 		}
 		if result, ok, err := t.selectStreamingDirectRowView(ctx, stmt, plan, requestedFields); ok || err != nil {
 			return result, err
+		}
+		// Neither fast path handled the query; compute selectedFields now for the
+		// selectStreamingDirect fallback (sequential scans, non-row-view index paths).
+		if stmt.cachedSelectedFields != nil {
+			selectedFields = stmt.cachedSelectedFields
+		} else {
+			selectedFields = exprSourceFields(requestedFields)
+			conditionFieldsEstimate := 0
+			for _, conditions := range stmt.Conditions {
+				conditionFieldsEstimate += len(conditions) * 2
+			}
+			if cap(selectedFields) == 0 && conditionFieldsEstimate > 0 {
+				selectedFields = make([]Field, 0, conditionFieldsEstimate)
+			}
+			for _, conditions := range stmt.Conditions {
+				for _, cond := range conditions {
+					selectedFields = appendOperandSourceFields(selectedFields, cond.Operand1)
+					selectedFields = appendOperandSourceFields(selectedFields, cond.Operand2)
+				}
+			}
 		}
 		return t.selectStreamingDirect(ctx, stmt, plan, selectedFields, requestedFields)
 	}
@@ -1775,9 +1806,17 @@ func (t *Table) selectStreamingDirectRowView(
 	if t.virtualRows != nil || len(plan.Scans) != 1 {
 		return StatementResult{}, false, nil
 	}
-	fieldIndexes, resultColumns, ok := rowViewProjectionPlan(t.Columns, requestedFields, stmt.TableName, stmt.TableAlias)
-	if !ok {
-		return StatementResult{}, false, nil
+	var fieldIndexes []int
+	var resultColumns []Column
+	if plan.CachedFieldIndexes != nil {
+		fieldIndexes = plan.CachedFieldIndexes
+		resultColumns = plan.CachedResultColumns
+	} else {
+		var ok bool
+		fieldIndexes, resultColumns, ok = rowViewProjectionPlan(t.Columns, requestedFields, stmt.TableName, stmt.TableAlias)
+		if !ok {
+			return StatementResult{}, false, nil
+		}
 	}
 
 	result := StatementResult{Columns: resultColumns}

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -461,6 +461,11 @@ type Statement struct {
 	// prepareInsert path. It is only set for simple prepared INSERT statements
 	// where binding can be safely delayed until table columns are available.
 	boundArgs []any
+	// cachedSelectedFields is the precomputed "selectedFields" for simple SELECT
+	// statements — the union of projected column fields and WHERE condition column
+	// references. Populated at PrepareStatement time; nil means not cached.
+	// The slice is never mutated during execution, so it is safe to share across clones.
+	cachedSelectedFields []Field
 }
 
 // HasWindowFuncs reports whether the SELECT field list contains at least one
@@ -473,6 +478,47 @@ func (s Statement) HasWindowFuncs() bool {
 		}
 	}
 	return false
+}
+
+// selectFieldsNeedCopy reports whether BindArguments will write to stmt.Fields
+// for a SELECT statement. This is only true when a SELECT field expression
+// contains a placeholder (e.g. VEC_L2(embedding, ?)).
+func (s Statement) selectFieldsNeedCopy() bool {
+	for _, f := range s.Fields {
+		if countExprPlaceholders(f.Expr) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// precomputeSelectedFields populates cachedSelectedFields for simple SELECT
+// statements where the set of columns needed from disk is fully determined by
+// the static query structure (no sub-expressions, no subqueries, no JOINs).
+// Called once at PrepareStatement time; the result is shared across clones.
+func (s *Statement) precomputeSelectedFields() {
+	if s.Kind != Select || s.IsSelectCountAll() || s.IsSelectGroupBy() || s.IsSelectAggregate() {
+		return
+	}
+	if s.FromSubquery != nil || len(s.CTEs) > 0 || len(s.Joins) > 0 || len(s.Unions) > 0 {
+		return
+	}
+	for _, group := range s.Conditions {
+		for _, cond := range group {
+			if cond.Operand1.Type == OperandExpr || cond.Operand2.Type == OperandExpr ||
+				cond.Operand2.Type == OperandSubquery {
+				return
+			}
+		}
+	}
+	sf := exprSourceFields(s.Fields)
+	for _, group := range s.Conditions {
+		for _, cond := range group {
+			sf = appendOperandSourceFields(sf, cond.Operand1)
+			sf = appendOperandSourceFields(sf, cond.Operand2)
+		}
+	}
+	s.cachedSelectedFields = sf
 }
 
 // NumPlaceholders returns the number of placeholder parameters (?) in the statement.
@@ -615,10 +661,14 @@ func (s Statement) Clone() Statement {
 	// reference to avoid an allocation that immediately becomes dead.
 	// For UPDATE, BindArguments only reads Fields (to find which Updates keys hold
 	// placeholders) and never writes to it — share the reference too.
-	// For all other kinds, deep-copy so that downstream mutations don't corrupt
-	// the prepared statement.
+	// For DELETE, Fields is never accessed during execution — share.
+	// For SELECT, BindArguments only writes to Fields when a SELECT expression
+	// itself contains a placeholder (e.g. VEC_L2(v, ?)). In the common case of
+	// plain column fields with no embedded placeholders, Fields is read-only and
+	// safe to share.
 	var fields []Field
-	if s.Kind == Insert || s.Kind == Update {
+	if s.Kind == Insert || s.Kind == Update || s.Kind == Delete ||
+		(s.Kind == Select && !s.selectFieldsNeedCopy()) {
 		fields = s.Fields
 	} else {
 		fields = make([]Field, len(s.Fields))
@@ -670,8 +720,9 @@ func (s Statement) Clone() Statement {
 		AlterColumnName:    s.AlterColumnName,
 		NewColumnName:      s.NewColumnName,
 		NewTableName:       s.NewTableName,
-		insertCache:        s.insertCache,
-		boundArgs:          s.boundArgs,
+		insertCache:          s.insertCache,
+		boundArgs:            s.boundArgs,
+		cachedSelectedFields: s.cachedSelectedFields, // immutable; safe to share
 	}
 	for i := range s.Inserts {
 		stmt.Inserts[i] = make([]OptionalValue, len(s.Inserts[i]))

--- a/internal/minisql/stmt_cache_test.go
+++ b/internal/minisql/stmt_cache_test.go
@@ -35,6 +35,7 @@ func TestDatabase_PrepareStatementCaching(t *testing.T) {
 	}
 	stmt1Want := stmt1Mock
 	stmt1Want.CacheKey = query1
+	stmt1Want.cachedSelectedFields = []Field{{Name: "id"}}
 
 	query2 := `SELECT * FROM posts WHERE user_id = ?`
 	stmt2Mock := Statement{
@@ -48,6 +49,7 @@ func TestDatabase_PrepareStatementCaching(t *testing.T) {
 	}
 	stmt2Want := stmt2Mock
 	stmt2Want.CacheKey = query2
+	stmt2Want.cachedSelectedFields = []Field{{Name: "user_id"}}
 
 	mockParser.On("Parse", ctx, query1).Return([]Statement{stmt1Mock}, nil).Once()
 


### PR DESCRIPTION
Three targeted changes to avoid redundant allocations on the hot path for prepared SELECT statements:

1. Clone() shares stmt.Fields for SELECT (when no Expr-embedded placeholders) and DELETE — both paths only read Fields during bind, never write. Saves the make([]Field, n) + cloneExpr-per-field allocation on every QueryContext call.

2. selectedFields computation deferred for simple streaming queries. For the row-view and covering-index fast paths, selectedFields was computed eagerly then discarded without ever being used. Now it is computed lazily just before selectStreamingDirect for queries that actually reach the slow path. cachedSelectedFields (precomputed once at PrepareStatement time) is used when available. COUNT(*) with WHERE filters preserves original behaviour.

3. rowViewProjectionPlan result cached in QueryPlan (CachedFieldIndexes + CachedResultColumns). Computed once when the plan is first stored in the plan cache; reused by selectStreamingDirectRowView on all subsequent calls. Guarded by canCache so ad-hoc (non-prepared) queries are unaffected.

Result on BenchmarkSelect_PointScan (Apple M1 Max):
  Before: ~6400 ns/op  3807 B/op  47 allocs/op
  After:  ~4400 ns/op  2559 B/op  42 allocs/op  (−31% time, −33% bytes)