### PR TITLE
Eliminate per-exec make([]any,N) and make([][]OptionalValue,N) for prepared INSERT

### DIFF
--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -9,6 +9,8 @@
 
 SQLite comparisons use the `sqlite` driver compiled into the same test binary. MiniSQL benchmarks run against fresh temp-file databases per sub-benchmark. Times are wall-clock (`ns/op`); memory figures are heap allocations reported by the Go runtime. Single-iteration benchmarks (HNSW build at large N) carry higher variance than multi-iteration ones.
 
+2026-06-22: INSERT arg-buffer reuse — two per-exec heap allocations eliminated for prepared single-row INSERT statements by pre-allocating reuse buffers on `Conn`. (1) `insertArgsBuf []any`: replaces the `make([]any, N)` in `toInternalArgs`; the buffer is grown-or-reused before each exec and filled in place. (2) `insertsOuterBuf [][]OptionalValue`: replaces the `make([][]OptionalValue, N)` in the `BindArguments` delayed-bind fast path; a new `BindArgumentsReusing(args []any, outerBuf [][]OptionalValue)` engine method copies the template row pointers into the reuse buffer and stores it as `stmt.Inserts` without allocating. Both buffers are safe to reuse because `database/sql` guarantees each `Conn` is used by at most one goroutine at a time, and `prepareInsert` fully consumes both buffers before `ExecContext` returns. Multi-row prepared INSERT (`INSERT … VALUES (…),(…)`) also benefits from `insertArgsBuf` reuse. Net effect on batch/prepared-batch INSERT (100 rows/tx): allocs **1,954 → 1,755 (−10.2%)**, memory **115 KiB → 108 KiB (−6%)**.
+
 2026-06-19: INSERT autoincrement cache + single-row `rowValues` elimination — two targeted allocator removals. (1) `lastAutoincrementKey atomic.Int64` on `Table` (initialised to −1) caches the last written PK value; `insertAutoincrementedPrimaryKey` uses the cache directly and falls back to `SeekLastKey` only on cold start, eliminating the per-insert B-tree traversal and its `int64→any` boxing. Explicit PK inserts update the cache via a CAS high-water-mark loop so gaps from explicit keys are handled correctly. (2) `Table.Insert` no longer allocates a `rowValues` buffer for single-row inserts that arrive in column order (the common prepared-stmt path): when `len(stmt.Inserts)==1` and `len(values)==len(t.Columns)` we alias `rowValues = values` directly, skipping one `make([]OptionalValue, nCols)` per exec. Net effect on batch insert (100 rows/tx): allocs **2,143 → 1,954 (−8.8%)**, memory **123 KiB → 115 KiB (−6.5%)**; multi-values INSERT allocs **1,457 → 1,363 (−6.5%)** (single-row optimisation does not apply to multi-row statements; only the SeekLastKey saving contributes there).
 
 2026-06-17: VACUUM direct row-copy path (`vacuumCopier`) — replaces the per-row `Statement{...}` + `[][]OptionalValue` + `rowValues` allocations in the VACUUM copy loop with a `vacuumCopier` struct that pre-computes column-index maps once per table and calls `insertPrimaryKey` / `insertUniqueIndexKey` / `insertSecondaryIndexKey` / `LeafNodeInsert` directly. Skips field-name linear scans (`InsertValuesForColumns`), `rowValues` allocation, JSON normalisation, check-constraint validation, FK checks, conflict checks, and RETURNING overhead — all unnecessary when copying pre-validated data from the live database. VACUUM small: **1.39 ms → 1.22 ms (−12%)**; allocs: 5,668 → 4,667 (−18%); B/op: 745 KiB → 687 KiB (−8%).
@@ -57,9 +59,9 @@ The results are grouped by benchmark family. In comparison tables, a time ratio 
 | Benchmark | MiniSQL time | SQLite time | Time ratio | MiniSQL memory | SQLite memory | Allocs |
 |---|---|---|---|---|---|---|
 | Insert single row | 11.0 µs | 56.7 µs | 0.19× | 2.0 KiB | 311 B | 27 / 12 |
-| Insert batch | 373 µs | 271 µs | 1.38× | 116 KiB | 31.8 KiB | 1,955 / 1,309 |
-| Insert prepared batch | 368 µs | 268 µs | 1.37× | 115 KiB | 31.8 KiB | 1,954 / 1,308 |
-| Insert multi-values | 212 µs | 209 µs | 1.01× | 109 KiB | 25.9 KiB | 1,363 / 623 |
+| Insert batch | 322 µs | 242 µs | 1.33× | 109 KiB | 31.8 KiB | 1,756 / 1,310 |
+| Insert prepared batch | 333 µs | 242 µs | 1.38× | 108 KiB | 31.8 KiB | 1,755 / 1,309 |
+| Insert multi-values | 184 µs | 180 µs | 1.02× | 102 KiB | 25.9 KiB | 1,362 / 623 |
 | Update by PK | 8.3 µs | 39.1 µs | 0.21× | 3.6 KiB | 263 B | 38 / 10 |
 | Delete by PK | 15.6 µs | 86.1 µs | 0.18× | 3.1 KiB | 447 B | 49 / 19 |
 | ON CONFLICT DO UPDATE | 7.7 µs | 40.9 µs | 0.19× | 1.6 KiB | 259 B | 29 / 10 |

--- a/internal/minisql/stmt.go
+++ b/internal/minisql/stmt.go
@@ -792,6 +792,23 @@ func (s Statement) Clone() Statement {
 	return stmt
 }
 
