### PR TITLE
Add GEN_RANDOM_UUID() scalar function and DEFAULT GEN_RANDOM_UUID() s…

### DIFF
--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -121,11 +121,16 @@ INSERT INTO events (payload) VALUES ('["go","sql","json"]');
 ### UUID
 
 ```sql
-CREATE TABLE sessions (
-    id      UUID PRIMARY KEY,
-    user_id INT8 NOT NULL
+CREATE TABLE users (
+    id      UUID     NOT NULL DEFAULT GEN_RANDOM_UUID(),
+    email   VARCHAR(255) NOT NULL UNIQUE,
+    name    TEXT     NOT NULL
 );
 
+-- id is generated automatically
+INSERT INTO users (email, name) VALUES ('alice@example.com', 'Alice');
+
+-- or supply an explicit value
 INSERT INTO sessions (id, user_id)
 VALUES ('550e8400-e29b-41d4-a716-446655440000', 1);
 
@@ -134,6 +139,7 @@ SELECT CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID);
 
 - Stored as 16-byte binary (compact, no string overhead).
 - Accepted and returned as lowercase hyphenated string.
+- Use `DEFAULT GEN_RANDOM_UUID()` to auto-generate a random UUID v4 on INSERT. See [UUID Functions](functions/uuid.md).
 
 ### VECTOR(n)
 

--- a/docs/functions/uuid.md
+++ b/docs/functions/uuid.md
@@ -54,7 +54,7 @@ Existing rows receive a freshly generated UUID for the new column.
 
 `GEN_RANDOM_UUID()` produces **version 4** UUIDs — 122 bits of cryptographic randomness with 6 fixed version/variant bits. This matches PostgreSQL's `gen_random_uuid()` behaviour.
 
-The alternative is **version 7** (RFC 9562, 2024), which embeds a Unix millisecond timestamp in the high bits, making values monotonically increasing within the same millisecond. This improves B-tree insertion locality (sequential writes avoid random page splits) but leaks creation-time information. MiniSQL currently generates v4; if you need sorted identifiers consider using `INT8 PRIMARY KEY AUTOINCREMENT` or supplying v7 UUIDs from your application layer.
+The alternative is **version 7** (RFC 9562, 2024), which embeds a Unix millisecond timestamp in the high bits, making values monotonically increasing within the same millisecond. This improves B-tree insertion locality (sequential writes avoid random page splits) but leaks creation-time information. The `UUID` column type is version-agnostic — it stores any valid 16-byte UUID regardless of version — so you can supply v7 UUIDs from your application layer and insert them normally. `GEN_RANDOM_UUID()` specifically produces v4; if you need the B-tree locality benefit of v7, generate them in your application and pass them as bind parameters.
 
 ### Return type
 

--- a/docs/functions/uuid.md
+++ b/docs/functions/uuid.md
@@ -1,0 +1,61 @@
+# UUID Functions
+
+## GEN_RANDOM_UUID()
+
+Generates a random [UUID version 4](https://www.rfc-editor.org/rfc/rfc9562) value.
+
+```sql
+SELECT GEN_RANDOM_UUID() FROM users LIMIT 1;
+-- e.g. 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+INSERT INTO sessions (id, user_id) VALUES (GEN_RANDOM_UUID(), 1);
+
+UPDATE tokens SET id = GEN_RANDOM_UUID() WHERE id = ?;
+```
+
+### DEFAULT GEN_RANDOM_UUID()
+
+The most common use is as a column default so UUID primary keys are generated automatically on every INSERT:
+
+```sql
+CREATE TABLE users (
+    id         UUID     NOT NULL DEFAULT GEN_RANDOM_UUID(),
+    email      VARCHAR(255) NOT NULL UNIQUE,
+    name       TEXT     NOT NULL,
+    created_at TIMESTAMP    DEFAULT NOW()
+);
+
+-- id is generated automatically — no need to supply it
+INSERT INTO users (email, name) VALUES ('alice@example.com', 'Alice');
+
+SELECT id, email FROM users WHERE email = 'alice@example.com';
+-- 'f47ac10b-58cc-4372-a567-0e02b2c3d479'  alice@example.com
+```
+
+The constraint order required by the parser is `NOT NULL` before `DEFAULT`:
+
+```sql
+-- correct
+id UUID NOT NULL DEFAULT GEN_RANDOM_UUID()
+
+-- incorrect — parser does not accept DEFAULT before NOT NULL
+id UUID DEFAULT GEN_RANDOM_UUID() NOT NULL
+```
+
+### ALTER TABLE ADD COLUMN
+
+```sql
+ALTER TABLE documents ADD COLUMN external_id UUID NOT NULL DEFAULT GEN_RANDOM_UUID();
+```
+
+Existing rows receive a freshly generated UUID for the new column.
+
+### UUID version
+
+`GEN_RANDOM_UUID()` produces **version 4** UUIDs — 122 bits of cryptographic randomness with 6 fixed version/variant bits. This matches PostgreSQL's `gen_random_uuid()` behaviour.
+
+The alternative is **version 7** (RFC 9562, 2024), which embeds a Unix millisecond timestamp in the high bits, making values monotonically increasing within the same millisecond. This improves B-tree insertion locality (sequential writes avoid random page splits) but leaks creation-time information. MiniSQL currently generates v4; if you need sorted identifiers consider using `INT8 PRIMARY KEY AUTOINCREMENT` or supplying v7 UUIDs from your application layer.
+
+### Return type
+
+Returns `UUID` (16-byte binary, displayed as a lowercase hyphenated string).

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ for rows.Next() {
 | [Data Types](data-types.md) | All supported column types |
 | [SQL Reference](sql/create-table.md) | Full SQL syntax reference |
 | [Indexes](indexes/overview.md) | B-tree, full-text, JSON, HNSW |
-| [Functions](functions/string.md) | All built-in functions |
+| [Functions](functions/string.md) | String, numeric, date/time, UUID, aggregate, window, JSON functions |
 | [JSON](json.md) | JSON type, operators, inverted index |
 | [Vector Search](vector-search.md) | VECTOR type and HNSW ANN search |
 | [Encryption](encryption.md) | Transparent AES-256-CTR encryption |

--- a/docs/sql/create-table.md
+++ b/docs/sql/create-table.md
@@ -20,7 +20,8 @@ CREATE TABLE table_name (
 | `NULL` | Explicitly marks column as nullable (default). |
 | `UNIQUE` | Creates a unique index on this column. |
 | `DEFAULT value` | Default value when column is omitted from INSERT. |
-| `DEFAULT NOW()` | Default current UTC timestamp for TIMESTAMP columns. |
+| `DEFAULT NOW()` | Default current UTC timestamp for `TIMESTAMP` columns. |
+| `DEFAULT GEN_RANDOM_UUID()` | Default random UUID v4 for `UUID` columns. |
 | `CHECK (expr)` | Rejects rows where expression is false. |
 | `REFERENCES table (col)` | Inline foreign key. |
 
@@ -102,6 +103,20 @@ CREATE TABLE orders (
     amount  INT8 NOT NULL,
     CONSTRAINT fk_orders_users FOREIGN KEY (user_id) REFERENCES users (id)
 );
+```
+
+**Table with a UUID primary key (auto-generated):**
+
+```sql
+CREATE TABLE users (
+    id         UUID         NOT NULL DEFAULT GEN_RANDOM_UUID(),
+    email      VARCHAR(255) NOT NULL UNIQUE,
+    name       TEXT         NOT NULL,
+    created_at TIMESTAMP    DEFAULT NOW()
+);
+
+-- id is generated automatically on every insert
+INSERT INTO users (email, name) VALUES ('alice@example.com', 'Alice');
 ```
 
 **Table with JSON, UUID, and VECTOR columns:**

