### PR TITLE
Reduce inverted index build allocations by ~16% via insert-only cell …

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -11,6 +11,8 @@ SQLite comparisons use the `sqlite` driver compiled into the same test binary. M
 
 2026-06-16: VACUUM correctness and I/O reduction (Priority 4) — three changes targeting VACUUM: (1) `Database.closeForDiscard()` closes the live DB without checkpointing or syncing (the live DB is discarded immediately after close, so the WAL checkpoint is wasted work); (2) `WAL.CloseNoSync()` / `pagerImpl.CloseNoSync()` close file handles without fdatasync for the discard path; (3) after VACUUM the WAL is now correctly restored — previously the WAL was lost after every VACUUM and all subsequent writes used the slower `commitDirect` path instead of WAL. The microbenchmark (1000-row table, thousands of VACUUMs/second) shows a ~20% regression because WAL is now properly maintained across VACUUM iterations (each seeding pass now goes through WAL, which is correct but adds per-iteration overhead vs the pre-existing WAL-loss bug). Real-world VACUUM on large tables with significant WAL backlogs benefits from skipping the checkpoint.
 
+2026-06-16: Inverted index build allocation reduction — skip `append(deleteCells, insertCells...)` copy in `appendSegmentCells` for the insert-only path (build, online INSERT). Both callers discard their slice arguments after the call, so aliasing `cells = insertCells` and sorting in-place is safe. Full-text build: **1.42 MiB → 1.19 MiB (−16%)**, 3.44 ms → 3.08 ms (−10%); JSON inverted build: **1.29 MiB → 1.17 MiB (−9%)**, 2.11 ms → 2.00 ms (−5%).
+
 2026-06-16: INSERT allocation reduction (Priority 3) — four micro-optimisations targeting the INSERT hot path: (1) `Seek`/`SeekWithPrefix`/`SeekLastKey` converted to iterative loops, eliminating goroutine-stack growth that appeared as heap allocations in pprof; (2) `SeekNextRowID` now returns `Cursor` by value instead of `*Cursor`, removing one heap allocation per row; (3) `WithTransaction` context wrap cached on `Conn` for explicit-transaction batches, eliminating one `context.WithValue` allocation per statement; (4) `typeCodes []byte` slice cached on `Table` at construction time and reused in `saveToCell`, removing one `make([]byte, nCols)` per INSERT. Net effect on `BenchmarkInsert_Batch` (100 rows/tx): **2637 → 2153 allocs/op (−18.4%)**, 134 KiB → 124 KiB (−7.5%).
 
 2026-06-16: Vector overflow page reuse on UPDATE — `updateOverflowVectors` replaces the `freeOverflowPages` + `storeOverflowVectors` pair with in-place reuse of existing overflow pages. `VECTOR(n)` dimensions are fixed at column-definition time, so old and new chains always have the same page count; every UPDATE is a pure page-reuse with zero `AddFreePage` + `GetFreePage` calls. Dimension validation in `coerceColumnValue` (stmt.go) guarantees the invariant holds before any data reaches `updateOverflow`.
@@ -89,7 +91,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| Build index | 3.44 ms | 2.27 ms | 1.52× | 1.42 MiB | 392 B | 12,289 / 20 |
+| Build index | 3.08 ms | 2.08 ms | 1.49× | 1.19 MiB | 392 B | 12,222 / 20 |
 | Insert with index | 40.2 µs | 100.5 µs | 0.40× | 14.4 KiB | 271 B | 135 / 10 |
 | Search single term, rare | 5.4 µs | 7.0 µs | 0.77× | 2.1 KiB | 408 B | 39 / 13 |
 | Search single term, medium | 5.3 µs | 8.3 µs | 0.64× | 2.1 KiB | 408 B | 39 / 13 |
@@ -109,7 +111,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 
 | Benchmark | Time | Memory | Allocs |
 |---|---|---|---|
-| Build index | 2.11 ms | 1.29 MiB | 26,670 |
+| Build index | 2.00 ms | 1.17 MiB | 26,669 |
 | Insert with index | 71.2 µs | 163.5 KiB | 150 |
 | Contains after deletes | 61.4 µs | 19.0 KiB | 75 |
 | Update with index | 5.9 µs | 4.0 KiB | 43 |
@@ -186,8 +188,8 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 | DISTINCT | High-cardinality distinct + ORDER BY | 4.54 MiB |
 | DISTINCT | High-cardinality distinct + ORDER BY indexed | 4.38 MiB |
 | DISTINCT | High-cardinality distinct (no ORDER BY) | 1.26 MiB |
