### PR TITLE
perf: reuse overflow pages in-place on text UPDATE

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,6 +9,8 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`) median of 3 runs; memory figures are heap allocations reported by the Go runtime.
 
+2026-06-14: Overflow page reuse on UPDATE — `updateOverflowTexts` replaces the free-then-reallocate cycle (`freeOverflowPages` + `storeOverflowTexts`) with in-place reuse of existing overflow pages. `GetOverflowPage` already calls `ModifyPage` internally so the pages are already writable; new data is written directly, eliminating N `AddFreePage` + N `GetFreePage` calls per reused page. Excess tail pages are freed when the new value is shorter; extra pages are allocated when it is longer. Also fixes a latent bug where unchanged text-overflow columns were re-stored on UPDATE (creating orphaned duplicate chains). Net effect on same-size overflow UPDATE: −26% time at inline, −43% at 1-page, −39% at 4-page, −36% at 16-page; allocs halved at 16-page (131→60); MiniSQL now beats SQLite at 16-page updates (100 µs vs 138 µs).
+
 This file was refreshed after Tier-2 point-scan optimizations (2026-06-11): `conditionsCanSkipFolding` avoids folding work for bound-parameter WHERE clauses; `buildColumnNames` precomputes `Rows.Columns()` names once at construction; `RuntimeIndexKeys [][]any` decouples per-execution index key injection from the static `Scan` struct (avoids a 264-byte-per-scan copy on the rehydration hot path); read-only transaction object reused via a single-slot cache under the existing `mu` lock instead of allocating a new `Transaction` on every read query. Net effect on point scan: −20% heap (2.5 KiB→2.0 KiB/op), −7% alloc count (42→39/op), −2% time.
 
 Tier-1 (same date): `Statement.Clone()` shares the Fields slice instead of deep-copying it when SELECT field expressions contain no placeholders; `cachedSelectedFields` precomputed once at `PrepareStatement` time; `QueryPlan.CachedFieldIndexes`/`CachedResultColumns` cache the `rowViewProjectionPlan` result for prepared statements. Combined effect: −31% heap, −11% allocs on point scan.
@@ -185,6 +187,50 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 | Join | Left join, unmatched rows | 869 KiB |
 | Maintenance | VACUUM small | 753 KiB |
 | Subquery | IN list | 559 KiB |
+
+### Overflow Page INSERT
+
+One INSERT per b.N iteration, auto-commit. "inline" (512 B) fits within `MaxInlineVarchar` and uses no overflow pages; it is the control group. `1pg`/`4pg`/`16pg` spill to 1, 4, and 16 overflow pages respectively.
+
+| Blob size | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs (MiniSQL / SQLite) |
+|---|---|---|---|---|---|---|
+| inline (512 B) | 16.1 µs | 58.8 µs | 0.27× | 4.3 KiB | 144 B | 28 / 7 |
+| 1pg (~4 KB) | 42.2 µs | 76.5 µs | 0.55× | 19.6 KiB | 144 B | 45 / 7 |
+| 4pg (~16 KB) | 89.5 µs | 122 µs | 0.73× | 58.0 KiB | 144 B | 72 / 7 |
+| 16pg (~64 KB) | 275 µs | 363 µs | 0.76× | 213 KiB | 144 B | 177 / 7 |
+
+### Overflow Page Point Read
+
+100 rows seeded once; each b.N iteration does one `SELECT … WHERE id = ?` and traverses the overflow chain.
+
+| Blob size | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs (MiniSQL / SQLite) |
+|---|---|---|---|---|---|---|
+| inline (512 B) | 5.66 µs | 3.90 µs | 1.5× | 2.4 KiB | 1.5 KiB | 40 / 18 |
+| 1pg (~4 KB) | 8.52 µs | 7.37 µs | 1.2× | 9.9 KiB | 8.5 KiB | 41 / 18 |
+| 4pg (~16 KB) | 14.8 µs | 23.2 µs | 0.64× | 33.8 KiB | 32.5 KiB | 41 / 18 |
+| 16pg (~64 KB) | 32.9 µs | 76.1 µs | 0.43× | 130 KiB | 128 KiB | 41 / 18 |
+
+### Overflow Page Full Scan
+
+50 rows seeded once; each b.N iteration scans all 50 rows reading every overflow chain.
+
+| Blob size | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs (MiniSQL / SQLite) |
+|---|---|---|---|---|---|---|
+| inline (512 B) | 25.9 µs | 41.9 µs | 0.62× | 27.1 KiB | 51.4 KiB | 123 / 214 |
+| 1pg (~4 KB) | 157 µs | 192 µs | 0.82× | 402 KiB | 401 KiB | 173 / 214 |
+| 4pg (~16 KB) | 466 µs | 864 µs | 0.54× | 1.56 MiB | 1.56 MiB | 173 / 214 |
+| 16pg (~64 KB) | 1.14 ms | 3.49 ms | 0.33× | 6.25 MiB | 6.25 MiB | 173 / 214 |
+
+### Overflow Page UPDATE (after in-place reuse optimization, 2026-06-14)
+
+One row seeded; each b.N iteration updates the blob body (alternates two payloads to prevent short-circuit). Old overflow chain is reused in-place — no free+alloc per page for same-size updates.
+
+| Blob size | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs (MiniSQL / SQLite) |
+|---|---|---|---|---|---|---|
+| inline (512 B) | 7.4 µs | 40.0 µs | 0.19× | 4.6 KiB | 176 B | 33 / 7 |
+| 1pg (~4 KB) | 15.0 µs | 45.1 µs | 0.33× | 15.9 KiB | 176 B | 40 / 7 |
+| 4pg (~16 KB) | 33.2 µs | 79.8 µs | 0.42× | 52.2 KiB | 176 B | 44 / 7 |
+| 16pg (~64 KB) | 100 µs | 138 µs | 0.73× | 201 KiB | 176 B | 60 / 7 |
 
 ### Good Next Optimisation Targets
 

--- a/benchmarks/overflow_bench_test.go
+++ b/benchmarks/overflow_bench_test.go
@@ -1,0 +1,311 @@
+//go:build bench
+
+package benchmarks
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// overflowSizes lists the blob sizes exercised by overflow benchmarks.
+// The names are chosen to make the page-level behaviour obvious:
+//
+//   - inline  (512 B)  – fits within MaxInlineVarchar, no overflow pages at all
+//   - 1pg     (~4 KB)  – spills onto exactly one overflow page
+//   - 4pg     (~16 KB) – four overflow pages
+//   - 16pg    (~64 KB) – sixteen overflow pages (near the current hard limit)
+//
+// "inline" acts as a control: if it is slower than expected the overhead is
+// in the write/read path itself, not in overflow page management.
+var overflowSizes = []struct {
+	name string
+	size int
+}{
+	{"inline", 512},
+	{"1pg", 4096},
+	{"4pg", 16384},
+	{"16pg", 65280},
+}
+
+// makeBlob returns a deterministic byte slice of the given length.
+// Using a non-zero, non-repeating pattern avoids compression skewing results.
+func makeBlob(size int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = alphabet[i%len(alphabet)]
+	}
+	return string(b)
+}
+
+func overflowCreateTable(d dbDriver) string {
+	if d.name == "sqlite" {
+		return `CREATE TABLE IF NOT EXISTS overflow_rows (
+			id   INTEGER PRIMARY KEY AUTOINCREMENT,
+			body TEXT NOT NULL
+		)`
+	}
+	return `create table "overflow_rows" (
+		id   int8 primary key autoincrement,
+		body text not null
+	)`
+}
+
+func overflowInsertSQL(d dbDriver) string {
+	if d.name == "sqlite" {
+		return `INSERT INTO overflow_rows (body) VALUES (?)`
+	}
+	return `insert into "overflow_rows" (body) values (?)`
+}
+
+func overflowSelectSQL(d dbDriver) string {
+	if d.name == "sqlite" {
+		return `SELECT body FROM overflow_rows WHERE id = ?`
+	}
+	return `select body from "overflow_rows" where id = ?`
+}
+
+func overflowSelectAllSQL(d dbDriver) string {
+	if d.name == "sqlite" {
+		return `SELECT id, body FROM overflow_rows`
+	}
+	return `select id, body from "overflow_rows"`
+}
+
+func overflowUpdateSQL(d dbDriver) string {
+	if d.name == "sqlite" {
+		return `UPDATE overflow_rows SET body = ? WHERE id = ?`
+	}
+	return `update "overflow_rows" set body = ? where id = ?`
+}
+
+// openOverflowDB opens a temporary database for the given driver and creates
+// the overflow_rows table used by all overflow benchmarks.
+func openOverflowDB(b *testing.B, d dbDriver) (*sql.DB, func()) {
+	b.Helper()
+
+	f, err := os.CreateTemp("", "bench_overflow_"+d.name+"_")
+	if err != nil {
+		b.Fatalf("create temp file: %v", err)
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		b.Fatalf("close temp file: %v", err)
+	}
+
+	db, err := sql.Open(d.driverName, d.dsn(path))
+	if err != nil {
+		b.Fatalf("open db (%s): %v", d.name, err)
+	}
+	db.SetMaxOpenConns(1)
+
+	if d.afterOpen != nil {
+		if err := d.afterOpen(db); err != nil {
+			b.Fatalf("afterOpen (%s): %v", d.name, err)
+		}
+	}
+
+	mustExec(b, db, overflowCreateTable(d))
+
+	cleanup := func() {
+		_ = db.Close()
+		_ = os.Remove(path)
+		_ = os.Remove(path + "-wal")
+		_ = os.Remove(path + "-shm")
+	}
+	return db, cleanup
+}
+
+// BenchmarkOverflow_Insert measures the cost of inserting a single row with a
+// TEXT body that spans zero or more overflow pages. Each b.N iteration is one
+// INSERT + implicit commit (auto-commit mode).
+//
+// This isolates the write path: GetFreePage calls, OverflowPage.Marshal, and
+// the WAL append for each overflow page.
+func BenchmarkOverflow_Insert(b *testing.B) {
+	for _, sz := range overflowSizes {
+		blob := makeBlob(sz.size)
+		for _, d := range drivers {
+			b.Run(fmt.Sprintf("%s/%s", sz.name, d.name), func(b *testing.B) {
+				db, cleanup := openOverflowDB(b, d)
+				defer cleanup()
+
+				stmt, err := db.Prepare(overflowInsertSQL(d))
+				if err != nil {
+					b.Fatalf("prepare: %v", err)
+				}
+				defer stmt.Close()
+
+				b.SetBytes(int64(sz.size))
+				b.ResetTimer()
+				for range b.N {
+					if _, err := stmt.Exec(blob); err != nil {
+						b.Fatalf("exec: %v", err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkOverflow_PointRead measures the cost of reading a single large-body
+// row by primary key. The table is seeded once before the timer starts; each
+// b.N iteration performs one SELECT + overflow page chain traversal.
+//
+// This isolates the read path: ReadPage calls per overflow page, the
+// OverflowPage.Unmarshal zero-copy sub-slice, and the append loop.
+func BenchmarkOverflow_PointRead(b *testing.B) {
+	const seedRows = 100
+
+	for _, sz := range overflowSizes {
+		blob := makeBlob(sz.size)
+		for _, d := range drivers {
+			b.Run(fmt.Sprintf("%s/%s", sz.name, d.name), func(b *testing.B) {
+				db, cleanup := openOverflowDB(b, d)
+				defer cleanup()
+
+				// Seed rows once; record the row IDs so lookups are deterministic.
+				ids := make([]int64, seedRows)
+				ins, err := db.Prepare(overflowInsertSQL(d))
+				if err != nil {
+					b.Fatalf("prepare insert: %v", err)
+				}
+				for i := range seedRows {
+					res, err := ins.Exec(blob)
+					if err != nil {
+						b.Fatalf("seed insert %d: %v", i, err)
+					}
+					ids[i], _ = res.LastInsertId()
+				}
+				ins.Close()
+
+				sel, err := db.Prepare(overflowSelectSQL(d))
+				if err != nil {
+					b.Fatalf("prepare select: %v", err)
+				}
+				defer sel.Close()
+
+				b.SetBytes(int64(sz.size))
+				b.ResetTimer()
+				for i := range b.N {
+					id := ids[i%seedRows]
+					var body string
+					if err := sel.QueryRow(id).Scan(&body); err != nil {
+						b.Fatalf("scan: %v", err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkOverflow_FullScan measures the cost of a sequential full-table scan
+// over rows with large TEXT bodies. The table is seeded with 50 rows before the
+// timer starts; each b.N iteration scans all 50 rows, reading every overflow
+// page chain.
+//
+// This is the worst-case read pattern: the LRU page cache cannot help because
+// the working set (50 × numPages overflow pages) likely exceeds the cache window
+// for large blobs.
+func BenchmarkOverflow_FullScan(b *testing.B) {
+	const seedRows = 50
+
+	for _, sz := range overflowSizes {
+		blob := makeBlob(sz.size)
+		for _, d := range drivers {
+			b.Run(fmt.Sprintf("%s/%s", sz.name, d.name), func(b *testing.B) {
+				db, cleanup := openOverflowDB(b, d)
+				defer cleanup()
+
+				ins, err := db.Prepare(overflowInsertSQL(d))
+				if err != nil {
+					b.Fatalf("prepare insert: %v", err)
+				}
+				for i := range seedRows {
+					if _, err := ins.Exec(blob); err != nil {
+						b.Fatalf("seed insert %d: %v", i, err)
+					}
+				}
+				ins.Close()
+
+				sel, err := db.Prepare(overflowSelectAllSQL(d))
+				if err != nil {
+					b.Fatalf("prepare select all: %v", err)
+				}
+				defer sel.Close()
+
+				totalBytes := int64(seedRows) * int64(sz.size)
+				b.SetBytes(totalBytes)
+				b.ResetTimer()
+				for range b.N {
+					rows, err := sel.Query()
+					if err != nil {
+						b.Fatalf("query: %v", err)
+					}
+					var (
+						id   int64
+						body string
+					)
+					for rows.Next() {
+						if err := rows.Scan(&id, &body); err != nil {
+							rows.Close()
+							b.Fatalf("scan: %v", err)
+						}
+					}
+					rows.Close()
+				}
+				b.ReportMetric(float64(seedRows), "rows/op")
+			})
+		}
+	}
+}
+
+// BenchmarkOverflow_Update measures the cost of replacing a large TEXT body
+// in-place. Each b.N iteration runs one UPDATE that writes a new overflow page
+// chain and (in MiniSQL's copy-on-write WAL model) also writes the old pages to
+// the WAL as modified.
+//
+// This benchmark surfaces the total write amplification for blob updates.
+func BenchmarkOverflow_Update(b *testing.B) {
+	for _, sz := range overflowSizes {
+		blob := makeBlob(sz.size)
+		newBlob := strings.ToUpper(makeBlob(sz.size)) // different content, same size
+
+		for _, d := range drivers {
+			b.Run(fmt.Sprintf("%s/%s", sz.name, d.name), func(b *testing.B) {
+				db, cleanup := openOverflowDB(b, d)
+				defer cleanup()
+
+				// Insert one row to update repeatedly.
+				res, err := db.Exec(overflowInsertSQL(d), blob)
+				if err != nil {
+					b.Fatalf("seed insert: %v", err)
+				}
+				rowID, _ := res.LastInsertId()
+
+				upd, err := db.Prepare(overflowUpdateSQL(d))
+				if err != nil {
+					b.Fatalf("prepare update: %v", err)
+				}
+				defer upd.Close()
+
+				b.SetBytes(int64(sz.size))
+				b.ResetTimer()
+				for i := range b.N {
+					// Alternate between blob and newBlob to avoid any
+					// short-circuit optimisation that detects identical content.
+					payload := blob
+					if i%2 == 1 {
+						payload = newBlob
+					}
+					if _, err := upd.Exec(payload, rowID); err != nil {
+						b.Fatalf("exec update: %v", err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/minisql/cursor.go
+++ b/internal/minisql/cursor.go
@@ -430,20 +430,13 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		return true, nil
 	}
 
-	// Remove any overflow pages for changed text columns.
-	if overflowColumns := c.Table.textOverflowCols; len(overflowColumns) > 0 {
-		// TODO - a more efficient implementation would be to try to reuse existing overflow pages
-		// if possible. For example if text size didn't change much and fits into existing overflow pages.
-		changedColumns := make([]Column, 0, len(changedValues))
-		for _, col := range overflowColumns {
-			_, ok := changedValues[col.Name]
-			if !ok {
-				continue
-			}
-			changedColumns = append(changedColumns, col)
-		}
-		if err := c.Table.freeOverflowPages(ctx, oldRow, changedColumns...); err != nil {
-			return false, err
+	// Update overflow text pages for changed columns, reusing old pages in-place
+	// where possible (avoids AddFreePage + GetFreePage churn on same-size updates).
+	if len(c.Table.textOverflowCols) > 0 {
+		var err error
+		row, err = row.updateOverflowTexts(ctx, c.Table.pager, oldRow, changedValues)
+		if err != nil {
+			return false, fmt.Errorf("update overflow texts: %w", err)
 		}
 	}
 
@@ -462,10 +455,6 @@ func (c *Cursor) update(ctx context.Context, stmt Statement, row Row) (bool, err
 		}
 	}
 
-	row, err = row.storeOverflowTexts(ctx, c.Table.pager)
-	if err != nil {
-		return false, fmt.Errorf("store overflow texts: %w", err)
-	}
 	row, err = row.storeOverflowVectors(ctx, c.Table.pager)
 	if err != nil {
 		return false, fmt.Errorf("store overflow vectors: %w", err)

--- a/internal/minisql/text_pointer.go
+++ b/internal/minisql/text_pointer.go
@@ -1,7 +1,6 @@
 package minisql
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 )
@@ -191,6 +190,155 @@ func (tp *TextPointer) storeOverflowText(ctx context.Context, pager TxPager) err
 	return nil
 }
 
+// updateOverflowText writes overflow pages for tp, reusing the chain rooted at
+// oldFirstPage wherever possible instead of free-then-reallocating.
+//
+// GetOverflowPage calls ModifyPage internally, so the pages it returns are
+// already in the write set and can be overwritten without an additional pager
+// call. The three cases are:
+//
+//   - same size (most common on UPDATE): reuse all old pages, zero free/alloc calls.
+//   - new > old: reuse old pages, call GetFreePage for the tail extension.
+//   - new < old: reuse new-length prefix, call AddFreePage for the excess tail.
+//
+// When oldFirstPage == 0 (old value was inline or absent) the call falls
+// through to storeOverflowText so callers need not special-case this.
+func (tp *TextPointer) updateOverflowText(ctx context.Context, pager TxPager, oldFirstPage PageIndex) error {
+	if tp.IsInline() {
+		return nil
+	}
+	if oldFirstPage == 0 {
+		return tp.storeOverflowText(ctx, pager)
+	}
+	if len(tp.Data) > MaxOverflowTextSize {
+		return fmt.Errorf("text size %d exceeds maximum overflow text size %d", len(tp.Data), MaxOverflowTextSize)
+	}
+
+	// Walk old chain. GetOverflowPage calls ModifyPage, so each page is already
+	// writable; we record the NextPage before the reuse loop overwrites it.
+	type entry struct {
+		page *Page
+		next PageIndex
+	}
+	old := make([]entry, 0, tp.NumberOfPages())
+	for curIdx := oldFirstPage; curIdx > 0; {
+		p, err := pager.GetOverflowPage(ctx, curIdx)
+		if err != nil {
+			return fmt.Errorf("read old overflow page %d: %w", curIdx, err)
+		}
+		next := p.OverflowPage.Header.NextPage
+		old = append(old, entry{p, next})
+		curIdx = next
+	}
+
+	numNewPages := tp.NumberOfPages()
+	numOldPages := uint32(len(old))
+	reuse := min(numNewPages, numOldPages)
+	dataSizeToStore := tp.Length
+
+	var previousPage *Page
+	for i := range reuse {
+		p := old[i].page
+		if i == 0 {
+			tp.FirstPage = p.Index
+		}
+		dataSize := min(dataSizeToStore, MaxOverflowPageData)
+		dataSizeToStore -= dataSize
+		p.OverflowPage.Header.DataSize = dataSize
+		p.OverflowPage.Header.NextPage = 0
+		p.OverflowPage.Data = tp.Data[i*MaxOverflowPageData : i*MaxOverflowPageData+dataSize]
+		if previousPage != nil {
+			previousPage.OverflowPage.Header.NextPage = p.Index
+		}
+		previousPage = p
+	}
+
+	// New text is longer than old chain: allocate extra pages at the tail.
+	for i := reuse; i < numNewPages; i++ {
+		freePage, err := pager.GetFreePage(ctx)
+		if err != nil {
+			return fmt.Errorf("allocate overflow page: %w", err)
+		}
+		dataSize := min(dataSizeToStore, MaxOverflowPageData)
+		dataSizeToStore -= dataSize
+		freePage.OverflowPage = &OverflowPage{
+			Header: OverflowPageHeader{DataSize: dataSize},
+			Data:   tp.Data[i*MaxOverflowPageData : i*MaxOverflowPageData+dataSize],
+		}
+		if previousPage != nil {
+			previousPage.OverflowPage.Header.NextPage = freePage.Index
+		}
+		previousPage = freePage
+	}
+
+	// New text is shorter than old chain: return excess tail pages to the free list.
+	for i := reuse; i < numOldPages; i++ {
+		if err := pager.AddFreePage(ctx, old[i].page.Index); err != nil {
+			return fmt.Errorf("free excess overflow page: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// updateOverflowTexts handles the text-overflow UPDATE hot path, replacing the
+// freeOverflowPages + storeOverflowTexts pair. It only touches columns present
+// in changedCols, which:
+//   - avoids re-storing unchanged overflow columns (which would orphan their
+//     existing pages and create duplicate chains), and
+//   - eliminates the free-then-reallocate cycle by reusing old pages in-place.
+func (r Row) updateOverflowTexts(ctx context.Context, pager TxPager, oldRow Row, changedCols map[string]Column) (Row, error) {
+	for i, col := range r.Columns {
+		if !col.Kind.IsText() {
+			continue
+		}
+		if _, isChanged := changedCols[col.Name]; !isChanged {
+			continue
+		}
+		value := r.Values[i]
+		if !value.Valid {
+			continue
+		}
+		newTP, ok := value.Value.(TextPointer)
+		if !ok {
+			return r, fmt.Errorf("expected TextPointer value for text column %s", col.Name)
+		}
+
+		// Determine whether the old value occupied an overflow chain.
+		var oldFirstPage PageIndex
+		if oldVal, ok2 := oldRow.GetValue(col.Name); ok2 && oldVal.Valid {
+			if oldTP, ok3 := oldVal.Value.(TextPointer); ok3 && !oldTP.IsInline() {
+				oldFirstPage = oldTP.FirstPage
+			}
+		}
+
+		if newTP.IsInline() {
+			// New value fits inline; free the old overflow chain if one existed.
+			if oldFirstPage != 0 {
+				for curIdx := oldFirstPage; curIdx > 0; {
+					p, err := pager.GetOverflowPage(ctx, curIdx)
+					if err != nil {
+						return r, fmt.Errorf("read overflow page %d: %w", curIdx, err)
+					}
+					next := p.OverflowPage.Header.NextPage
+					if err := pager.AddFreePage(ctx, curIdx); err != nil {
+						return r, fmt.Errorf("free overflow page %d: %w", curIdx, err)
+					}
+					curIdx = next
+				}
+			}
+			continue
+		}
+
+		// New value needs overflow pages — reuse old chain where possible.
+		if err := newTP.updateOverflowText(ctx, pager, oldFirstPage); err != nil {
+			return r, fmt.Errorf("update overflow text for column %s: %w", col.Name, err)
+		}
+		r.Values[i] = OptionalValue{Valid: true, Value: newTP}
+	}
+	return r, nil
+}
+
 func (tp TextPointer) readOverflowText(ctx context.Context, pager TxPager) (TextPointer, error) {
 	if tp.IsInline() {
 		return tp, nil
@@ -216,7 +364,7 @@ func (tp TextPointer) readOverflowText(ctx context.Context, pager TxPager) (Text
 		remainingSize -= dataSize
 		currentPageIdx = overflowPage.OverflowPage.Header.NextPage
 	}
-	tp.Data = bytes.Trim(overflowData, "\x00")
+	tp.Data = overflowData
 	return tp, nil
 }
 

--- a/internal/minisql/update_test.go
+++ b/internal/minisql/update_test.go
@@ -362,18 +362,19 @@ func TestTable_Update_Overflow(t *testing.T) {
 		require.Equal(t, 5, int(pager.TotalPages()))
 		assert.NotNil(t, pager.pages[0].LeafNode)
 		assert.NotNil(t, pager.pages[1].FreePage)
-		assert.NotNil(t, pager.pages[2].FreePage) // freed overflow page
-		// freed overflow page which gets reused when shrinking from 2 to 1 overflow pages
-		assert.NotNil(t, pager.pages[3].OverflowPage)
+		// page 2 is reused in-place (first page of old chain → first page of new chain)
+		assert.NotNil(t, pager.pages[2].OverflowPage)
+		// page 3 is freed as the excess tail (old chain was 2 pages, new is 1)
+		assert.NotNil(t, pager.pages[3].FreePage)
 		assert.NotNil(t, pager.pages[4].OverflowPage)
 
-		assert.Equal(t, 0, int(pager.pages[3].OverflowPage.Header.NextPage))
+		assert.Equal(t, 0, int(pager.pages[2].OverflowPage.Header.NextPage))
 		assert.Equal(t, 0, int(pager.pages[4].OverflowPage.Header.NextPage))
 
-		assert.Equal(t, MaxOverflowPageData-100, int(pager.pages[3].OverflowPage.Header.DataSize))
+		assert.Equal(t, MaxOverflowPageData-100, int(pager.pages[2].OverflowPage.Header.DataSize))
 		assert.Equal(t, int(MaxInlineVarchar+200), int(pager.pages[4].OverflowPage.Header.DataSize))
 
-		assertFreePages(t, tablePager, []PageIndex{2, 1})
+		assertFreePages(t, tablePager, []PageIndex{3, 1})
 	})
 
 	t.Run("Update overflow text to expand overflow pages from 1 to 2", func(t *testing.T) {
@@ -414,19 +415,20 @@ func TestTable_Update_Overflow(t *testing.T) {
 		require.Equal(t, 5, int(pager.TotalPages()))
 		assert.NotNil(t, pager.pages[0].LeafNode)
 		assert.NotNil(t, pager.pages[1].FreePage)
-		// this free page gets reused when expanding from 1 to 2 overflow pages
+		// page 2 still holds rows[2]'s updated profile (unchanged by this test)
 		assert.NotNil(t, pager.pages[2].OverflowPage)
-		// freed overflow page which gets reused when shrinking from 2 to 1 overflow pages
+		// page 3 is re-allocated from the free list as the second page of the expansion
 		assert.NotNil(t, pager.pages[3].OverflowPage)
+		// page 4 is reused in-place as the first page of rows[0]'s expanded profile
 		assert.NotNil(t, pager.pages[4].OverflowPage)
 
 		assert.Equal(t, 0, int(pager.pages[3].OverflowPage.Header.NextPage))
-		assert.Equal(t, 2, int(pager.pages[4].OverflowPage.Header.NextPage))
+		assert.Equal(t, 3, int(pager.pages[4].OverflowPage.Header.NextPage))
 		assert.Equal(t, 0, int(pager.pages[2].OverflowPage.Header.NextPage))
 
-		assert.Equal(t, MaxOverflowPageData-100, int(pager.pages[3].OverflowPage.Header.DataSize))
+		assert.Equal(t, MaxOverflowPageData-100, int(pager.pages[2].OverflowPage.Header.DataSize))
 		assert.Equal(t, MaxOverflowPageData, int(pager.pages[4].OverflowPage.Header.DataSize))
-		assert.Equal(t, 200, int(pager.pages[2].OverflowPage.Header.DataSize))
+		assert.Equal(t, 200, int(pager.pages[3].OverflowPage.Header.DataSize))
 
 		assertFreePages(t, tablePager, []PageIndex{1})
 	})


### PR DESCRIPTION
Replace the free-then-reallocate cycle (freeOverflowPages + storeOverflowTexts) with updateOverflowTexts, which writes new data directly into the existing overflow page chain via GetOverflowPage (which already calls ModifyPage internally). For same-size updates this eliminates N AddFreePage + N GetFreePage calls per overflow column, halving allocations at 16 pages (131→60) and cutting latency by 26–43% across blob sizes. Shorter new values free excess tail pages; longer values allocate extra pages at the tail.

Also fixes a latent bug where unchanged text-overflow columns were re-stored on every UPDATE, orphaning their existing page chains and creating duplicate chains.

Add overflow benchmarks covering INSERT, point read, full scan, and UPDATE at four blob sizes (inline/1pg/4pg/16pg) for both MiniSQL and SQLite drivers. Remove spurious bytes.Trim from readOverflowText (DataSize per page makes null padding impossible and trim would corrupt values ending with \x00). Update RESULTS.md with measured numbers and optimization notes.