--- a/docs/sql/insert.md
+++ b/docs/sql/insert.md
@@ -26,11 +26,12 @@ INSERT INTO users (email, name) VALUES
 Omit columns that have defaults — they are filled in automatically:
 
 ```sql
--- active defaults to true, created defaults to NOW()
+-- active defaults to true, created defaults to NOW(), id defaults to GEN_RANDOM_UUID()
 INSERT INTO users (email, name) VALUES ('eve@example.com', 'Eve');
 
--- Explicit NOW()
+-- Explicit NOW() or GEN_RANDOM_UUID() in VALUES
 INSERT INTO events (name, created) VALUES ('login', NOW());
+INSERT INTO sessions (id, user_id) VALUES (GEN_RANDOM_UUID(), 42);
 ```
 
 ### Bind parameters
@@ -267,6 +268,26 @@ _, err = db.Exec(
 ```
 
 ## Inserting UUID
+
+**Auto-generate with `DEFAULT GEN_RANDOM_UUID()`** (recommended):
+
+```sql
+CREATE TABLE users (
+    id    UUID NOT NULL DEFAULT GEN_RANDOM_UUID(),
+    email VARCHAR(255) NOT NULL
+);
+
+-- id is generated automatically — omit it from the column list
+INSERT INTO users (email) VALUES ('alice@example.com');
+```
+
+**Explicit `GEN_RANDOM_UUID()` call in VALUES:**
+
+```sql
+INSERT INTO sessions (id, user_id) VALUES (GEN_RANDOM_UUID(), 1);
+```
+
+**Explicit UUID string literal:**
 
 ```sql
 INSERT INTO sessions (id, user_id)

--- a/e2e_tests/uuid_test.go
+++ b/e2e_tests/uuid_test.go
@@ -1,5 +1,126 @@
 package e2etests
 
+import (
+	"regexp"
+)
+
+var uuidRegexp = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func (s *TestSuite) TestGenRandomUUID() {
+	_, err := s.db.Exec(`create table accounts (
+		id      uuid    not null default gen_random_uuid(),
+		name    text    not null,
+		ref_id  uuid
+	);`)
+	s.Require().NoError(err)
+
+	s.Run("default_generates_uuid_on_omit", func() {
+		_, err := s.db.Exec(`insert into accounts (name) values (?)`, "Alice")
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select id, name from accounts where name = ?`, "Alice")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotID, gotName string
+		s.Require().NoError(rows.Scan(&gotID, &gotName))
+		s.Equal("Alice", gotName)
+		s.Regexp(uuidRegexp, gotID, "generated UUID must be valid v4")
+	})
+
+	s.Run("explicit_gen_random_uuid_in_values", func() {
+		_, err := s.db.Exec(`insert into accounts (id, name) values (gen_random_uuid(), ?)`, "Bob")
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select id from accounts where name = ?`, "Bob")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotID string
+		s.Require().NoError(rows.Scan(&gotID))
+		s.Regexp(uuidRegexp, gotID, "explicit GEN_RANDOM_UUID() must produce valid v4 UUID")
+	})
+
+	s.Run("update_set_gen_random_uuid", func() {
+		_, err := s.db.Exec(`insert into accounts (name) values (?)`, "Carol")
+		s.Require().NoError(err)
+
+		_, err = s.db.Exec(`update accounts set ref_id = gen_random_uuid() where name = ?`, "Carol")
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select ref_id from accounts where name = ?`, "Carol")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotRefID string
+		s.Require().NoError(rows.Scan(&gotRefID))
+		s.Regexp(uuidRegexp, gotRefID, "UPDATE SET gen_random_uuid() must produce valid v4 UUID")
+	})
+
+	s.Run("select_gen_random_uuid_scalar", func() {
+		// SELECT gen_random_uuid() as an expression alongside a real column.
+		rows, err := s.db.Query(`select gen_random_uuid() from accounts where name = ?`, "Alice")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var gotID string
+		s.Require().NoError(rows.Scan(&gotID))
+		s.Regexp(uuidRegexp, gotID, "SELECT gen_random_uuid() must produce valid v4 UUID")
+	})
+
+	s.Run("two_inserts_get_distinct_uuids", func() {
+		_, err := s.db.Exec(`insert into accounts (name) values (?)`, "Dave")
+		s.Require().NoError(err)
+		_, err = s.db.Exec(`insert into accounts (name) values (?)`, "Eve")
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select id from accounts where name = ? or name = ? order by name`, "Dave", "Eve")
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		var ids []string
+		for rows.Next() {
+			var id string
+			s.Require().NoError(rows.Scan(&id))
+			ids = append(ids, id)
+		}
+		s.Require().Len(ids, 2)
+		s.NotEqual(ids[0], ids[1], "each row must get a unique UUID")
+	})
+
+	s.Run("ddl_round_trip_preserves_default", func() {
+		_, err := s.db.Exec(`create table sessions (
+			token   uuid    not null default gen_random_uuid(),
+			user_id int8    not null
+		);`)
+		s.Require().NoError(err)
+
+		_, err = s.db.Exec(`insert into sessions (user_id) values (?)`, 42)
+		s.Require().NoError(err)
+
+		rows, err := s.db.Query(`select token from sessions where user_id = ?`, 42)
+		s.Require().NoError(err)
+		defer rows.Close()
+
+		s.Require().True(rows.Next())
+		var tok string
+		s.Require().NoError(rows.Scan(&tok))
+		s.Regexp(uuidRegexp, tok, "UUID generated after DDL round-trip must be valid v4")
+	})
+
+	s.Run("gen_random_uuid_on_non_uuid_column_rejected", func() {
+		_, err := s.db.Exec(`create table bad_default (
+			id   int8    not null,
+			name text    default gen_random_uuid() not null
+		);`)
+		s.Require().Error(err, "GEN_RANDOM_UUID() default must be rejected on non-UUID column")
+	})
+}
+
 func (s *TestSuite) TestUUID() {
 	_, err := s.db.Exec(`create table widgets (
 		id    uuid primary key,

--- a/internal/minisql/expr.go
+++ b/internal/minisql/expr.go
@@ -1163,6 +1163,18 @@ func (e *Expr) evalFunc(row Row) (any, error) {
 		}
 		return math.Mod(af, bf), nil
 
+	// ── UUID functions ───────────────────────────────────────────────────────
+
+	case "GEN_RANDOM_UUID":
+		if len(e.Args) != 0 {
+			return nil, fmt.Errorf("GEN_RANDOM_UUID takes no arguments")
+		}
+		uuid, err := NewRandomUUID()
+		if err != nil {
+			return nil, fmt.Errorf("GEN_RANDOM_UUID: %w", err)
+		}
+		return uuid, nil
+
 	// ── Date/time functions ──────────────────────────────────────────────────
 
 	case "NOW":

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -234,8 +234,9 @@ type Column struct {
 	Check           string // raw SQL text of CHECK expression, e.g. "age > 0"
 	Kind            ColumnKind
 	Size            uint32
-	Nullable        bool
-	DefaultValueNow bool
+	Nullable                bool
+	DefaultValueNow         bool
+	DefaultValueGenRandUUID bool
 	// Deleted marks a column that has been dropped via ALTER TABLE DROP COLUMN.
 	// Deleted columns remain in the schema so that existing cells (which still
 	// carry their bytes at that position) can be decoded correctly.  They are
@@ -369,9 +370,13 @@ type Function struct {
 }
 
 const nowFunctionName = "NOW()"
+const genRandomUUIDFunctionName = "GEN_RANDOM_UUID()"
 
 // FunctionNow is the sentinel value used for the NOW() scalar function in default values.
 var FunctionNow = Function{Name: nowFunctionName}
+
+// FunctionGenRandomUUID is the sentinel value used for the GEN_RANDOM_UUID() scalar function in default values.
+var FunctionGenRandomUUID = Function{Name: genRandomUUIDFunctionName}
 
 // Placeholder is the sentinel type for a ? bind parameter in a prepared statement.
 type Placeholder struct{}
@@ -1276,10 +1281,17 @@ func (s Statement) prepareInsert(now Time) (Statement, error) {
 				}
 			} else {
 				// Column was omitted — apply table default.
-				if col.DefaultValue.Valid {
+				switch {
+				case col.DefaultValue.Valid:
 					val = col.DefaultValue
-				} else if col.DefaultValueNow {
+				case col.DefaultValueNow:
 					val = OptionalValue{Valid: true, Value: TimestampMicros(now.TotalMicroseconds())}
+				case col.DefaultValueGenRandUUID:
+					uuid, err := NewRandomUUID()
+					if err != nil {
+						return Statement{}, fmt.Errorf("GEN_RANDOM_UUID: %w", err)
+					}
+					val = OptionalValue{Valid: true, Value: uuid}
 				}
 				newRow[i] = val
 				continue
@@ -1411,11 +1423,20 @@ func coerceColumnValue(col Column, val OptionalValue, now Time, ctx string) (Opt
 		return val, nil
 	}
 	if fn, ok := val.Value.(Function); ok {
-		if fn.Name != FunctionNow.Name {
+		switch fn.Name {
+		case FunctionNow.Name:
+			val.Value = TimestampMicros(now.TotalMicroseconds())
+			return val, nil
+		case FunctionGenRandomUUID.Name:
+			uuid, err := NewRandomUUID()
+			if err != nil {
+				return val, fmt.Errorf("GEN_RANDOM_UUID: %w", err)
+			}
+			val.Value = uuid
+			return val, nil
+		default:
 			return val, fmt.Errorf("unsupported function %q in %s", fn.Name, ctx)
 		}
-		val.Value = TimestampMicros(now.TotalMicroseconds())
-		return val, nil
 	}
 	switch col.Kind {
 	case Timestamp:
@@ -1903,6 +1924,9 @@ func (s Statement) validateInsert(table *Table) error {
 			continue
 		}
 		if col.DefaultValue.Valid {
+			continue
+		}
+		if col.DefaultValueNow || col.DefaultValueGenRandUUID {
 			continue
 		}
 		if hasPk && col.Name == pkColumn.Name && table.PrimaryKey.Autoincrement {
@@ -2403,9 +2427,12 @@ func (s Statement) createTableDDL() string {
 			if _, ok := uniqueKeys[col.Name]; ok {
 				sb.WriteString(" unique")
 			}
-			if col.DefaultValueNow {
+			switch {
+			case col.DefaultValueNow:
 				sb.WriteString(" default now()")
-			} else if col.DefaultValue.Valid {
+			case col.DefaultValueGenRandUUID:
+				sb.WriteString(" default gen_random_uuid()")
+			case col.DefaultValue.Valid:
 				switch col.Kind {
 				case Boolean:
 					if col.DefaultValue.Value.(bool) {

--- a/internal/parser/alter_table.go
+++ b/internal/parser/alter_table.go
@@ -99,13 +99,20 @@ func (p *parserItem) doParseAlterTable() error {
 			p.pop()
 		case "DEFAULT":
 			p.pop()
-			if strings.ToUpper(p.peek()) == "NOW()" {
+			switch strings.ToUpper(p.peek()) {
+			case "NOW()":
 				if p.Columns[len(p.Columns)-1].Kind != minisql.Timestamp {
 					return p.errorf("at ALTER TABLE ADD COLUMN: NOW() default is only valid for TIMESTAMP columns")
 				}
 				p.Columns[len(p.Columns)-1].DefaultValueNow = true
 				p.pop()
-			} else {
+			case "GEN_RANDOM_UUID()":
+				if p.Columns[len(p.Columns)-1].Kind != minisql.UUID {
+					return p.errorf("at ALTER TABLE ADD COLUMN: GEN_RANDOM_UUID() default is only valid for UUID columns")
+				}
+				p.Columns[len(p.Columns)-1].DefaultValueGenRandUUID = true
+				p.pop()
+			default:
 				defaultValue, n := p.peekValue()
 				if n == 0 {
 					return p.errorf("at ALTER TABLE ADD COLUMN: expected default value after DEFAULT")

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -160,6 +160,12 @@ func (p *parserItem) parseFactor() (*minisql.Expr, error) {
 		return &minisql.Expr{FuncName: "NOW"}, nil
 	}
 
+	// GEN_RANDOM_UUID() is tokenised as a single reserved-word — no argument list to parse.
+	if token == "GEN_RANDOM_UUID()" {
+		p.pop()
+		return &minisql.Expr{FuncName: "GEN_RANDOM_UUID"}, nil
+	}
+
 	// Scalar literals: integer, float, string, boolean
 	value, ln := p.peekValue()
 	if ln > 0 {

--- a/internal/parser/insert.go
+++ b/internal/parser/insert.go
@@ -162,6 +162,12 @@ func (p *parserItem) doParseInsert() error {
 			p.step = stepInsertValuesCommaOrClosingParens
 			return nil
 		}
+		if specialValue == "GEN_RANDOM_UUID()" {
+			p.Inserts[len(p.Inserts)-1] = append(p.Inserts[len(p.Inserts)-1], minisql.OptionalValue{Value: minisql.FunctionGenRandomUUID, Valid: true})
+			p.pop()
+			p.step = stepInsertValuesCommaOrClosingParens
+			return nil
+		}
 		value, ln := p.peekValue()
 		if ln > 0 {
 			var insertValue minisql.OptionalValue
@@ -271,6 +277,10 @@ func (p *parserItem) doParseInsert() error {
 			p.pop()
 		case "NOW()":
 			p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: minisql.FunctionNow, Valid: true})
+			p.nextUpdateField = ""
+			p.pop()
+		case "GEN_RANDOM_UUID()":
+			p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: minisql.FunctionGenRandomUUID, Valid: true})
 			p.nextUpdateField = ""
 			p.pop()
 		default:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -48,7 +48,7 @@ var reservedWords = []string{
 	// statement other
 	"*", "COUNT(*)", "SUM(", "AVG(", "MIN(", "MAX(", "GROUP BY", "HAVING", "ORDER BY", "LIMIT", "OFFSET",
 	"PRIMARY KEY AUTOINCREMENT", "PRIMARY KEY", "DEFAULT", "NOT NULL", "NULL", "UNIQUE",
-	"IS NULL", "IS NOT NULL", "NOT BETWEEN", "NOT LIKE", "BETWEEN", "LIKE", "TRUE", "FALSE", "NOW()",
+	"IS NULL", "IS NOT NULL", "NOT BETWEEN", "NOT LIKE", "BETWEEN", "LIKE", "TRUE", "FALSE", "NOW()", "GEN_RANDOM_UUID()",
 	"CHECK",
 	"IF NOT EXISTS", "WHERE", "FROM", "SET NULL", "SET", "ASC", "DESC", "AS",
 	"BEGIN", "COMMIT", "ROLLBACK", "ANALYZE", "VACUUM",

--- a/internal/parser/select.go
+++ b/internal/parser/select.go
@@ -53,7 +53,7 @@ func (p *parserItem) doParseSelect() error {
 		upperIdent := strings.ToUpper(identifier)
 		isAggFunc := aggregateKindFromToken(upperIdent) != 0
 
-		if !isIdentifier(identifier) && identifier != "*" && upperIdent != "COUNT(*)" && !isAggFunc && upperIdent != "NOW()" {
+		if !isIdentifier(identifier) && identifier != "*" && upperIdent != "COUNT(*)" && !isAggFunc && upperIdent != "NOW()" && upperIdent != "GEN_RANDOM_UUID()" {
 			return p.wrapErr(errSelectWithoutFields)
 		}
 

--- a/internal/parser/table.go
+++ b/internal/parser/table.go
@@ -211,6 +211,14 @@ func (p *parserItem) doParseCreateTable() error {
 			p.pop()
 			return nil
 		}
+		if strings.ToUpper(p.peek()) == "GEN_RANDOM_UUID()" {
+			if p.Columns[len(p.Columns)-1].Kind != minisql.UUID {
+				return p.errorf("at CREATE TABLE: GEN_RANDOM_UUID() default value is only valid for UUID columns")
+			}
+			p.Columns[len(p.Columns)-1].DefaultValueGenRandUUID = true
+			p.pop()
+			return nil
+		}
 		defaultValue, n := p.peekValue()
 		if n == 0 {
 			return p.wrapErr(errCreateTableDefaultValueExpected)

--- a/internal/parser/update.go
+++ b/internal/parser/update.go
@@ -99,6 +99,10 @@ func (p *parserItem) doParseUpdate() error {
 			p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: minisql.FunctionNow, Valid: true})
 			p.nextUpdateField = ""
 			p.pop()
+		case "GEN_RANDOM_UUID()":
+			p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: minisql.FunctionGenRandomUUID, Valid: true})
+			p.nextUpdateField = ""
+			p.pop()
 		case "TRUE":
 			p.setUpdate(p.nextUpdateField, minisql.OptionalValue{Value: true, Valid: true})
 			p.nextUpdateField = ""

--- a/internal/parser/uuid_test.go
+++ b/internal/parser/uuid_test.go
@@ -43,6 +43,35 @@ func TestParse_UUIDColumn(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"CREATE TABLE uuid with default gen_random_uuid()",
+			"CREATE TABLE users (id uuid not null default gen_random_uuid(), name text not null);",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "users",
+					Columns: []minisql.Column{
+						{Name: "id", Kind: minisql.UUID, Size: 16, Nullable: false, DefaultValueGenRandUUID: true},
+						{Name: "name", Kind: minisql.Text, Nullable: false},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"CREATE TABLE uuid with GEN_RANDOM_UUID() uppercase",
+			"CREATE TABLE tokens (id UUID NOT NULL DEFAULT GEN_RANDOM_UUID());",
+			[]minisql.Statement{
+				{
+					Kind:      minisql.CreateTable,
+					TableName: "tokens",
+					Columns: []minisql.Column{
+						{Name: "id", Kind: minisql.UUID, Size: 16, Nullable: false, DefaultValueGenRandUUID: true},
+					},
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, aTestCase := range testCases {
@@ -56,6 +85,36 @@ func TestParse_UUIDColumn(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equal(t, aTestCase.Expected, got)
+		})
+	}
+}
+
+func TestParse_UUIDDefaultGenRandUUIDErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{
+			"GEN_RANDOM_UUID() on int8 column",
+			"CREATE TABLE bad (id int8 not null default gen_random_uuid());",
+		},
+		{
+			"GEN_RANDOM_UUID() on text column",
+			"CREATE TABLE bad (name text not null default gen_random_uuid());",
+		},
+		{
+			"GEN_RANDOM_UUID() on timestamp column",
+			"CREATE TABLE bad (ts timestamp default gen_random_uuid());",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New().Parse(context.Background(), tc.sql)
+			require.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
…upport

UUID columns can now use DEFAULT GEN_RANDOM_UUID() analogous to TIMESTAMP columns using DEFAULT NOW(), auto-populating the column on INSERT when the field is omitted. The function also works as an explicit value in INSERT VALUES, UPDATE SET, and SELECT expressions.