-| Full-text | Build index | 1.42 MiB |
-| JSON inverted | Build index | 1.29 MiB |
+| Full-text | Build index | 1.19 MiB |
+| JSON inverted | Build index | 1.17 MiB |
 | SELECT | Full scan | 1.26 MiB |
 | Join | Inner join, small-large | 1.00 MiB |
 | Join | Left join, unmatched rows | 869 KiB |
@@ -241,7 +243,7 @@ One row seeded; each b.N iteration updates the blob body. Old overflow chain is 
 ### Good Next Optimisation Targets
 
 - HNSW build allocation counts are stable; build memory remains the largest broad-suite outlier at 3k rows (72.9 MiB for dims768). The 3k corpus was chosen so each sub-benchmark completes in 2–6 s (was 9–38 s at 10k). Single-iteration benchmarks carry high variance — compare only against a fresh count=3 run.
-- Full-text and JSON build paths still allocate ~1.3–1.4 MiB per operation and remain the most relevant inverted-index targets.
+- Full-text and JSON build paths still allocate ~1.2 MiB per operation and remain the most relevant inverted-index targets.
 - GROUP BY / HAVING memory gap vs SQLite (9.6× / 13.3×) is largely structural: Go's runtime map has higher per-entry overhead than SQLite's C hash table. Further reduction requires a custom open-address hash table — low ROI at this stage.
 - DISTINCT high cardinality without ORDER BY (1.26 MiB vs SQLite 586 KiB, 2.2×): streaming hash-set path; the gap is structural — SQLite sorts/hashes on the C side and delivers rows lazily, avoiding upfront Go heap allocation.
 - DISTINCT + ORDER BY high cardinality (4.53 MiB vs SQLite 586 KiB): ORDER BY requires upfront materialization of all rows before sorting. The sort-then-adjacent-dedup optimization removes hash-set overhead from deduplication, but the dominant cost is O(N) row materialization — unavoidable without disk-backed sort (see ROADMAP).

--- a/internal/minisql/database.go
+++ b/internal/minisql/database.go
@@ -2033,6 +2033,7 @@ func (d *Database) populateJSONInvertedIndex(ctx context.Context, table *Table, 
 	rowIDsByTerm := make(map[string][]RowID, populateInvertedIndexInitialTerms)
 	termBuf := make([]string, 0, 16)
 	bufferedPostings := 0
+
 	flush := func(reset bool) error {
 		if len(rowIDsByTerm) == 0 {
 			return nil
@@ -2049,6 +2050,7 @@ func (d *Database) populateJSONInvertedIndex(ctx context.Context, table *Table, 
 		bufferedPostings = 0
 		return nil
 	}
+
 	addTerms := func(rowID RowID, terms []string) error {
 		for _, term := range terms {
 			rowIDsByTerm[term] = append(rowIDsByTerm[term], rowID)

--- a/internal/minisql/log_structured_inverted_index.go
+++ b/internal/minisql/log_structured_inverted_index.go
@@ -1464,7 +1464,14 @@ func (idx *logStructuredInvertedIndex) appendSegmentCells(
 	deleteCells, insertCells []invertedSegmentCell,
 	postingCount uint32,
 ) error {
-	cells := append(deleteCells, insertCells...)
+	// For the common insert-only path (build, online INSERT), skip the append-copy
+	// and sort insertCells in-place. Both callers discard their slices after this call.
+	var cells []invertedSegmentCell
+	if len(deleteCells) == 0 {
+		cells = insertCells
+	} else {
+		cells = append(deleteCells, insertCells...)
+	}
 	sortSegmentCells(cells)
 	firstTerm, lastTerm := segmentTermBounds(cells)
 	rootPage, err := idx.writeSegmentCells(ctx, cells)


### PR DESCRIPTION
…path

Skip the `append(deleteCells, insertCells...)` copy in `appendSegmentCells` when deleteCells is empty (the common path for builds and online INSERTs). Both callers discard their slice arguments after the call, so aliasing `cells = insertCells` and sorting in-place is safe.

Full-text build: 1.42 MiB → 1.19 MiB (−16%), 3.44 ms → 3.08 ms (−10%).
JSON inverted build: 1.29 MiB → 1.17 MiB (−9%), 2.11 ms → 2.00 ms (−5%).