### PR TITLE
Reduce INSERT allocations via autoincrement key cache and single-row rowValues alias

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,6 +9,8 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`); memory figures are heap allocations reported by the Go runtime. Single-iteration benchmarks (HNSW build at large N) carry higher variance than multi-iteration ones.
 
+2026-06-19: INSERT autoincrement cache + single-row `rowValues` elimination — two targeted allocator removals. (1) `lastAutoincrementKey atomic.Int64` on `Table` (initialised to −1) caches the last written PK value; `insertAutoincrementedPrimaryKey` uses the cache directly and falls back to `SeekLastKey` only on cold start, eliminating the per-insert B-tree traversal and its `int64→any` boxing. Explicit PK inserts update the cache via a CAS high-water-mark loop so gaps from explicit keys are handled correctly. (2) `Table.Insert` no longer allocates a `rowValues` buffer for single-row inserts that arrive in column order (the common prepared-stmt path): when `len(stmt.Inserts)==1` and `len(values)==len(t.Columns)` we alias `rowValues = values` directly, skipping one `make([]OptionalValue, nCols)` per exec. Net effect on batch insert (100 rows/tx): allocs **2,143 → 1,954 (−8.8%)**, memory **123 KiB → 115 KiB (−6.5%)**; multi-values INSERT allocs **1,457 → 1,363 (−6.5%)** (single-row optimisation does not apply to multi-row statements; only the SeekLastKey saving contributes there).
+
 2026-06-17: VACUUM direct row-copy path (`vacuumCopier`) — replaces the per-row `Statement{...}` + `[][]OptionalValue` + `rowValues` allocations in the VACUUM copy loop with a `vacuumCopier` struct that pre-computes column-index maps once per table and calls `insertPrimaryKey` / `insertUniqueIndexKey` / `insertSecondaryIndexKey` / `LeafNodeInsert` directly. Skips field-name linear scans (`InsertValuesForColumns`), `rowValues` allocation, JSON normalisation, check-constraint validation, FK checks, conflict checks, and RETURNING overhead — all unnecessary when copying pre-validated data from the live database. VACUUM small: **1.39 ms → 1.22 ms (−12%)**; allocs: 5,668 → 4,667 (−18%); B/op: 745 KiB → 687 KiB (−8%).
 
 2026-06-17: VACUUM deferred-write optimization — `pagerImpl.SetNoIntermediateSync(true)` on the temp DB eliminates per-commit `pwrite`+`fsync` calls during the copy phase. All cached pages are written to disk in a single sequential `WriteAt` per consecutive run at `Close()` time, followed by one `fsync`. Reduces I/O syscall count from O(commits × pages) to O(1 fsync + ~3 writes). VACUUM small: **1.51 ms → 1.39 ms (−8%)**; allocs: 5,722 → 5,668 (−1%); B/op: +17 KiB from the contiguous flush buffer (traded N pool round-trips for one heap allocation).
@@ -55,9 +57,9 @@ The results are grouped by benchmark family. In comparison tables, a time ratio 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
 | Insert single row | 11.0 µs | 56.7 µs | 0.19× | 2.0 KiB | 311 B | 27 / 12 |
-| Insert batch | 353 µs | 240 µs | 1.47× | 124 KiB | 31.0 KiB | 2,144 / 1,301 |
-| Insert prepared batch | 342 µs | 235 µs | 1.45× | 123 KiB | 31.0 KiB | 2,143 / 1,300 |
-| Insert multi-values | 193 µs | 186 µs | 1.04× | 107 KiB | 25.2 KiB | 1,457 / 616 |
+| Insert batch | 373 µs | 271 µs | 1.38× | 116 KiB | 31.8 KiB | 1,955 / 1,309 |
+| Insert prepared batch | 368 µs | 268 µs | 1.37× | 115 KiB | 31.8 KiB | 1,954 / 1,308 |
+| Insert multi-values | 212 µs | 209 µs | 1.01× | 109 KiB | 25.9 KiB | 1,363 / 623 |
 | Update by PK | 8.3 µs | 39.1 µs | 0.21× | 3.6 KiB | 263 B | 38 / 10 |
 | Delete by PK | 15.6 µs | 86.1 µs | 0.18× | 3.1 KiB | 447 B | 49 / 19 |
 | ON CONFLICT DO UPDATE | 7.7 µs | 40.9 µs | 0.19× | 1.6 KiB | 259 B | 29 / 10 |

--- a/internal/minisql/insert.go
+++ b/internal/minisql/insert.go
@@ -35,9 +35,14 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 	newRowsInserted := 0
 	var returningRows []Row
 	var lastInsertID int64
-	// Allocate once and reuse across iterations. saveToCell marshals the row to
-	// bytes immediately, so the backing array is safe to overwrite next iteration.
-	rowValues := make([]OptionalValue, len(t.Columns))
+	// For multi-row inserts, allocate a shared buffer that is overwritten each
+	// iteration (saveToCell marshals immediately so the next iteration is safe).
+	// For single-row inserts taking the column-aligned fast path, we alias
+	// rowValues to the values slice directly and skip the allocation entirely.
+	var rowValues []OptionalValue
+	if len(stmt.Inserts) > 1 {
+		rowValues = make([]OptionalValue, len(t.Columns))
+	}
 	for insertIdx, values := range stmt.Inserts {
 		switch stmt.ConflictAction {
 		case ConflictActionDoNothing:
@@ -123,14 +128,22 @@ func (t *Table) Insert(ctx context.Context, stmt Statement) (StatementResult, er
 			}
 		}
 
-		// Assemble row values in table-column order into the reused rowValues slice.
-		// Fast path: after prepareInsert, values[i] == value for t.Columns[i] — just copy.
+		// Assemble row values in table-column order.
+		// Fast path: after prepareInsert, values[i] == value for t.Columns[i].
+		//   Multi-row: copy into the shared buffer (safe to overwrite each iteration).
+		//   Single-row: alias rowValues to values directly — no allocation needed.
 		// Slow path: direct Insert call without prepareInsert — use field-name lookup.
 		if len(values) == len(t.Columns) {
-			// prepareInsert was called; values are already in column order.
-			copy(rowValues, values)
+			if rowValues != nil {
+				copy(rowValues, values)
+			} else {
+				rowValues = values
+			}
 		} else {
 			// Direct call without prepareInsert; resolve by field name.
+			if rowValues == nil {
+				rowValues = make([]OptionalValue, len(t.Columns))
+			}
 			// Clear stale values from prior iteration before selective assignment.
 			clear(rowValues)
 			fieldPositions := make(map[string]int, len(stmt.Fields))

--- a/internal/minisql/table.go
+++ b/internal/minisql/table.go
@@ -70,6 +70,12 @@ type Table struct {
 	// lastTxIDTablePage guards against stale hints from rolled-back transactions.
 	rightmostTablePage atomic.Int64
 	lastTxIDTablePage  atomic.Uint64
+	// lastAutoincrementKey caches the most recently written autoincrement PK value,
+	// eliminating the per-insert SeekLastKey B-tree traversal.
+	// -1 = not yet seeded; on first autoincrement insert SeekLastKey initialises it.
+	// Gaps from rolled-back transactions are acceptable — autoincrement only
+	// guarantees monotonic increase, not contiguity.
+	lastAutoincrementKey atomic.Int64
 	Name               string
 	Columns            []Column
 	rootPageIdx        PageIndex
@@ -97,6 +103,7 @@ func NewTable(logger *zap.Logger, pager TxPager, txManager *TransactionManager, 
 	}
 
 	table.rightmostTablePage.Store(-1)
+	table.lastAutoincrementKey.Store(-1)
 
 	// If no provider is given, create a simple single-table provider for testing
 	if provider == nil {

--- a/internal/minisql/table_primary_key.go
+++ b/internal/minisql/table_primary_key.go
@@ -125,6 +125,22 @@ func (t *Table) insertPrimaryKey(ctx context.Context, keyParts []OptionalValue, 
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
 	}
 
+	// Keep the autoincrement high-water mark in sync so that subsequent
+	// auto-generated keys don't collide with explicitly inserted keys.
+	if t.PrimaryKey.Autoincrement {
+		if newKey, ok := castedKey.(int64); ok {
+			for {
+				cached := t.lastAutoincrementKey.Load()
+				if cached >= newKey {
+					break
+				}
+				if t.lastAutoincrementKey.CompareAndSwap(cached, newKey) {
+					break
+				}
+			}
+		}
+	}
+
 	return castedKey, nil
 }
 
@@ -133,15 +149,22 @@ func (t *Table) insertAutoincrementedPrimaryKey(ctx context.Context, rowID RowID
 		return 0, fmt.Errorf("autoincrement primary key %s must be of type INT8", t.PrimaryKey.Name)
 	}
 
-	lastKey, err := t.PrimaryKey.Index.SeekLastKey(ctx, t.PrimaryKey.Index.GetRootPageIdx())
-	if err != nil {
-		return 0, err
+	var newPrimaryKey int64
+	if cached := t.lastAutoincrementKey.Load(); cached >= 0 {
+		// Fast path: skip B-tree traversal; the cache holds the last written key.
+		newPrimaryKey = cached + 1
+	} else {
+		// Cold path: traverse PK index to find the highest existing key.
+		lastKey, err := t.PrimaryKey.Index.SeekLastKey(ctx, t.PrimaryKey.Index.GetRootPageIdx())
+		if err != nil {
+			return 0, err
+		}
+		lastPrimaryKey, ok := lastKey.(int64)
+		if !ok {
+			return 0, errors.New("failed to cast last primary key value for autoincrement")
+		}
+		newPrimaryKey = lastPrimaryKey + 1
 	}
-	lastPrimaryKey, ok := lastKey.(int64)
-	if !ok {
-		return 0, errors.New("failed to cast last primary key value for autoincrement")
-	}
-	newPrimaryKey := lastPrimaryKey + 1
 
 	if ce := t.logger.Check(zap.DebugLevel, "inserting autoincremented primary key"); ce != nil {
 		ce.Write(
@@ -154,6 +177,7 @@ func (t *Table) insertAutoincrementedPrimaryKey(ctx context.Context, rowID RowID
 		return 0, fmt.Errorf("failed to insert primary key %s: %w", t.PrimaryKey.Name, err)
 	}
 
+	t.lastAutoincrementKey.Store(newPrimaryKey)
 	return newPrimaryKey, nil
 }
 


### PR DESCRIPTION
## Summary

- **Autoincrement key cache** (`lastAutoincrementKey atomic.Int64` on `Table`): eliminates the per-insert `SeekLastKey` B-tree traversal and its `int64→any` boxing. Cold start (cache = −1) calls `SeekLastKey` once; all subsequent autoincrement inserts use `cache + 1` directly. Explicit PK inserts on autoincrement tables update the cache via a CAS high-water loop so a mix of explicit and auto-generated keys stays collision-free.
- **Single-row `rowValues` alias** (`Table.Insert`): when inserting one row whose values are already in column order (the post-`prepareInsert` fast path), `rowValues` is aliased directly to `values` instead of copying into a freshly allocated `[]OptionalValue`. Multi-row statements still pre-allocate the shared reuse buffer as before.

## Benchmark results

| Benchmark | Before | After | Delta |
|---|---|---|---|
| Insert batch — allocs/op | 2,144 | 1,955 | −8.8% |
| Insert prepared batch — allocs/op | 2,143 | 1,954 | −8.8% |
| Insert multi-values — allocs/op | 1,457 | 1,363 | −6.5% |
| Insert batch — B/op | 124 KiB | 116 KiB | −6.5% |
| Insert prepared batch — B/op | 123 KiB | 115 KiB | −6.5% |

The savings on `multi-values` are smaller because that path has multiple rows per statement (`len(stmt.Inserts) > 1`), so the single-row alias optimisation does not apply; only the SeekLastKey elimination contributes.

## Test plan

- [x] All 4333 tests pass (`LOG_LEVEL=error go test ./... -count=1`)
- [x] `BenchmarkInsert_PreparedBatch`, `BenchmarkInsert_Batch`, `BenchmarkInsert_MultiValues` run cleanly
- [x] e2e `TestSelect` suite (which mixes explicit and autoincrement PK inserts) passes — this was the key correctness check for the high-water-mark CAS in `insertPrimaryKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)