### PR TITLE
Add -o flag for exporting query results to a CSV file

### DIFF
--- a/cmd/minisql/main.go
+++ b/cmd/minisql/main.go
@@ -26,6 +26,8 @@ Options:
   -c <query>      Execute a single SQL statement and exit (no shell).
                   May be specified multiple times to run several statements.
   -csv            Set output mode to CSV (default: table).
+  -o <file>       Write query output to a file in CSV format (implies -csv).
+                  Errors and status messages are still printed to stderr.
   -version        Print version information and exit.
   -h, --help      Show this message.
 
@@ -34,16 +36,19 @@ Examples:
   minisql -c 'select * from "users"' my.db
   minisql -c 'create table "t" (id int8)' -c 'insert into "t" values (1)' my.db
   minisql -csv -c 'select * from "users"' my.db
+  minisql -o report.csv -c 'select * from "users"' my.db
 `
 
 func main() {
 	var (
 		queries     multiFlag
 		csvMode     bool
+		outputFile  string
 		showVersion bool
 	)
 	flag.Var(&queries, "c", "SQL statement to execute (may be repeated)")
 	flag.BoolVar(&csvMode, "csv", false, "output in CSV format")
+	flag.StringVar(&outputFile, "o", "", "write query output to file (implies -csv)")
 	flag.BoolVar(&showVersion, "version", false, "print version and exit")
 	flag.Usage = func() { fmt.Fprint(os.Stderr, usage) }
 	flag.Parse()
@@ -76,8 +81,18 @@ func main() {
 	defer db.Close()
 
 	sh := newShell(db, filePath)
-	if csvMode {
+	if csvMode || outputFile != "" {
 		sh.mode = modeCSV
+	}
+	if outputFile != "" {
+		f, err := os.Create(outputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening output file %s: %v\n", outputFile, err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		sh.out = f
+		sh.errOut = os.Stderr
 	}
 
 	if len(queries) > 0 {

--- a/cmd/minisql/main.go
+++ b/cmd/minisql/main.go
@@ -40,6 +40,10 @@ Examples:
 `
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	var (
 		queries     multiFlag
 		csvMode     bool
@@ -55,12 +59,12 @@ func main() {
 
 	if showVersion {
 		fmt.Printf("minisql %s (commit %s, built %s)\n", version, commit, date)
-		return
+		return 0
 	}
 
 	if flag.NArg() != 1 {
 		fmt.Fprint(os.Stderr, usage)
-		os.Exit(1)
+		return 1
 	}
 
 	filePath := flag.Arg(0)
@@ -68,7 +72,7 @@ func main() {
 	db, err := sql.Open("minisql", filePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error opening %s: %v\n", filePath, err)
-		os.Exit(1)
+		return 1
 	}
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
@@ -76,7 +80,7 @@ func main() {
 	if err := db.Ping(); err != nil {
 		_ = db.Close()
 		fmt.Fprintf(os.Stderr, "Error connecting to %s: %v\n", filePath, err)
-		os.Exit(1)
+		return 1
 	}
 	defer db.Close()
 
@@ -88,7 +92,7 @@ func main() {
 		f, err := os.Create(outputFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error opening output file %s: %v\n", outputFile, err)
-			os.Exit(1)
+			return 1
 		}
 		defer f.Close()
 		sh.out = f
@@ -99,10 +103,11 @@ func main() {
 		for _, q := range queries {
 			sh.exec(q)
 		}
-		return
+		return 0
 	}
 
 	sh.run()
+	return 0
 }
 
 // multiFlag collects repeated -c flags into a slice.

--- a/cmd/minisql/shell.go
+++ b/cmd/minisql/shell.go
@@ -23,7 +23,8 @@ const (
 
 type shell struct {
 	db       *sql.DB
-	out      io.Writer
+	out      io.Writer // receives query result data (table or CSV rows)
+	errOut   io.Writer // receives errors, status lines, timing — never mixed into result output
 	mode     outputMode
 	timer    bool
 	buf      strings.Builder
@@ -37,6 +38,7 @@ func newShell(db *sql.DB, filePath string) *shell {
 	sh := &shell{
 		db:       db,
 		out:      os.Stdout,
+		errOut:   os.Stdout,
 		mode:     modeTable,
 		filePath: filePath,
 		isatty:   isatty.IsTerminal(os.Stdin.Fd()),
@@ -76,7 +78,7 @@ func historyFile() string {
 
 func (s *shell) run() {
 	if s.isatty {
-		fmt.Fprintf(s.out, "MiniSQL — %s\nEnter \".help\" for usage hints.\n", s.filePath)
+		fmt.Fprintf(s.errOut, "MiniSQL — %s\nEnter \".help\" for usage hints.\n", s.filePath)
 	}
 	if s.liner != nil {
 		// Load history from previous sessions.
@@ -207,9 +209,9 @@ func (s *shell) exec(query string) {
 func (s *shell) execQuery(query string, start time.Time) {
 	rows, err := s.db.Query(query)
 	if err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 		if s.timer {
-			fmt.Fprintf(s.out, "Time: %.3fs\n", time.Since(start).Seconds())
+			fmt.Fprintf(s.errOut, "Time: %.3fs\n", time.Since(start).Seconds())
 		}
 		return
 	}
@@ -217,7 +219,7 @@ func (s *shell) execQuery(query string, start time.Time) {
 
 	cols, err := rows.Columns()
 	if err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 		return
 	}
 
@@ -230,7 +232,7 @@ func (s *shell) execQuery(query string, start time.Time) {
 
 	for rows.Next() {
 		if err := rows.Scan(ptrs...); err != nil {
-			fmt.Fprintf(s.out, "Error: %v\n", err)
+			fmt.Fprintf(s.errOut, "Error: %v\n", err)
 			return
 		}
 		row := make([]string, len(cols))
@@ -240,7 +242,7 @@ func (s *shell) execQuery(query string, start time.Time) {
 		resultRows = append(resultRows, row)
 	}
 	if err := rows.Err(); err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 		return
 	}
 
@@ -249,7 +251,7 @@ func (s *shell) execQuery(query string, start time.Time) {
 	}
 
 	if s.timer {
-		fmt.Fprintf(s.out, "Time: %.3fs\n", time.Since(start).Seconds())
+		fmt.Fprintf(s.errOut, "Time: %.3fs\n", time.Since(start).Seconds())
 	}
 }
 
@@ -257,20 +259,20 @@ func (s *shell) execQuery(query string, start time.Time) {
 func (s *shell) execStatement(query string, start time.Time) {
 	result, err := s.db.Exec(query)
 	if err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 		if s.timer {
-			fmt.Fprintf(s.out, "Time: %.3fs\n", time.Since(start).Seconds())
+			fmt.Fprintf(s.errOut, "Time: %.3fs\n", time.Since(start).Seconds())
 		}
 		return
 	}
 
 	n, err := result.RowsAffected()
 	if err == nil && n > 0 {
-		fmt.Fprintf(s.out, "%d row(s) affected\n", n)
+		fmt.Fprintf(s.errOut, "%d row(s) affected\n", n)
 	}
 
 	if s.timer {
-		fmt.Fprintf(s.out, "Time: %.3fs\n", time.Since(start).Seconds())
+		fmt.Fprintf(s.errOut, "Time: %.3fs\n", time.Since(start).Seconds())
 	}
 }
 
@@ -304,7 +306,7 @@ func (s *shell) dotCommand(cmd string) {
 
 	case ".mode":
 		if len(fields) < 2 {
-			fmt.Fprintf(s.out, "current output mode: %s\n", s.modeName())
+			fmt.Fprintf(s.errOut, "current output mode: %s\n", s.modeName())
 			return
 		}
 		switch fields[1] {
@@ -313,12 +315,12 @@ func (s *shell) dotCommand(cmd string) {
 		case "csv":
 			s.mode = modeCSV
 		default:
-			fmt.Fprintf(s.out, "Error: unknown mode %q (choose: table, csv)\n", fields[1])
+			fmt.Fprintf(s.errOut, "Error: unknown mode %q (choose: table, csv)\n", fields[1])
 		}
 
 	case ".timer":
 		if len(fields) < 2 {
-			fmt.Fprintf(s.out, "timer: %v\n", onOff(s.timer))
+			fmt.Fprintf(s.errOut, "timer: %v\n", onOff(s.timer))
 			return
 		}
 		switch fields[1] {
@@ -327,7 +329,7 @@ func (s *shell) dotCommand(cmd string) {
 		case "off":
 			s.timer = false
 		default:
-			fmt.Fprintf(s.out, "Error: unknown timer setting %q (choose: on, off)\n", fields[1])
+			fmt.Fprintf(s.errOut, "Error: unknown timer setting %q (choose: on, off)\n", fields[1])
 		}
 
 	case ".tables":
@@ -343,7 +345,7 @@ func (s *shell) dotCommand(cmd string) {
 		s.printDDL(query)
 
 	default:
-		fmt.Fprintf(s.out, "Error: unknown dot command %q — try .help\n", fields[0])
+		fmt.Fprintf(s.errOut, "Error: unknown dot command %q — try .help\n", fields[0])
 	}
 }
 
@@ -352,7 +354,7 @@ func (s *shell) dotCommand(cmd string) {
 func (s *shell) printDDL(query string) {
 	rows, err := s.db.Query(query)
 	if err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 		return
 	}
 	defer rows.Close()
@@ -360,7 +362,7 @@ func (s *shell) printDDL(query string) {
 	for rows.Next() {
 		var ddl string
 		if err := rows.Scan(&ddl); err != nil {
-			fmt.Fprintf(s.out, "Error: %v\n", err)
+			fmt.Fprintf(s.errOut, "Error: %v\n", err)
 			return
 		}
 		if !first {
@@ -371,7 +373,7 @@ func (s *shell) printDDL(query string) {
 		fmt.Fprintln(s.out, clean+";")
 	}
 	if err := rows.Err(); err != nil {
-		fmt.Fprintf(s.out, "Error: %v\n", err)
+		fmt.Fprintf(s.errOut, "Error: %v\n", err)
 	}
 }
 

--- a/cmd/minisql/shell_test.go
+++ b/cmd/minisql/shell_test.go
@@ -33,11 +33,14 @@ func openTestDB(t *testing.T) *sql.DB {
 }
 
 // newTestShell builds a shell that reads from input and writes to a buffer.
+// Both result data and status/error messages go to the same buffer so that
+// existing assertions on "Error:" and "row(s) affected" continue to work.
 func newTestShell(db *sql.DB, input string) (*shell, *strings.Builder) {
 	var out strings.Builder
 	sh := &shell{
 		db:      db,
 		out:     &out,
+		errOut:  &out,
 		mode:    modeTable,
 		scanner: bufio.NewScanner(strings.NewReader(input)),
 		isatty:  false,
@@ -467,5 +470,85 @@ func TestShell_Exec_Vector_Display(t *testing.T) {
 	got := out.String()
 	assert.NotContains(t, got, "Error:")
 	assert.Contains(t, got, "[1.5, 2, 3.75]")
+}
+
+// --- -o file output ---
+
+// newFileShell creates a shell whose result output goes to f and whose
+// error/status output goes to errBuf, simulating the -o flag behaviour.
+func newFileShell(db *sql.DB, f *os.File, errBuf *strings.Builder) *shell {
+	return &shell{
+		db:      db,
+		out:     f,
+		errOut:  errBuf,
+		mode:    modeCSV,
+		scanner: bufio.NewScanner(strings.NewReader("")),
+		isatty:  false,
+	}
+}
+
+func TestShell_OutputFile_WritesCSV(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.Exec(`create table "t" (id int8, name varchar(255))`)
+	require.NoError(t, err)
+	_, err = db.Exec(`insert into "t" (id, name) values (1, 'alice'), (2, 'bob')`)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "minisql_out_*.csv")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
+	var errBuf strings.Builder
+	sh := newFileShell(db, f, &errBuf)
+	sh.exec(`select id, name from "t"`)
+	require.NoError(t, f.Close())
+
+	content, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, "id,name\n1,alice\n2,bob\n", string(content))
+	assert.Empty(t, errBuf.String())
+}
+
+func TestShell_OutputFile_ErrorsGoToErrOut(t *testing.T) {
+	db := openTestDB(t)
+
+	f, err := os.CreateTemp("", "minisql_out_*.csv")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
+	var errBuf strings.Builder
+	sh := newFileShell(db, f, &errBuf)
+	sh.exec(`select * from "nonexistent"`)
+	require.NoError(t, f.Close())
+
+	// Error must appear in errOut, not in the CSV file.
+	content, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Empty(t, string(content))
+	assert.Contains(t, errBuf.String(), "Error:")
+}
+
+func TestShell_OutputFile_NullAndSpecialChars(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.Exec(`create table "t" (id int8, note varchar(255))`)
+	require.NoError(t, err)
+	_, err = db.Exec(`insert into "t" (id, note) values (1, 'hello, world'), (2, null)`)
+	require.NoError(t, err)
+
+	f, err := os.CreateTemp("", "minisql_out_*.csv")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
+	var errBuf strings.Builder
+	sh := newFileShell(db, f, &errBuf)
+	sh.exec(`select id, note from "t"`)
+	require.NoError(t, f.Close())
+
+	content, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	// comma in value must be quoted; NULL renders as empty string in CSV.
+	assert.Contains(t, string(content), `"hello, world"`)
+	assert.Contains(t, string(content), "2,")
+	assert.Empty(t, errBuf.String())
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,7 @@ The database file is created automatically if it does not exist.
 |------|-------------|
 | `-c <query>` | Execute a SQL statement and exit (may be repeated). |
 | `-csv` | Set output format to CSV (default: table). |
+| `-o <file>` | Write query output to a file in CSV format (implies `-csv`). Errors and status messages are still printed to stderr. |
 | `-h` / `--help` | Print usage. |
 
 ## Interactive shell
@@ -87,6 +88,29 @@ minisql -csv -c 'select * from "users"' my.db | cut -d, -f2
 ```
 
 Output mode flags apply to `-c` as well — combine `-csv` with `-c` for machine-readable output.
+
+## Exporting to a CSV file (`-o`)
+
+Use `-o <file>` to write query results directly to a file instead of stdout. CSV format is enabled automatically.
+
+```bash
+# Export a table to a file
+minisql -o users.csv -c 'select * from "users"' my.db
+
+# Export with an explicit query
+minisql -o report.csv -c 'select name, age from "users" where age > 25 order by age' my.db
+```
+
+Errors and status messages (row counts, timing) are printed to stderr and never written to the output file, so the file always contains valid CSV even when something goes wrong.
+
+```bash
+# The CSV file is clean; errors appear only in the terminal
+minisql -o out.csv -c 'select * from "missing_table"' my.db
+# stderr: Error: table "missing_table" not found
+# out.csv: (empty)
+```
+
+`-o` is intended for a single SELECT query. When multiple `-c` flags are used alongside `-o`, each SELECT writes its own header line followed by its rows, which produces invalid CSV for most parsers. For multi-step exports, run a single query that joins or unions the data you need.
 
 ## Dot commands
 


### PR DESCRIPTION
Introduces an errOut writer to the shell so result data (written to s.out) is always separate from errors, status lines, and timing output (written to s.errOut). When -o <file> is given, query rows go to the file in CSV format while errors remain visible on stderr. -csv is implied automatically. Three new tests cover correct CSV output, error routing, and NULL / special-character escaping.