+// BindArgumentsReusing is the allocation-free fast path for prepared INSERT
+// statements. It is equivalent to the BindArguments delayed-bind fast path but
+// uses caller-supplied buffers (args and outerBuf) instead of allocating new
+// ones, so that drivers with per-connection reuse buffers pay zero heap cost
+// per exec. Both buffers must have length == len(s.Inserts) args consumed.
+// Returns false when the statement is not eligible for delayed binding.
+func (s Statement) BindArgumentsReusing(args []any, outerBuf [][]OptionalValue) (Statement, bool) {
+	if !s.canDelayPreparedInsertBind() || len(outerBuf) < len(s.Inserts) {
+		return Statement{}, false
+	}
+	copy(outerBuf, s.Inserts)
+	stmt := s
+	stmt.Inserts = outerBuf
+	stmt.boundArgs = args
+	return stmt, true
+}
+
 // BindArguments substitutes ? placeholders in the statement with the provided
 // arguments in left-to-right order. It clones the statement first so the
 // original prepared form is not modified and can be reused with different args.

--- a/minisql.go
+++ b/minisql.go
@@ -169,6 +169,12 @@ type Conn struct {
 	// txCtx cache: avoids calling WithTransaction on every row within an explicit transaction.
 	lastExecBaseCtx context.Context
 	lastExecTxCtx   context.Context
+	// insertArgsBuf and insertsOuterBuf are reused across INSERT ExecContext calls
+	// to eliminate the per-call make([]any, N) and make([][]OptionalValue, N) allocs
+	// that would otherwise occur in toInternalArgs and BindArguments respectively.
+	// Safe because database/sql guarantees each Conn is used by at most one goroutine.
+	insertArgsBuf   []any
+	insertsOuterBuf [][]minisql.OptionalValue
 }
 
 // Ping verifies the connection is still alive. MiniSQL is an embedded engine

--- a/stmt.go
+++ b/stmt.go
@@ -132,6 +132,32 @@ func (s Stmt) bindNamedArguments(args []driver.NamedValue) (minisql.Statement, e
 		return stmt, err
 	}
 
+	// Fast path for prepared INSERT with delayed binding: reuse the conn's arg and
+	// outer-inserts buffers to avoid the two per-exec heap allocations (make([]any, N)
+	// and make([][]OptionalValue, N)) that the generic BindArguments path incurs.
+	n := len(args)
+	nTuples := len(s.statement.Inserts)
+	if cap(s.conn.insertArgsBuf) >= n {
+		s.conn.insertArgsBuf = s.conn.insertArgsBuf[:n]
+	} else {
+		s.conn.insertArgsBuf = make([]any, n)
+	}
+	if cap(s.conn.insertsOuterBuf) >= nTuples {
+		s.conn.insertsOuterBuf = s.conn.insertsOuterBuf[:nTuples]
+	} else {
+		s.conn.insertsOuterBuf = make([][]minisql.OptionalValue, nTuples)
+	}
+	for i, arg := range args {
+		v, err := toInternalArg(arg)
+		if err != nil {
+			return minisql.Statement{}, err
+		}
+		s.conn.insertArgsBuf[i] = v
+	}
+	if stmt, ok := s.statement.BindArgumentsReusing(s.conn.insertArgsBuf, s.conn.insertsOuterBuf); ok {
+		return stmt, nil
+	}
+
 	internalArgs, err := toInternalArgs(args)
 	if err != nil {
 		return minisql.Statement{}, err


### PR DESCRIPTION
## Summary

- **`BindArgumentsReusing` engine method**: allocation-free variant of the `BindArguments` delayed-bind fast path — copies template row pointers into a caller-supplied `outerBuf` and stores a caller-supplied `args` slice as `boundArgs`, both without allocating. Returns `false` for statements not eligible for delayed binding, so callers fall through to the existing path unchanged.
- **`Conn.insertArgsBuf []any`**: reuse buffer replacing the `make([]any, N)` in `toInternalArgs`. Grown lazily on first use (or when arg count increases), then reused in place across all subsequent INSERT execs on the same connection.
- **`Conn.insertsOuterBuf [][]OptionalValue`**: reuse buffer replacing the `make([][]OptionalValue, N)` in the `BindArguments` delayed-bind fast path. Same grow-once, reuse-always pattern.

Both buffers are safe to reuse because `database/sql` guarantees each `Conn` is used by at most one goroutine at a time, and `prepareInsert` fully consumes both before `ExecContext` returns.

## Benchmark results

| Benchmark | Before | After | Delta |
|---|---|---|---|
| Insert batch — allocs/op | 1,955 | 1,756 | −10.2% |
| Insert prepared batch — allocs/op | 1,954 | 1,755 | −10.2% |
| Insert batch — B/op | 116 KiB | 109 KiB | −6% |
| Insert prepared batch — B/op | 115 KiB | 108 KiB | −6% |

Combined with PR #327 (autoincrement key cache + rowValues alias), total batch INSERT alloc reduction from the pre-work baseline: **2,637 → 1,755 (−33%)**.

## Test plan

- [x] All 4333 tests pass (`LOG_LEVEL=error go test ./... -count=1`)
- [x] pprof `alloc_objects` profile confirms `toInternalArgs` and `BindArguments` no longer appear as allocators
- [x] `BenchmarkInsert_PreparedBatch`, `BenchmarkInsert_Batch`, `BenchmarkInsert_MultiValues` all pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)