### PR TITLE
Reduce VACUUM per-row overhead via direct row-copy path

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,6 +9,8 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`); memory figures are heap allocations reported by the Go runtime. Single-iteration benchmarks (HNSW build at large N) carry higher variance than multi-iteration ones.
 
+2026-06-17: VACUUM direct row-copy path (`vacuumCopier`) — replaces the per-row `Statement{...}` + `[][]OptionalValue` + `rowValues` allocations in the VACUUM copy loop with a `vacuumCopier` struct that pre-computes column-index maps once per table and calls `insertPrimaryKey` / `insertUniqueIndexKey` / `insertSecondaryIndexKey` / `LeafNodeInsert` directly. Skips field-name linear scans (`InsertValuesForColumns`), `rowValues` allocation, JSON normalisation, check-constraint validation, FK checks, conflict checks, and RETURNING overhead — all unnecessary when copying pre-validated data from the live database. VACUUM small: **1.39 ms → 1.22 ms (−12%)**; allocs: 5,668 → 4,667 (−18%); B/op: 745 KiB → 687 KiB (−8%).
+
 2026-06-17: VACUUM deferred-write optimization — `pagerImpl.SetNoIntermediateSync(true)` on the temp DB eliminates per-commit `pwrite`+`fsync` calls during the copy phase. All cached pages are written to disk in a single sequential `WriteAt` per consecutive run at `Close()` time, followed by one `fsync`. Reduces I/O syscall count from O(commits × pages) to O(1 fsync + ~3 writes). VACUUM small: **1.51 ms → 1.39 ms (−8%)**; allocs: 5,722 → 5,668 (−1%); B/op: +17 KiB from the contiguous flush buffer (traded N pool round-trips for one heap allocation).
 
 2026-06-17: Full-text build — flat-buffer sort-at-flush — replaced the per-term `map[string][]invertedPosting` accumulation map in `populateFullTextIndex` with a flat `[]flatPosting` slice sorted at flush time. A single contiguous `postingPool` replaces per-term `append` growth events. Allocations reduced **−24%** (12,298 → 9,373). The 1000-doc benchmark shows a memory increase (1.06 MiB → 1.87 MiB) due to a 16-byte per-entry string header overhead and buffer growth copies in a cold-start workload that never reaches the 64K-posting flush threshold; in production with large tables and multi-flush cycles the flat buffer is reused after the first flush, giving ~68% per-flush byte reduction and ~99.9% alloc-event reduction.
@@ -134,7 +136,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
-| VACUUM small | 1.39 ms | 265 µs | 5.2× | 745 KiB | 89 B | 5,668 / 4 |
+| VACUUM small | 1.22 ms | 288 µs | 4.2× | 687 KiB | 88 B | 4,667 / 4 |
 | WAL checkpoint | 203 µs | 106 µs | 1.9× | 3.3 KiB | 440 B | 37 / 12 |
 | EXPLAIN | 5.2 µs | 1.2 µs | 4.2× | 5.5 KiB | 680 B | 51 / 18 |
 
@@ -199,7 +201,7 @@ which flushes the rows across ~8 sorted run files that are then N-way merged.
 | SELECT | Full scan | 1.23 MiB |
 | Join | Inner join, small-large | 1.00 MiB |
 | Join | Left join, unmatched rows | 869 KiB |
-| Maintenance | VACUUM small | 745 KiB (WAL overhead included since Priority 4 WAL-restore fix; +17 KiB vs prior baseline from combined page-flush buffer — one contiguous alloc replaces N pool round-trips) |
+| Maintenance | VACUUM small | 687 KiB (WAL overhead included since Priority 4 WAL-restore fix) |
 | Subquery | IN list | 559 KiB |
 
 ### Overflow Page INSERT

--- a/internal/minisql/vacuum.go
+++ b/internal/minisql/vacuum.go
@@ -6,6 +6,112 @@ import (
 	"os"
 )
 
+// vacuumCopier pre-computes the column-to-index maps for a table so that the
+// per-row copy path can extract key parts with direct slice indexing instead of
+// linear field-name scans.  Create one per table before the copy loop and reuse
+// it for every row.
+type vacuumCopier struct {
+	table   *Table
+	pkIdx   []int            // t.Columns position for each PK column
+	uniqIdx map[string][]int // uniqueIndex.Name → t.Columns positions for each column
+	secIdx  map[string][]int // secondaryIndex.Name → t.Columns positions; absent = expression index
+}
+
+func newVacuumCopier(t *Table) *vacuumCopier {
+	colPos := make(map[string]int, len(t.Columns))
+	for i, col := range t.Columns {
+		colPos[col.Name] = i
+	}
+	vc := &vacuumCopier{
+		table:   t,
+		uniqIdx: make(map[string][]int, len(t.UniqueIndexes)),
+		secIdx:  make(map[string][]int, len(t.SecondaryIndexes)),
+	}
+	if t.HasPrimaryKey() {
+		vc.pkIdx = make([]int, len(t.PrimaryKey.Columns))
+		for i, col := range t.PrimaryKey.Columns {
+			vc.pkIdx[i] = colPos[col.Name]
+		}
+	}
+	for name, ui := range t.UniqueIndexes {
+		idxs := make([]int, len(ui.Columns))
+		for i, col := range ui.Columns {
+			idxs[i] = colPos[col.Name]
+		}
+		vc.uniqIdx[name] = idxs
+	}
+	for name, si := range t.SecondaryIndexes {
+		if si.Expression != nil {
+			continue // absent entry marks an expression index; row is passed as-is
+		}
+		idxs := make([]int, len(si.Columns))
+		for i, col := range si.Columns {
+			idxs[i] = colPos[col.Name]
+		}
+		vc.secIdx[name] = idxs
+	}
+	return vc
+}
+
+// copyRow inserts one row from the live DB into the temp table.  It is
+// functionally equivalent to Table.Insert but avoids per-row overhead that is
+// unnecessary when copying validated data:
+//
+//   - No Statement / [][]OptionalValue allocation
+//   - No field-name linear scans (InsertValuesForColumns)
+//   - No rowValues copy (row.Values used directly)
+//   - No JSON normalisation (already normalised in the live DB)
+//   - No check-constraint or FK validation (already enforced in the live DB)
+//   - No conflict checks (temp DB is empty — duplicates are impossible)
+//   - No RETURNING or lastInsertID tracking (not needed during VACUUM)
+func (vc *vacuumCopier) copyRow(ctx context.Context, row Row) error {
+	t := vc.table
+	cursor, nextRowID, err := t.SeekNextRowID(ctx, t.GetRootPageIdx())
+	if err != nil {
+		return err
+	}
+	if t.HasPrimaryKey() {
+		keyParts := make([]OptionalValue, len(vc.pkIdx))
+		for i, colIdx := range vc.pkIdx {
+			keyParts[i] = row.Values[colIdx]
+		}
+		if _, err := t.insertPrimaryKey(ctx, keyParts, nextRowID); err != nil {
+			return err
+		}
+	}
+	for name, uniqueIndex := range t.UniqueIndexes {
+		colIdxs := vc.uniqIdx[name]
+		keyParts := make([]OptionalValue, len(colIdxs))
+		for i, colIdx := range colIdxs {
+			keyParts[i] = row.Values[colIdx]
+		}
+		if err := t.insertUniqueIndexKey(ctx, uniqueIndex, keyParts, nextRowID); err != nil {
+			return err
+		}
+	}
+	for name, secondaryIndex := range t.SecondaryIndexes {
+		var keyParts []OptionalValue
+		if colIdxs, ok := vc.secIdx[name]; ok {
+			keyParts = make([]OptionalValue, len(colIdxs))
+			for i, colIdx := range colIdxs {
+				keyParts[i] = row.Values[colIdx]
+			}
+		}
+		if err := t.insertSecondaryIndexKey(ctx, secondaryIndex, keyParts, nextRowID, row); err != nil {
+			return err
+		}
+	}
+	if err := cursor.LeafNodeInsert(ctx, nextRowID, row); err != nil {
+		return err
+	}
+	if t.getRowCount != nil {
+		if tx := TxFromContext(ctx); tx != nil {
+			tx.AddRowCountDelta(t.Name, 1)
+		}
+	}
+	return nil
+}
+
 // Vacuum compacts the database file by copying all live data into a fresh file,
 // then atomically replacing the original.  The algorithm is:
 //
@@ -168,7 +274,7 @@ func (d *Database) vacuumWithKey(ctx context.Context, newKey []byte) error {
 		}
 
 		liveFields := fieldsFromColumns(liveTable.Columns...)
-		insertFields := fieldsFromColumns(tempTable.Columns...)
+		copier := newVacuumCopier(tempTable)
 
 		// Stream rows into one temp-table transaction. The temp database is not
 		// visible until the final atomic swap and is discarded on failure, so
@@ -184,12 +290,7 @@ func (d *Database) vacuumWithKey(ctx context.Context, newKey []byte) error {
 					return err
 				}
 				for result.Rows.Next(readCtx) {
-					row := result.Rows.Row()
-					if _, err := tempTable.Insert(copyCtx, Statement{
-						Kind:    Insert,
-						Fields:  insertFields,
-						Inserts: [][]OptionalValue{row.Values},
-					}); err != nil {
+					if err := copier.copyRow(copyCtx, result.Rows.Row()); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
Replace the per-row Statement{...} + [][]OptionalValue + rowValues allocations in the VACUUM copy loop with a vacuumCopier that pre-computes column-index maps once per table (O(cols) setup) and extracts key parts with direct slice index access per row (O(1) vs O(N) field-name scan in InsertValuesForColumns).

The copyRow path bypasses everything that is unnecessary when copying pre-validated data from the live database: Statement allocation, field-name linear scans, rowValues copy, JSON normalisation, check constraints, FK checks, conflict checks, and RETURNING logic. Index maintenance (PK, unique, secondary) is preserved to keep the temp table consistent.

Result on BenchmarkVacuum_Small: 1.39 ms → 1.22 ms (−12%), 5,668 → 4,667 allocs/op (−18%), 745 KiB → 687 KiB B/op (−8%). SQLite ratio improves from 5.2× to 4.2×.