### PR TITLE
Reduce VACUUM I/O from O(commits×pages) pwrite+fsync to one sequentia…

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,6 +9,8 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`); memory figures are heap allocations reported by the Go runtime. Single-iteration benchmarks (HNSW build at large N) carry higher variance than multi-iteration ones.
 
+2026-06-17: VACUUM deferred-write optimization — `pagerImpl.SetNoIntermediateSync(true)` on the temp DB eliminates per-commit `pwrite`+`fsync` calls during the copy phase. All cached pages are written to disk in a single sequential `WriteAt` per consecutive run at `Close()` time, followed by one `fsync`. Reduces I/O syscall count from O(commits × pages) to O(1 fsync + ~3 writes). VACUUM small: **1.51 ms → 1.39 ms (−8%)**; allocs: 5,722 → 5,668 (−1%); B/op: +17 KiB from the contiguous flush buffer (traded N pool round-trips for one heap allocation).
+
 2026-06-17: Full-text build — flat-buffer sort-at-flush — replaced the per-term `map[string][]invertedPosting` accumulation map in `populateFullTextIndex` with a flat `[]flatPosting` slice sorted at flush time. A single contiguous `postingPool` replaces per-term `append` growth events. Allocations reduced **−24%** (12,298 → 9,373). The 1000-doc benchmark shows a memory increase (1.06 MiB → 1.87 MiB) due to a 16-byte per-entry string header overhead and buffer growth copies in a cold-start workload that never reaches the 64K-posting flush threshold; in production with large tables and multi-flush cycles the flat buffer is reused after the first flush, giving ~68% per-flush byte reduction and ~99.9% alloc-event reduction.
 
 2026-06-16: VACUUM correctness and I/O reduction (Priority 4) — three changes targeting VACUUM: (1) `Database.closeForDiscard()` closes the live DB without checkpointing or syncing (the live DB is discarded immediately after close, so the WAL checkpoint is wasted work); (2) `WAL.CloseNoSync()` / `pagerImpl.CloseNoSync()` close file handles without fdatasync for the discard path; (3) after VACUUM the WAL is now correctly restored — previously the WAL was lost after every VACUUM and all subsequent writes used the slower `commitDirect` path instead of WAL. The microbenchmark (1000-row table, thousands of VACUUMs/second) shows a ~20% regression because WAL is now properly maintained across VACUUM iterations (each seeding pass now goes through WAL, which is correct but adds per-iteration overhead vs the pre-existing WAL-loss bug). Real-world VACUUM on large tables with significant WAL backlogs benefits from skipping the checkpoint.
@@ -132,7 +134,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| VACUUM small | 1.51 ms | 265 µs | 5.7× | 728 KiB | 89 B | 5,722 / 4 |
+| VACUUM small | 1.39 ms | 265 µs | 5.2× | 745 KiB | 89 B | 5,668 / 4 |
 | WAL checkpoint | 203 µs | 106 µs | 1.9× | 3.3 KiB | 440 B | 37 / 12 |
 | EXPLAIN | 5.2 µs | 1.2 µs | 4.2× | 5.5 KiB | 680 B | 51 / 18 |
 
@@ -197,7 +199,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 | SELECT | Full scan | 1.23 MiB |
 | Join | Inner join, small-large | 1.00 MiB |
 | Join | Left join, unmatched rows | 869 KiB |
-| Maintenance | VACUUM small | 728 KiB (WAL overhead included since Priority 4 WAL-restore fix) |
+| Maintenance | VACUUM small | 745 KiB (WAL overhead included since Priority 4 WAL-restore fix; +17 KiB vs prior baseline from combined page-flush buffer — one contiguous alloc replaces N pool round-trips) |
 | Subquery | IN list | 559 KiB |
 
 ### Overflow Page INSERT
@@ -251,4 +253,4 @@ One row seeded; each b.N iteration updates the blob body. Old overflow chain is 
 - GROUP BY / HAVING memory gap vs SQLite (9.5× / 13.4×) is largely structural: Go's runtime map has higher per-entry overhead than SQLite's C hash table. Further reduction requires a custom open-address hash table — low ROI at this stage.
 - DISTINCT high cardinality without ORDER BY (1.26 MiB vs SQLite 586 KiB, 2.2×): streaming hash-set path; the gap is structural — SQLite sorts/hashes on the C side and delivers rows lazily, avoiding upfront Go heap allocation.
 - DISTINCT + ORDER BY high cardinality (4.54 MiB vs SQLite 586 KiB): ORDER BY requires upfront materialization of all rows before sorting. The sort-then-adjacent-dedup optimization removes hash-set overhead from deduplication, but the dominant cost is O(N) row materialization — unavoidable without disk-backed sort (see ROADMAP).
-- VACUUM is much improved after streaming row copy, though it still allocates far more than SQLite because it rebuilds the compacted MiniSQL database through normal table/index write paths.
+- VACUUM (1.39 ms vs SQLite 265 µs, 5.2×): deferred-write optimization eliminated per-commit fsyncs and now batches all page writes into one sequential I/O at close. Remaining gap vs SQLite is structural — MiniSQL rebuilds the B-tree row-by-row through normal INSERT paths (parse, marshal, split), while SQLite bulk-copies pages directly. A page-level bulk-copy path for the temp DB would close most of the gap.

--- a/internal/minisql/pager.go
+++ b/internal/minisql/pager.go
@@ -45,6 +45,12 @@ type pagerImpl struct {
 	mu             sync.RWMutex
 	dbHeader       DatabaseHeader
 	totalPages     uint32
+	// noIntermediateSync defers all writes to Close(): Flush/FlushBatch skip
+	// WriteAt+fsync, letting pages accumulate in the pager cache. Close() then
+	// writes all cached pages in sorted order — one pwrite per consecutive run —
+	// and does a single fsync. Used by the VACUUM temp DB to collapse O(commits)
+	// pwrite+fsync calls into one sequential write + one fsync.
+	noIntermediateSync bool
 }
 
 // NewPager opens the database file and initialises the pager.
@@ -130,6 +136,14 @@ func (p *pagerImpl) SetCipher(c *pkgcrypto.PageCipher) {
 	p.cipher = c
 }
 
+// SetNoIntermediateSync controls whether Flush/FlushBatch skip fsync after each
+// write, deferring durability to the single fsync in Close().  Enable this for
+// temp/scratch files (like the VACUUM copy) that are discarded on crash anyway —
+// it reduces the fsync count from O(commits) to 1.
+func (p *pagerImpl) SetNoIntermediateSync(v bool) {
+	p.noIntermediateSync = v
+}
+
 // CloseNoSync closes the underlying file handle without syncing. Used when the
 // database file is being discarded (e.g. during VACUUM of the live database).
 func (p *pagerImpl) CloseNoSync() error {
@@ -137,11 +151,131 @@ func (p *pagerImpl) CloseNoSync() error {
 }
 
 // Close syncs the file to ensure pending writes are flushed, then closes it.
+// When noIntermediateSync is set, all cached pages are written to disk first
+// (in sorted-index order, with consecutive pages in one WriteAt), then synced.
 func (p *pagerImpl) Close() error {
+	if p.noIntermediateSync {
+		if err := p.flushAllCached(); err != nil {
+			return fmt.Errorf("deferred flush on close: %w", err)
+		}
+	}
 	if err := fastSync(p.file); err != nil {
 		return fmt.Errorf("failed to sync file before close: %w", err)
 	}
 	return p.file.Close()
+}
+
+// flushAllCached writes every page currently in the pager cache to the DB file.
+// Page 0 is written first with its special header layout; all other pages are
+// written in ascending index order, with consecutive runs coalesced into a
+// single WriteAt to minimise syscall count.
+// Called by Close() when noIntermediateSync is true.
+func (p *pagerImpl) flushAllCached() error {
+	p.mu.RLock()
+	dbHeader := p.dbHeader
+	pages := p.pages // read-only snapshot of the slice header
+	p.mu.RUnlock()
+
+	// Collect non-nil, non-root page indices.
+	// Page 0 uses a different on-disk layout (interleaved DB header), so it is
+	// written first via writeRootPage.
+	nonRoot := make([]PageIndex, 0, len(pages))
+	for i, pg := range pages {
+		if pg == nil {
+			continue
+		}
+		if i == 0 {
+			if err := p.writeRootPage(pg, &dbHeader); err != nil {
+				return fmt.Errorf("flush page 0: %w", err)
+			}
+			continue
+		}
+		nonRoot = append(nonRoot, PageIndex(i))
+	}
+
+	if len(nonRoot) == 0 {
+		return nil
+	}
+
+	// nonRoot is already in ascending order (built by iterating pages[]).
+	// Coalesce consecutive pages into single WriteAt calls.
+	runStart := 0
+	for i := 1; i <= len(nonRoot); i++ {
+		if i < len(nonRoot) && nonRoot[i] == nonRoot[i-1]+1 {
+			continue
+		}
+		if err := p.writeConsecutiveRun(nonRoot[runStart:i], pages); err != nil {
+			return err
+		}
+		runStart = i
+	}
+	return nil
+}
+
+// writeRootPage writes page 0 to disk with its special layout:
+// bytes [0, RootPageConfigSize) hold the database header; bytes [RootPageConfigSize, pageSize) hold the B-tree payload.
+func (p *pagerImpl) writeRootPage(pg *Page, dbHeader *DatabaseHeader) error {
+	buf := p.bufferPool.Get().([]byte)
+	defer p.bufferPool.Put(buf)
+	clear(buf)
+	if err := marshalPage(pg, buf); err != nil {
+		return err
+	}
+	var headerBuf [RootPageConfigSize]byte
+	if err := dbHeader.MarshalTo(headerBuf[:]); err != nil {
+		return err
+	}
+	writeRootPageChecksum(headerBuf[:], buf, p.pageSize)
+	if p.cipher != nil {
+		p.cipher.XORKeyStream(buf[:p.pageSize-RootPageConfigSize], 0)
+	}
+	if _, err := p.file.WriteAt(headerBuf[:], 0); err != nil {
+		return err
+	}
+	_, err := p.file.WriteAt(buf[0:p.pageSize-RootPageConfigSize], int64(RootPageConfigSize))
+	return err
+}
+
+// writeConsecutiveRun marshals and writes a slice of consecutive non-root page
+// indices in a single WriteAt call.
+func (p *pagerImpl) writeConsecutiveRun(indices []PageIndex, pages []*Page) error {
+	if len(indices) == 0 {
+		return nil
+	}
+	if len(indices) == 1 {
+		idx := indices[0]
+		pg := pages[idx]
+		buf := p.bufferPool.Get().([]byte)
+		defer p.bufferPool.Put(buf)
+		clear(buf)
+		if err := marshalPage(pg, buf); err != nil {
+			return fmt.Errorf("marshal page %d: %w", idx, err)
+		}
+		writePageChecksum(buf)
+		if p.cipher != nil {
+			p.cipher.XORKeyStream(buf, uint32(idx))
+		}
+		_, err := p.file.WriteAt(buf, int64(idx)*int64(p.pageSize))
+		return err
+	}
+
+	// Multi-page run: one contiguous allocation → one WriteAt syscall.
+	combined := make([]byte, len(indices)*p.pageSize)
+	for i, idx := range indices {
+		seg := combined[i*p.pageSize : (i+1)*p.pageSize]
+		if err := marshalPage(pages[idx], seg); err != nil {
+			return fmt.Errorf("marshal page %d: %w", idx, err)
+		}
+		writePageChecksum(seg)
+		if p.cipher != nil {
+			p.cipher.XORKeyStream(seg, uint32(idx))
+		}
+	}
+	offset := int64(indices[0]) * int64(p.pageSize)
+	if _, err := p.file.WriteAt(combined, offset); err != nil {
+		return fmt.Errorf("write run pages %d-%d: %w", indices[0], indices[len(indices)-1], err)
+	}
+	return nil
 }
 
 // TotalPages returns the current total number of pages tracked by the pager,
@@ -400,7 +534,13 @@ func (p *pagerImpl) SavePage(ctx context.Context, pageIdx PageIndex, page *Page)
 // Flush marshals the page at pageIdx and writes it to the DB file. For page 0
 // it writes the database header first, then the remainder of the page data, and
 // calls fsync to ensure durability. No-ops if the page is not in cache.
+// When noIntermediateSync is set, the page stays in the pager cache and is
+// written by Close().
 func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
+	if p.noIntermediateSync {
+		return nil // page stays in cache; Close() will write all cached pages
+	}
+
 	p.mu.RLock()
 	if int(pageIdx) >= len(p.pages) || p.pages[pageIdx] == nil {
 		p.mu.RUnlock()
@@ -460,7 +600,13 @@ func (p *pagerImpl) Flush(ctx context.Context, pageIdx PageIndex) error {
 // FlushBatch writes multiple pages to disk in a single operation.
 // This reduces the number of syscalls and allows the OS to optimize I/O.
 // Pages are marshaled in parallel outside of locks, then written sequentially.
+// When noIntermediateSync is set, pages stay in the pager cache and are
+// written by Close().
 func (p *pagerImpl) FlushBatch(ctx context.Context, pageIndices []PageIndex) error {
+	if p.noIntermediateSync {
+		return nil // pages stay in cache; Close() will write all cached pages
+	}
+
 	if len(pageIndices) == 0 {
 		return nil
 	}

--- a/internal/minisql/pager_test.go
+++ b/internal/minisql/pager_test.go
@@ -289,3 +289,194 @@ func TestNewPager_InvalidDatabaseHeader(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "invalid database header magic", err.Error())
 }
+
+// TestPager_NoIntermediateSync_FlushIsNoop verifies that Flush is a no-op
+// when noIntermediateSync is true: the page stays in the in-memory cache but
+// nothing reaches the file until Close is called.
+func TestPager_NoIntermediateSync_FlushIsNoop(t *testing.T) {
+	t.Parallel()
+
+	dbFile, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer dbFile.Close()
+	defer os.Remove(dbFile.Name())
+
+	pager, err := NewPager(dbFile, PageSize, 1000)
+	require.NoError(t, err)
+	pager.SetNoIntermediateSync(true)
+
+	leaf := NewLeafNode()
+	leaf.Header.IsRoot = true
+	leaf.Header.NextLeaf = PageIndex(42) // sentinel value to check after reload
+	pager.pages = append(pager.pages, &Page{Index: 0, LeafNode: leaf})
+	pager.totalPages = 1
+
+	// Flush must be a no-op: the file should remain empty.
+	require.NoError(t, pager.Flush(context.Background(), 0))
+
+	info, err := dbFile.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), info.Size(), "file must still be empty after Flush with noIntermediateSync")
+}
+
+// TestPager_NoIntermediateSync_FlushBatchIsNoop verifies that FlushBatch is a
+// no-op when noIntermediateSync is true.
+func TestPager_NoIntermediateSync_FlushBatchIsNoop(t *testing.T) {
+	t.Parallel()
+
+	dbFile, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer dbFile.Close()
+	defer os.Remove(dbFile.Name())
+
+	pager, err := NewPager(dbFile, PageSize, 1000)
+	require.NoError(t, err)
+	pager.SetNoIntermediateSync(true)
+
+	rootPage, internalPages, leafPages := newTestBtree()
+	pager.pages = append(pager.pages,
+		rootPage,
+		internalPages[0],
+		internalPages[1],
+		leafPages[0],
+		leafPages[1],
+	)
+	pager.totalPages = 5
+
+	indices := []PageIndex{0, 1, 2, 3, 4}
+	require.NoError(t, pager.FlushBatch(context.Background(), indices))
+
+	info, err := dbFile.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), info.Size(), "file must still be empty after FlushBatch with noIntermediateSync")
+}
+
+// TestPager_NoIntermediateSync_CloseWritesAllPages verifies the full deferred
+// path: Flush/FlushBatch are no-ops, but Close flushes all cached pages to
+// disk. A fresh pager opened on the same file must read back identical pages.
+func TestPager_NoIntermediateSync_CloseWritesAllPages(t *testing.T) {
+	t.Parallel()
+
+	dbFile, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(dbFile.Name())
+
+	pager, err := NewPager(dbFile, PageSize, 1000)
+	require.NoError(t, err)
+	pager.SetNoIntermediateSync(true)
+
+	rootPage, internalPages, leafPages := newTestBtree()
+	allPages := []*Page{rootPage, internalPages[0], internalPages[1], leafPages[0], leafPages[1], leafPages[2], leafPages[3]}
+	pager.pages = append(pager.pages, allPages...)
+	pager.totalPages = uint32(len(allPages))
+
+	// FlushBatch should be a no-op; file stays empty.
+	indices := make([]PageIndex, len(allPages))
+	for i := range indices {
+		indices[i] = PageIndex(i)
+	}
+	require.NoError(t, pager.FlushBatch(context.Background(), indices))
+
+	info, err := dbFile.Stat()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), info.Size(), "file must still be empty before Close")
+
+	// Close must flush all cached pages, then sync and close the file.
+	require.NoError(t, pager.Close())
+
+	info, err = os.Stat(dbFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(allPages))*int64(PageSize), info.Size(),
+		"file must contain all pages after Close")
+
+	// Reopen and verify every page is readable with the correct content.
+	dbFile2, err := os.Open(dbFile.Name())
+	require.NoError(t, err)
+	defer dbFile2.Close()
+
+	pager2, err := NewPager(dbFile2, PageSize, 1000)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(len(allPages)), pager2.TotalPages())
+
+	columns := []Column{{Kind: Varchar, Size: 270}}
+	tablePager := pager2.ForTable(columns)
+	ctx := context.Background()
+
+	page0, err := tablePager.GetPage(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, rootPage, page0)
+
+	page1, err := tablePager.GetPage(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, internalPages[0], page1)
+
+	page3, err := tablePager.GetPage(ctx, 3)
+	require.NoError(t, err)
+	assert.Equal(t, leafPages[0], page3)
+}
+
+// TestPager_NoIntermediateSync_NonConsecutivePages verifies that
+// flushAllCached correctly handles a sparse set of page indices (non-consecutive
+// runs are each written in separate WriteAt calls, not one combined buffer).
+func TestPager_NoIntermediateSync_NonConsecutivePages(t *testing.T) {
+	t.Parallel()
+
+	dbFile, err := os.CreateTemp("", testDBName)
+	require.NoError(t, err)
+	defer os.Remove(dbFile.Name())
+
+	pager, err := NewPager(dbFile, PageSize, 1000)
+	require.NoError(t, err)
+	pager.SetNoIntermediateSync(true)
+
+	// Place pages at non-consecutive indices: 0, 2, 4 (gaps at 1 and 3).
+	leaf0 := NewLeafNode()
+	leaf0.Header.IsRoot = true
+	leaf0.Header.NextLeaf = 11
+
+	leaf2 := NewLeafNode()
+	leaf2.Header.NextLeaf = 22
+
+	leaf4 := NewLeafNode()
+	leaf4.Header.NextLeaf = 44
+
+	pager.pages = []*Page{
+		{Index: 0, LeafNode: leaf0},
+		nil,
+		{Index: 2, LeafNode: leaf2},
+		nil,
+		{Index: 4, LeafNode: leaf4},
+	}
+	pager.totalPages = 5
+
+	require.NoError(t, pager.Close())
+
+	// File must be exactly 5 pages (indices 0-4), even though 1 and 3 are nil.
+	info, err := os.Stat(dbFile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, int64(5)*int64(PageSize), info.Size())
+
+	// Reopen and read back the three written pages.
+	dbFile2, err := os.Open(dbFile.Name())
+	require.NoError(t, err)
+	defer dbFile2.Close()
+
+	pager2, err := NewPager(dbFile2, PageSize, 1000)
+	require.NoError(t, err)
+
+	columns := []Column{{Kind: Varchar, Size: 270}}
+	tp := pager2.ForTable(columns)
+	ctx := context.Background()
+
+	p0, err := tp.GetPage(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, PageIndex(11), p0.LeafNode.Header.NextLeaf)
+
+	p2, err := tp.GetPage(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, PageIndex(22), p2.LeafNode.Header.NextLeaf)
+
+	p4, err := tp.GetPage(ctx, 4)
+	require.NoError(t, err)
+	assert.Equal(t, PageIndex(44), p4.LeafNode.Header.NextLeaf)
+}

--- a/internal/minisql/vacuum.go
+++ b/internal/minisql/vacuum.go
@@ -79,6 +79,10 @@ func (d *Database) vacuumWithKey(ctx context.Context, newKey []byte) error {
 		f.Close()
 		return fmt.Errorf("vacuum: create temp pager: %w", err)
 	}
+	// Skip per-commit fsyncs for the temp DB — it is a scratch file discarded on
+	// crash (the original is intact until the atomic rename succeeds). One fsync
+	// happens in Close() before the rename, which is sufficient for crash safety.
+	tempPager.SetNoIntermediateSync(true)
 
 	tempDBOpts := []DatabaseOption{WithHNSWVecCacheSize(d.hnswVecCacheSize)}
 	if len(newKey) > 0 {


### PR DESCRIPTION
…l write+fsync

Add pagerImpl.SetNoIntermediateSync(true) on the VACUUM temp DB so that Flush/FlushBatch become no-ops during the copy phase: all dirty pages accumulate in the pager cache instead of being written per-commit.

Close() then calls flushAllCached(), which writes all cached non-root pages in one contiguous WriteAt per consecutive-index run, followed by a single fastSync (fdatasync). This collapses O(commits × pages) pwrite+fsync calls into ~3 WriteAt + 1 fsync.

BenchmarkVacuum_Small/minisql: 1.51 ms → 1.39 ms (−8%); allocs −54 (−1%). B/op increases +17 KiB because the combined flush buffer is a new heap allocation that replaces N pool round-trips from the previous per-commit path.